### PR TITLE
Support fetch Roo task history

### DIFF
--- a/.changeset/angry-flowers-nail.md
+++ b/.changeset/angry-flowers-nail.md
@@ -1,0 +1,5 @@
+---
+"agent-maestro": minor
+---
+
+Support fetch Roo task history

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Install RooCode or its variants from the VS Code marketplace to ensure full func
 
 ### Installation
 
-Install the Agent Maestro extension from the VS Code Marketplace. Once activated, Agent Maestro automatically starts its API server on startup.
+Install the [Agent Maestro extension](https://marketplace.visualstudio.com/items?itemName=Joouis.agent-maestro) from the VS Code Marketplace. Once activated, Agent Maestro automatically starts its API server on startup.
 
 ### Usage
 
@@ -63,6 +63,8 @@ This workflow shows how tasks are created, how messages flow between the client 
 ## API Overview
 
 Agent Maestro exposes a RESTful API that abstracts the complexity of different AI coding agents into a unified interface.
+
+_Note: For latest API documentation, always refer to `/api/v1/openapi.json`._
 
 **Base URL**: `http://localhost:23333/api/v1`
 

--- a/src/core/RooCodeAdapter.ts
+++ b/src/core/RooCodeAdapter.ts
@@ -7,6 +7,7 @@ import {
   RooCodeEventName,
 } from "@roo-code/types";
 import { ExtensionBaseAdapter } from "./ExtensionBaseAdapter";
+import { TaskHistoryItem } from "../types/roo";
 
 export interface TaskEventHandlers {
   onMessage?: (taskId: string, message: any) => void;
@@ -496,6 +497,21 @@ export class RooCodeAdapter extends ExtensionBaseAdapter<RooCodeAPI> {
 
     logger.info(`Setting RooCode active profile: ${name}`);
     return await this.api.setActiveProfile(name);
+  }
+
+  /**
+   * Get task history
+   */
+  getTaskHistory(): TaskHistoryItem[] {
+    if (!this.api) {
+      throw new Error("RooCode API not available");
+    }
+
+    logger.info("Retrieving RooCode task history");
+    const configuration = this.api.getConfiguration();
+    const taskHistory = configuration.taskHistory || [];
+    logger.info(`Retrieved ${taskHistory.length} task history items`);
+    return taskHistory;
   }
 
   /**

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,7 +8,8 @@ let proxy: ProxyServer;
 
 export async function activate(context: vscode.ExtensionContext) {
   // Only show logger automatically in development mode
-  if (context.extensionMode === vscode.ExtensionMode.Development) {
+  const isDevMode = context.extensionMode === vscode.ExtensionMode.Development;
+  if (isDevMode) {
     logger.show();
   }
 
@@ -24,7 +25,7 @@ export async function activate(context: vscode.ExtensionContext) {
     );
   }
 
-  proxy = new ProxyServer(controller);
+  proxy = new ProxyServer(controller, isDevMode ? 33333 : undefined);
 
   // Register commands
   const disposables = [
@@ -50,7 +51,6 @@ export async function activate(context: vscode.ExtensionContext) {
           // Don't show error message for "another instance running" case
           if (result.reason === "Another instance is already running") {
             logger.info(`Server startup skipped: ${result.reason}`);
-            logger.info(`API is available at ${proxy.getStatus().url}`);
           } else {
             vscode.window.showInformationMessage(
               `Server startup: ${result.reason}`,

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -1,4 +1,5 @@
 import { RooCodeSettings } from "@roo-code/types";
+import { TaskHistoryItem } from "../types/roo";
 
 export interface MessageRequest {
   text: string;
@@ -20,4 +21,8 @@ export interface FileReadResponse {
   encoding: string;
   size: number;
   mimeType: string;
+}
+
+export interface TaskHistoryResponse {
+  data: TaskHistoryItem[];
 }

--- a/src/types/roo.ts
+++ b/src/types/roo.ts
@@ -1,0 +1,13 @@
+export interface TaskHistoryItem {
+  id: string;
+  number: number;
+  ts: number;
+  task: string;
+  tokensIn: number;
+  tokensOut: number;
+  cacheWrites?: number;
+  cacheReads?: number;
+  totalCost: number;
+  size?: number;
+  workspace?: string;
+}


### PR DESCRIPTION
This pull request introduces support for fetching the RooCode task history, updates the API documentation, and refines extension behavior for development mode. The most significant changes include the addition of a new API endpoint for task history retrieval, the implementation of the `getTaskHistory` method in the RooCode adapter, and improvements to the extension's activation logic.

### RooCode Task History Support:

* **New API Endpoint**: Added a `GET /api/v1/roo/tasks` endpoint to retrieve the complete task history from the RooCode extension configuration. This includes detailed schema definitions for the response. (`src/server/routes/rooRoutes.ts`, [src/server/routes/rooRoutes.tsR461-R528](diffhunk://#diff-bc30e470b5656b3c242a07b912ad2630a3597c1f7c0fa4c21dfe2152464ef04aR461-R528))
* **Task History Interface**: Introduced a new `TaskHistoryItem` interface to define the structure of task history objects. (`src/types/roo.ts`, [src/types/roo.tsR1-R13](diffhunk://#diff-c72478f05f2be797d6ef56aaeae0a3dc508d9e12e739ee7f1f9ca2333a4ffb1aR1-R13))
* **Adapter Method**: Implemented the `getTaskHistory` method in `RooCodeAdapter` to retrieve task history from the RooCode API. (`src/core/RooCodeAdapter.ts`, [src/core/RooCodeAdapter.tsR502-R516](diffhunk://#diff-93ab7bbde5f6a9563d3471475e787ac0cf69d698581c28999e4c58b6e32ef2cdR502-R516))

### Documentation Updates:

* **Installation Instructions**: Updated the `README.md` to include a link to the Agent Maestro extension on the VS Code Marketplace. (`README.md`, [README.mdL37-R37](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L37-R37))
* **API Documentation Reference**: Added a note in the `README.md` directing users to `/api/v1/openapi.json` for the latest API documentation. (`README.md`, [README.mdR67-R68](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R67-R68))

### Development Mode Enhancements:

* **Proxy Server Configuration**: Modified the `ProxyServer` instantiation to use port `33333` in development mode. (`src/extension.ts`, [src/extension.tsL27-R28](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626L27-R28))
* **Logger Behavior**: Adjusted the logger to automatically show only in development mode. (`src/extension.ts`, [src/extension.tsL11-R12](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626L11-R12))