### PR TITLE
Init a new Github Action build workflow to check the PR

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,0 +1,48 @@
+name: PR Check - Gated Build
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gated-build:
+    name: Gated Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup-node-pnpm
+
+      - name: Type check
+        run: pnpm run check-types
+
+      - name: Lint code
+        run: pnpm run lint
+
+      - name: Build project
+        run: pnpm run package
+
+      # Not ready yet
+      # - name: Run tests
+      #   run: pnpm run test
+
+  build-status:
+    name: Build Status Check
+    runs-on: ubuntu-latest
+    needs: gated-build
+    if: always()
+
+    steps:
+      - name: Check build result
+        run: |
+          if [ "${{ needs.gated-build.result }}" != "success" ]; then
+            echo "Gated build failed. PR cannot be merged."
+            exit 1
+          fi
+          echo "All checks passed. PR is ready for review."


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to ensure pull request quality through a gated build process. The workflow includes steps for type checking, linting, and building the project, with a placeholder for future test execution.

### New GitHub Actions Workflow:
* `.github/workflows/pr-check.yml`: Added a new workflow named "PR Check - Gated Build" triggered on pull request events for the `main` branch. It includes:
  - A `gated-build` job that performs type checking (`pnpm run check-types`), linting (`pnpm run lint`), and building the project (`pnpm run package`), with a placeholder for running tests in the future.
  - A `build-status` job that verifies the result of the `gated-build` job and ensures that only successful builds allow the pull request to proceed.