### PR TITLE
Release v0.2.4

### DIFF
--- a/.changeset/great-pianos-speak.md
+++ b/.changeset/great-pianos-speak.md
@@ -1,5 +1,0 @@
----
-"agent-maestro": patch
----
-
-Skip start if another proxy server is already running, otherwise find an available port if default one has been used

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.2.2] - 2025-06-16
+## [0.2.4] - 2025-06-16
 
 ### Features
 
@@ -8,10 +8,7 @@
 - Added configuration support when creating new Roo tasks
 - Improved extension publishing and dependency management
 - Added Server-Sent Events (SSE) documentation for Roo API
-
-### Bug Fixes
-
-- Fixed incorrect usage of extensionPack in extension manifest
+- Proxy server skips start if another one is already running, otherwise find an available port if default one has been used
 
 ## [0.1.0] - 2025-06-14
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "agent-maestro",
   "displayName": "Agent Maestro",
   "description": "Headless VS Code AI: bring best-in-class AI agents into any workflow — assist, automate tasks, and generate solutions everywhere.",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "icon": "assets/icons/icon.jpg",
   "publisher": "Joouis",
   "repository": "https://github.com/Joouis/agent-maestro",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,8 @@
     "test": "vscode-test",
     "prepare": "husky",
     "changeset": "changeset",
-    "changeset:version": "changeset version"
+    "changeset:version": "changeset version",
+    "changeset:tag": "changeset tag"
   },
   "lint-staged": {
     "**/*": "prettier --write --ignore-unknown"


### PR DESCRIPTION
This pull request updates the `agent-maestro` package to version `0.2.4`, introduces a new script for tagging changesets, and includes a bug fix for the proxy server functionality. Below are the key changes:

### Version Update and Metadata Changes:
* Updated the package version from `0.2.3` to `0.2.4` in `package.json` to reflect the new release.

### New Features:
* Added a new script, `"changeset:tag": "changeset tag"`, to the `scripts` section in `package.json` to support tagging changesets.

### Bug Fixes:
* Fixed the proxy server behavior to skip starting if another proxy server is already running. If the default port is in use, it will now find an available port instead. This fix is documented in the `CHANGELOG.md`. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL3-R11) [[2]](diffhunk://#diff-5c63d48b49a10e2a915e6fc47ef9d755a0b118ba6f5f4cd1c210368dcb3fbddbL1-L5)