### PR TITLE
Release v0.4.0

### DIFF
--- a/.changeset/changelog-polish.js
+++ b/.changeset/changelog-polish.js
@@ -9,4 +9,13 @@ text = text.replace(
   (_, ver) => `## v${ver} - ${today}`,
 );
 
+// 2. Remove section headings like "### Minor Changes" and "### Patch Changes"
+text = text.replace(
+  /^###\s+(Minor Changes|Patch Changes|Major Changes)\s*\n\n/gm,
+  "",
+);
+
+// 3. Remove blank lines between bullet points to prevent spacing between sections
+text = text.replace(/^- .+\n\n- /gm, (match) => match.replace("\n\n", "\n"));
+
 fs.writeFileSync(path, text, "utf8");

--- a/.changeset/changelog-polish.js
+++ b/.changeset/changelog-polish.js
@@ -1,0 +1,12 @@
+const fs = require("fs");
+const path = "CHANGELOG.md";
+let text = fs.readFileSync(path, "utf8");
+
+// 1. Turn "## 0.4.0" into "## v0.4.0 - YYYY.MM.DD"
+const today = new Date().toISOString().split("T")[0].replace(/-/g, ".");
+text = text.replace(
+  /^##\s*(\d+\.\d+\.\d+)/m,
+  (_, ver) => `## v${ver} - ${today}`,
+);
+
+fs.writeFileSync(path, text, "utf8");

--- a/.changeset/changelog.js
+++ b/.changeset/changelog.js
@@ -1,0 +1,8 @@
+/** @type {import("@changesets/types").ChangelogFunctions} */
+module.exports = {
+  // We're not using dependency updates:
+  getDependencyReleaseLine: () => Promise.resolve(""),
+
+  // The `changesets` array contains all of the summaries (minor + patch)
+  getReleaseLine: async ({ summary }) => `- ${summary}`,
+};

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
-  "changelog": "@changesets/cli/changelog",
+  "changelog": "./changelog.js",
   "commit": false,
   "fixed": [],
   "linked": [],

--- a/.changeset/fast-paws-wait.md
+++ b/.changeset/fast-paws-wait.md
@@ -1,5 +1,0 @@
----
-"agent-maestro": minor
----
-
-Support cancel current Roo task and resume Roo task by ID

--- a/.changeset/great-poems-mate.md
+++ b/.changeset/great-poems-mate.md
@@ -1,5 +1,0 @@
----
-"agent-maestro": patch
----
-
-Fix 'message "number" is required' issue when requesting /roo/tasks

--- a/.changeset/some-pigs-clean.md
+++ b/.changeset/some-pigs-clean.md
@@ -1,5 +1,0 @@
----
-"agent-maestro": minor
----
-
-Support get Roo task with id

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.4.0 - 2025.06.19
+
+- Support cancel current Roo task and resume Roo task by ID
+- Support get Roo task with id
+- Fix 'message "number" is required' issue when requesting /roo/tasks
+
 ## v0.3.0 - 2025-06-17
 
 - Support fetch Roo task history

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,16 @@
 # Changelog
 
-## [0.3.0] - 2025-06-17
+## v0.3.0 - 2025-06-17
 
 - Support fetch Roo task history
 - Support `newTab` argument for new Roo task creation
 
-## [0.2.5] - 2025-06-17
+## v0.2.5 - 2025-06-17
 
 - Fix logo missing issue and reduce package size by removing unnecessary files
 - Do not show output panel at extension activation
 
-## [0.2.4] - 2025-06-16
+## v0.2.4 - 2025-06-16
 
 ### Features
 
@@ -20,7 +20,7 @@
 - Added Server-Sent Events (SSE) documentation for Roo API
 - Proxy server skips start if another one is already running, otherwise find an available port if default one has been used
 
-## [0.1.0] - 2025-06-14
+## v0.1.0 - 2025-06-14
 
 ### Features
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "agent-maestro",
   "displayName": "Agent Maestro",
   "description": "Headless VS Code AI: bring best-in-class AI agents into any workflow — assist, automate tasks, and generate solutions everywhere.",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "icon": "assets/icons/icon.png",
   "publisher": "Joouis",
   "repository": "https://github.com/Joouis/agent-maestro",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "test": "vscode-test",
     "prepare": "husky",
     "changeset": "changeset",
-    "changeset:version": "changeset version",
+    "changeset:version": "pnpm changeset version && node .changeset/changelog-polish.js",
     "changeset:tag": "changeset tag"
   },
   "lint-staged": {


### PR DESCRIPTION
This pull request introduces several changes to improve the changelog generation process and update the project version to `0.4.0`. The most important changes include implementing custom changelog formatting, updating the `CHANGELOG.md` file with new entries, and modifying the versioning workflow to include additional polishing steps.

### Changelog improvements:

* [`.changeset/changelog-polish.js`](diffhunk://#diff-553ed8ab21c46a73d13f5ead44d3b4d1791d8789d7e3fa1c2c550c0cbb64b8dcR1-R21): Added a script to format the changelog by appending the release date to version headers, removing redundant section headings, and eliminating unnecessary blank lines between bullet points.
* [`.changeset/changelog.js`](diffhunk://#diff-6dc63fd6e685609b1f0bdac3ef4b88a8e489e7f645276ba9624f6d1ac8607fe8R1-R8): Implemented custom changelog generation logic to format release lines and exclude dependency updates.

### Version updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L5-R5): Updated the project version to `0.4.0` and modified the `changeset:version` script to include the new changelog polishing step. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L5-R5) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L124-R124)

### Changelog entries:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL3-R19): Added entries for version `0.4.0`, including support for canceling and resuming Roo tasks, retrieving Roo tasks by ID, and fixing a validation issue with task requests. Updated previous version headers to match the new formatting. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL3-R19) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL23-R29)

### Configuration updates:

* [`.changeset/config.json`](diffhunk://#diff-ed5b41335ff968c5cfd8035d4b8f8c8c0538b6746182d522adb0312eb9137fc5L3-R3): Updated the changelog configuration to use the custom `changelog.js` file instead of the default `@changesets/cli/changelog`.

### Cleanup:

* Removed outdated `.changeset` markdown files that are no longer needed after their entries were incorporated into the `CHANGELOG.md`. [[1]](diffhunk://#diff-5f3d6b379ba5370df016cb1270690434acbad1e71d76b84904d519682d9d88d0L1-L5) [[2]](diffhunk://#diff-ecc4c773069d9db7db1fcd1023280b03278d0e9180c4d6eac1983eab25c45a20L1-L5) [[3]](diffhunk://#diff-0d2d47441fef76ebe001e79279456d1d40dc08a3dd9e9940f557934baa953d15L1-L5)