### PR TITLE
Support newTab argument for new Roo task creation

### DIFF
--- a/.changeset/sixty-turkeys-nail.md
+++ b/.changeset/sixty-turkeys-nail.md
@@ -1,0 +1,5 @@
+---
+"agent-maestro": minor
+---
+
+Support newTab argument for new Roo task creation

--- a/examples/demo-site/src/app/roo/utils/constants.ts
+++ b/examples/demo-site/src/app/roo/utils/constants.ts
@@ -1,4 +1,5 @@
-export const API_BASE_URL = "http://127.0.0.1:23333/api/v1/roo";
+const PORT = 33333; // Dev mode port for Agent Maestro
+export const API_BASE_URL = `http://127.0.0.1:${PORT}/api/v1/roo`;
 
 export const API_ENDPOINTS = {
   TASK: `${API_BASE_URL}/task`,

--- a/src/core/controller.ts
+++ b/src/core/controller.ts
@@ -103,7 +103,7 @@ export class ExtensionController extends EventEmitter {
           configuration: options.configuration,
           text: options.text,
           images: options.images,
-          // newTab: options.newTab ?? true,
+          newTab: options.newTab,
           eventHandlers: options.eventHandlers,
         });
       default:

--- a/src/server/routes/rooRoutes.ts
+++ b/src/server/routes/rooRoutes.ts
@@ -149,7 +149,31 @@ export async function registerRooRoutes(
         summary: "Create a new RooCode task",
         description:
           "Creates and starts a new task using the RooCode extension. Returns Server-Sent Events stream for task progress.",
-        body: { $ref: "MessageRequest#" },
+        body: {
+          type: "object",
+          properties: {
+            text: {
+              type: "string",
+              description: "The task query text",
+            },
+            images: {
+              type: "array",
+              items: { type: "string" },
+              description:
+                "Optional array of image URLs or base64 encoded images",
+            },
+            configuration: {
+              type: "object",
+              description: "RooCode configuration settings",
+            },
+            newTab: {
+              type: "boolean",
+              description:
+                "Whether to open the task in a new tab. Note: When enabled, users cannot send follow-up messages due to issue https://github.com/RooCodeInc/Roo-Code/issues/4412",
+            },
+          },
+          required: ["text"],
+        },
         response: {
           200: {
             description: "Server-Sent Events stream for task progress",
@@ -176,7 +200,8 @@ export async function registerRooRoutes(
     },
     async (request, reply) => {
       try {
-        const { text, images, configuration } = request.body as MessageRequest;
+        const { text, images, configuration, newTab } =
+          request.body as MessageRequest;
 
         if (!text || text.trim() === "") {
           return reply.status(400).send({
@@ -205,6 +230,7 @@ export async function registerRooRoutes(
               text,
               images,
               configuration,
+              newTab,
               eventHandlers,
             },
             ExtensionType.ROO_CODE,

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -5,6 +5,7 @@ export interface MessageRequest {
   text: string;
   images?: string[];
   configuration?: RooCodeSettings;
+  newTab?: boolean;
 }
 
 export interface ActionRequest {


### PR DESCRIPTION
This pull request introduces support for the `newTab` argument in the creation of new Roo tasks, along with updates to the API and related code to accommodate this feature. It also refines the API base URL configuration for development mode. Below are the most important changes grouped by theme:

### Support for `newTab` argument:

* [`src/core/controller.ts`](diffhunk://#diff-df01ea63e8c0be216662ca404759c9d68e63d583635dc3e654b987d1ec6ee061L106-R106): Updated the `ExtensionController` to directly use the `newTab` option instead of defaulting to `true`.
* [`src/server/routes/rooRoutes.ts`](diffhunk://#diff-bc30e470b5656b3c242a07b912ad2630a3597c1f7c0fa4c21dfe2152464ef04aL152-R176): Enhanced the `registerRooRoutes` function to include the `newTab` property in the request body schema, with a detailed description of its behavior and limitations. Also updated the function implementation to handle `newTab` when creating tasks. [[1]](diffhunk://#diff-bc30e470b5656b3c242a07b912ad2630a3597c1f7c0fa4c21dfe2152464ef04aL152-R176) [[2]](diffhunk://#diff-bc30e470b5656b3c242a07b912ad2630a3597c1f7c0fa4c21dfe2152464ef04aL179-R204) [[3]](diffhunk://#diff-bc30e470b5656b3c242a07b912ad2630a3597c1f7c0fa4c21dfe2152464ef04aR233)
* [`src/server/types.ts`](diffhunk://#diff-9a3a0a5fdd0766b53ba8436a42cd88d004c2dadf2853adbe4ca061f4b2215a40R8): Added the optional `newTab` property to the `MessageRequest` interface to support the new functionality.

### API base URL refinement:

* [`examples/demo-site/src/app/roo/utils/constants.ts`](diffhunk://#diff-a3054a65eb73acbe1806fbbe3c3e3d8e5c0ba391c3e0899dc229327408279778L1-R2): Introduced a `PORT` constant for development mode and updated `API_BASE_URL` to dynamically use this port, improving flexibility for local development.

### Changeset documentation:

* [`.changeset/sixty-turkeys-nail.md`](diffhunk://#diff-51ac3877044d0d8edb9f34ad93524bc55a0ae6e51cc309a071fdbf7c9ed29773R1-R5): Documented the addition of the `newTab` argument for new Roo task creation as a minor update under the "agent-maestro" package.