### PR TITLE
Do not show output panel at extension activation

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,14 +1,16 @@
 import * as vscode from "vscode";
 import { logger } from "./utils/logger";
-import { ExtensionController, ExtensionType } from "./core/controller";
+import { ExtensionController } from "./core/controller";
 import { ProxyServer } from "./server/ProxyServer";
 
 let controller: ExtensionController;
 let proxy: ProxyServer;
 
 export async function activate(context: vscode.ExtensionContext) {
-  // Debugging usage
-  logger.show();
+  // Only show logger automatically in development mode
+  if (context.extensionMode === vscode.ExtensionMode.Development) {
+    logger.show();
+  }
 
   // Initialize the extension controller
   controller = new ExtensionController();
@@ -42,7 +44,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
         if (result.started) {
           vscode.window.showInformationMessage(
-            `Proxy server started on ${proxy.getStatus().url}, you can check all available API endpoints at ${proxy.getOpenAPIUrl()}`,
+            `Agent Maestro server started successfully. View API documentation at ${proxy.getOpenAPIUrl()}`,
           );
         } else {
           // Don't show error message for "another instance running" case


### PR DESCRIPTION
This pull request includes updates to the `src/extension.ts` file to improve development experience and refine user-facing messages. The most important changes include conditionally displaying the logger in development mode and updating the success message for the proxy server.

### Development experience improvements:
* Modified the `activate` function to show the logger automatically only in development mode by checking `context.extensionMode`. This prevents unnecessary logger display in production.

### User-facing message refinement:
* Updated the success message shown when the proxy server starts to provide a clearer and more concise description, now referring to it as "Agent Maestro server" and focusing on viewing the API documentation.