### PR TITLE
Enhance release changelog based on differences between tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,6 +36,19 @@ jobs:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
         run: pnpm run vscode:publish
 
+      - name: Find previous tag
+        if: startsWith(github.ref, 'refs/tags/')
+        id: previous-tag
+        run: |
+          # Get all tags sorted by version, excluding the current tag
+          previous_tag=$(git tag --sort=-version:refname | grep -v "^${{ github.ref_name }}$" | head -1)
+          if [ -n "$previous_tag" ]; then
+            echo "tag=$previous_tag" >> $GITHUB_OUTPUT
+            echo "found=true" >> $GITHUB_OUTPUT
+          else
+            echo "found=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Create GitHub Release
         if: startsWith(github.ref, 'refs/tags/')
         env:
@@ -44,9 +57,18 @@ jobs:
           # Find the generated VSIX file
           vsix_file=$(find . -name "*.vsix" -type f | head -1)
 
-          # Create release
-          gh release create ${{ github.ref_name }} \
-            --title "Release ${{ github.ref_name }}" \
-            --notes "Release ${{ github.ref_name }}" \
-            --generate-notes \
-            "$vsix_file"
+          # Create release with changelog between tags
+          if [ "${{ steps.previous-tag.outputs.found }}" = "true" ]; then
+            # Generate notes from previous tag to current tag
+            gh release create ${{ github.ref_name }} \
+              --title "Release ${{ github.ref_name }}" \
+              --generate-notes \
+              --notes-start-tag "${{ steps.previous-tag.outputs.tag }}" \
+              "$vsix_file"
+          else
+            # First release - generate notes for all commits
+            gh release create ${{ github.ref_name }} \
+              --title "Release ${{ github.ref_name }}" \
+              --generate-notes \
+              "$vsix_file"
+          fi


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for publishing VS Code extensions. The changes enhance the release creation process by introducing logic to generate changelogs based on differences between tags.

Enhancements to release creation:

* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R39-R51): Added a step to find the previous tag and determine if it exists. The step outputs the previous tag and a flag indicating whether it was found.
* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L47-R74): Updated the release creation process to include changelogs generated from the differences between the previous tag and the current tag, if a previous tag exists. For the first release, notes are generated for all commits.