### PR TITLE
Release v0.3.0

### DIFF
--- a/.changeset/angry-flowers-nail.md
+++ b/.changeset/angry-flowers-nail.md
@@ -1,5 +1,0 @@
----
-"agent-maestro": minor
----
-
-Support fetch Roo task history

--- a/.changeset/sixty-turkeys-nail.md
+++ b/.changeset/sixty-turkeys-nail.md
@@ -1,5 +1,0 @@
----
-"agent-maestro": minor
----
-
-Support newTab argument for new Roo task creation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.3.0] - 2025-06-17
+
+- Support fetch Roo task history
+- Support `newTab` argument for new Roo task creation
+
 ## [0.2.5] - 2025-06-17
 
 - Fix logo missing issue and reduce package size by removing unnecessary files

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "agent-maestro",
   "displayName": "Agent Maestro",
   "description": "Headless VS Code AI: bring best-in-class AI agents into any workflow — assist, automate tasks, and generate solutions everywhere.",
-  "version": "0.2.5",
+  "version": "0.3.0",
   "icon": "assets/icons/icon.png",
   "publisher": "Joouis",
   "repository": "https://github.com/Joouis/agent-maestro",


### PR DESCRIPTION
This pull request updates the `agent-maestro` package to version `0.3.0` and introduces new features related to Roo task functionality. The changes include updates to the changelog, version bump in `package.json`, and removal of outdated changeset files.

### Versioning and Documentation Updates:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R7): Added entries for version `0.3.0`, documenting support for fetching Roo task history and the addition of the `newTab` argument for Roo task creation.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L5-R5): Updated the package version from `0.2.5` to `0.3.0`.

### Cleanup of Changeset Files:

* [`.changeset/angry-flowers-nail.md`](diffhunk://#diff-7882a58685347db25a317836591f1422661dd03880c7e64231fddbabcd5ebdfbL1-L5): Removed outdated changeset file for Roo task history support.
* [`.changeset/sixty-turkeys-nail.md`](diffhunk://#diff-51ac3877044d0d8edb9f34ad93524bc55a0ae6e51cc309a071fdbf7c9ed29773L1-L5): Removed outdated changeset file for the `newTab` argument addition.