### PR TITLE
Fix find previous tag failed in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,7 @@ jobs:
         id: previous-tag
         run: |
           # Get all tags sorted by version, excluding the current tag
-          previous_tag=$(git tag --sort=-version:refname | grep -v "^${{ github.ref_name }}$" | head -1)
+          previous_tag=$(git tag --sort=-version:refname | grep -v "^${{ github.ref_name }}" | head -1)
           if [ -n "$previous_tag" ]; then
             echo "tag=$previous_tag" >> $GITHUB_OUTPUT
             echo "found=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This pull request includes a minor adjustment to the `.github/workflows/publish.yml` file. The change removes an unnecessary ` at the end of the `grep` pattern in the `previous_tag` command to ensure proper matching of tags.