### PR TITLE
Support install mcp server config to extension by command and API

### DIFF
--- a/.changeset/cruel-bobcats-cry.md
+++ b/.changeset/cruel-bobcats-cry.md
@@ -1,0 +1,5 @@
+---
+"agent-maestro": minor
+---
+
+Support install mcp server config to extension by command and API

--- a/package.json
+++ b/package.json
@@ -106,6 +106,11 @@
         "command": "agent-maestro.getMcpServerStatus",
         "title": "Get MCP Server Status",
         "category": "Agent Maestro"
+      },
+      {
+        "command": "agent-maestro.installMcpConfig",
+        "title": "Install MCP Configuration",
+        "category": "Agent Maestro"
       }
     ]
   },

--- a/src/server/McpServer.ts
+++ b/src/server/McpServer.ts
@@ -110,7 +110,7 @@ export class McpServer {
       await this.taskManager.initialize();
 
       this.server.addTool({
-        name: "Execute_Roo_Tasks",
+        name: "Execute Roo Tasks",
         description:
           "Execute multiple RooCode tasks in parallel. Returns real-time progress and results for each task.",
         parameters: ExecuteRooTasksSchema,
@@ -121,7 +121,7 @@ export class McpServer {
         execute: async (args, { streamContent }) => {
           const { tasks, maxConcurrency = defaultMaxConcurrency } = args;
           logger.info(
-            `MCP Tool Execute_Roo_Tasks called with ${tasks.length} tasks, maxConcurrency: ${maxConcurrency}`,
+            `MCP Tool Execute Roo Tasks called with ${tasks.length} tasks, maxConcurrency: ${maxConcurrency}`,
           );
 
           try {
@@ -136,14 +136,14 @@ export class McpServer {
               },
             });
 
-            logger.info(`MCP Tool Execute_Roo_Tasks completed.`);
+            logger.info(`MCP Tool Execute Roo Tasks completed.`);
 
             return {
               type: "text",
               text: JSON.stringify(taskResults),
             };
           } catch (error) {
-            logger.error("Error in Execute_Roo_Tasks tool:", error);
+            logger.error("Error in Execute Roo Tasks tool:", error);
             throw error;
           }
         },
@@ -162,6 +162,8 @@ export class McpServer {
 
       logger.info(`MCP Server started on http://127.0.0.1:${this.port}`);
       logger.info(`MCP Server is ready to accept tool calls`);
+
+      // TODO: Add MCP server info to global state
 
       return {
         started: true,

--- a/src/server/ProxyServer.ts
+++ b/src/server/ProxyServer.ts
@@ -1,6 +1,7 @@
 import Fastify, { FastifyInstance } from "fastify";
 import swagger from "@fastify/swagger";
 import cors from "@fastify/cors";
+import * as vscode from "vscode";
 import { logger } from "../utils/logger";
 import { analyzePortUsage, findAvailablePort } from "../utils/portUtils";
 import { ExtensionController } from "../core/controller";
@@ -12,11 +13,17 @@ import { registerInfoRoutes } from "./routes/infoRoutes";
 export class ProxyServer {
   private fastify: FastifyInstance;
   private controller: ExtensionController;
+  private context?: vscode.ExtensionContext;
   private isRunning = false;
   private port: number;
 
-  constructor(controller: ExtensionController, port = 23333) {
+  constructor(
+    controller: ExtensionController,
+    port = 23333,
+    context?: vscode.ExtensionContext,
+  ) {
     this.controller = controller;
+    this.context = context;
     this.port = port;
     this.fastify = Fastify({
       logger: false, // Use our custom logger instead
@@ -63,6 +70,10 @@ export class ProxyServer {
           {
             name: "System",
             description: "System information and status",
+          },
+          {
+            name: "MCP Configuration",
+            description: "MCP server configuration operations",
           },
           {
             name: "Documentation",
@@ -170,7 +181,7 @@ export class ProxyServer {
     this.fastify.register(
       async (fastify) => {
         await registerClineRoutes(fastify, this.controller);
-        await registerRooRoutes(fastify, this.controller);
+        await registerRooRoutes(fastify, this.controller, this.context);
         await registerFsRoutes(fastify);
         await registerInfoRoutes(fastify, this.controller);
 

--- a/src/utils/mcpConfig.ts
+++ b/src/utils/mcpConfig.ts
@@ -1,0 +1,309 @@
+import * as vscode from "vscode";
+import * as fs from "fs";
+import * as path from "path";
+import { readConfiguration } from "./config";
+import { logger } from "./logger";
+
+/**
+ * Result of MCP configuration operation
+ */
+export interface McpConfigResult {
+  success: boolean;
+  message: string;
+  extensionId?: string;
+  configPath?: string;
+}
+
+/**
+ * Extension information with ID and display name
+ */
+export interface ExtensionInfo {
+  id: string;
+  displayName: string;
+}
+
+/**
+ * Agent Maestro MCP server configuration
+ */
+export interface AgentMaestroMcpConfig {
+  type: "streamable-http";
+  url: string;
+  alwaysAllow: string[];
+  timeout: number;
+  disabled: boolean;
+}
+
+/**
+ * MCP settings file structure
+ */
+export interface McpSettings {
+  [serverName: string]: AgentMaestroMcpConfig | any;
+}
+
+/**
+ * Options for adding MCP configuration
+ */
+export interface AddMcpConfigOptions {
+  extensionId: string;
+  globalStorageUri: vscode.Uri;
+}
+
+/**
+ * Default Agent Maestro MCP configuration
+ */
+const DEFAULT_AGENT_MAESTRO_CONFIG: AgentMaestroMcpConfig = {
+  type: "streamable-http",
+  // TODO: read the port from extension context or configuration
+  url: "http://localhost:23334/mcp",
+  alwaysAllow: ["Execute Roo Tasks"],
+  timeout: 900,
+  disabled: false,
+};
+
+/**
+ * Possible MCP settings file names
+ */
+const MCP_SETTINGS_FILENAMES = ["cline_mcp_settings.json", "mcp_settings.json"];
+
+/**
+ * Gets all available extensions that support MCP configuration and are actually installed
+ */
+export function getAvailableExtensions(): ExtensionInfo[] {
+  const config = readConfiguration();
+  const configuredExtensions = [
+    config.defaultRooIdentifier,
+    ...config.rooVariantIdentifiers,
+  ];
+
+  // Filter configured extensions against actually installed extensions
+  const installedExtensions = configuredExtensions
+    .map((id) => {
+      const extension = vscode.extensions.getExtension(id);
+      return extension
+        ? {
+            id,
+            displayName:
+              extension.packageJSON?.displayName ||
+              extension.packageJSON?.name ||
+              id,
+          }
+        : null;
+    })
+    .filter((ext): ext is ExtensionInfo => ext !== null);
+
+  return installedExtensions;
+}
+
+/**
+ * Constructs the path to the MCP settings file for a given extension
+ */
+function getMcpSettingsPath(
+  globalStorageUri: vscode.Uri,
+  extensionId: string,
+  filename: string,
+): string {
+  return path.join(globalStorageUri.fsPath, extensionId, "settings", filename);
+}
+
+/**
+ * Checks if a file exists
+ */
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.promises.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Finds the existing MCP settings file for an extension
+ */
+async function findExistingMcpSettingsFile(
+  globalStorageUri: vscode.Uri,
+  extensionId: string,
+): Promise<string | null> {
+  for (const filename of MCP_SETTINGS_FILENAMES) {
+    const filePath = getMcpSettingsPath(
+      globalStorageUri,
+      extensionId,
+      filename,
+    );
+    if (await fileExists(filePath)) {
+      return filePath;
+    }
+  }
+  return null;
+}
+
+/**
+ * Reads MCP settings from a file
+ */
+async function readMcpSettings(filePath: string): Promise<McpSettings> {
+  try {
+    const content = await fs.promises.readFile(filePath, "utf-8");
+    return JSON.parse(content);
+  } catch (error) {
+    logger.warn(`Failed to read MCP settings from ${filePath}:`, error);
+    return {};
+  }
+}
+
+/**
+ * Writes MCP settings to a file
+ */
+async function writeMcpSettings(
+  filePath: string,
+  settings: McpSettings,
+): Promise<void> {
+  try {
+    // Ensure directory exists
+    const dir = path.dirname(filePath);
+    await fs.promises.mkdir(dir, { recursive: true });
+
+    // Write settings with proper formatting
+    const content = JSON.stringify(settings, null, 2);
+    await fs.promises.writeFile(filePath, content, "utf-8");
+  } catch (error) {
+    throw new Error(`Failed to write MCP settings to ${filePath}: ${error}`);
+  }
+}
+
+/**
+ * Checks if Agent Maestro configuration already exists in the settings
+ */
+function hasAgentMaestroConfig(settings: McpSettings): boolean {
+  return "Agent Maestro" in settings;
+}
+
+/**
+ * Adds Agent Maestro MCP server configuration to a supported extension
+ *
+ * @param options Configuration options including extension ID and storage path
+ * @returns Result of the configuration operation
+ */
+export async function addAgentMaestroMcpConfig(
+  options: AddMcpConfigOptions,
+): Promise<McpConfigResult> {
+  const { extensionId, globalStorageUri } = options;
+
+  try {
+    // Get the parent globalStorage directory to access other extensions' storage
+    const parentGlobalStorageUri = vscode.Uri.file(
+      path.dirname(globalStorageUri.fsPath),
+    );
+
+    // Find existing MCP settings file or determine where to create one
+    let settingsFilePath = await findExistingMcpSettingsFile(
+      parentGlobalStorageUri,
+      extensionId,
+    );
+
+    // Return error if settings file path cannot be found
+    if (!settingsFilePath) {
+      return {
+        success: false,
+        message: "Could not find MCP settings file for the specified extension",
+        extensionId,
+      };
+    }
+
+    // Read existing settings or start with empty object
+    const settings = await readMcpSettings(settingsFilePath);
+    if (!settings.mcpServers) {
+      settings.mcpServers = {};
+    }
+
+    // Check if Agent Maestro config already exists
+    if (hasAgentMaestroConfig(settings.mcpServers)) {
+      return {
+        success: false,
+        message: "Agent Maestro MCP configuration already exists",
+        extensionId,
+        configPath: settingsFilePath,
+      };
+    }
+
+    // Add the Agent Maestro configuration
+    settings.mcpServers["Agent Maestro"] = DEFAULT_AGENT_MAESTRO_CONFIG;
+
+    // Write updated settings back to file
+    await writeMcpSettings(settingsFilePath, settings);
+
+    logger.info(
+      `Successfully added Agent Maestro MCP configuration for extension "${extensionId}" at ${settingsFilePath}`,
+    );
+
+    return {
+      success: true,
+      message: "Agent Maestro MCP configuration added successfully",
+      extensionId,
+      configPath: settingsFilePath,
+    };
+  } catch (error) {
+    const errorMessage = `Failed to add Agent Maestro MCP configuration: ${(error as Error).message}`;
+    logger.error(errorMessage, error);
+
+    return {
+      success: false,
+      message: errorMessage,
+      extensionId,
+    };
+  }
+}
+
+/**
+ * Checks if Agent Maestro MCP configuration exists for a given extension
+ *
+ * @param options Configuration options including extension ID and storage path
+ * @returns Result indicating whether the configuration exists
+ */
+export async function checkAgentMaestroMcpConfig(
+  options: Pick<AddMcpConfigOptions, "extensionId" | "globalStorageUri">,
+): Promise<McpConfigResult & { exists: boolean }> {
+  const { extensionId, globalStorageUri } = options;
+
+  try {
+    // Find existing MCP settings file
+    const settingsFilePath = await findExistingMcpSettingsFile(
+      globalStorageUri,
+      extensionId,
+    );
+
+    if (!settingsFilePath) {
+      return {
+        success: true,
+        message: "No MCP settings file found",
+        extensionId,
+        exists: false,
+      };
+    }
+
+    // Read existing settings
+    const settings = await readMcpSettings(settingsFilePath);
+
+    // Check if Agent Maestro config exists
+    const exists = hasAgentMaestroConfig(settings);
+
+    return {
+      success: true,
+      message: exists
+        ? "Agent Maestro MCP configuration found"
+        : "Agent Maestro MCP configuration not found",
+      extensionId,
+      configPath: settingsFilePath,
+      exists,
+    };
+  } catch (error) {
+    const errorMessage = `Failed to check Agent Maestro MCP configuration: ${(error as Error).message}`;
+    logger.error(errorMessage, error);
+
+    return {
+      success: false,
+      message: errorMessage,
+      extensionId,
+      exists: false,
+    };
+  }
+}


### PR DESCRIPTION
This pull request introduces a new feature to support installing MCP server configurations via both commands and APIs, along with several related enhancements and adjustments. Below is a summary of the most important changes categorized by their themes:

### New MCP Configuration Feature:
* Added a new command, `agent-maestro.installMcpConfig`, to install MCP configurations through the VS Code extension. This includes a user-friendly interface to select supported extensions and handle configuration installation with progress reporting and error handling (`package.json`, `src/extension.ts`, [[1]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R219-R303) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R109-R113).
* Introduced a new API endpoint, `POST /api/v1/roo/install-mcp-config`, to allow programmatic installation of MCP configurations, including validation of supported extensions and error handling (`src/server/routes/rooRoutes.ts`, [src/server/routes/rooRoutes.tsR770-R897](diffhunk://#diff-bc30e470b5656b3c242a07b912ad2630a3597c1f7c0fa4c21dfe2152464ef04aR770-R897)).

### Codebase Enhancements:
* Updated the `ProxyServer` and `registerRooRoutes` to pass the `vscode.ExtensionContext` for accessing global storage and other extension-specific resources (`src/server/ProxyServer.ts`, [[1]](diffhunk://#diff-ec34d12362a10b8031f6b09f0cf3e16b78ef6950705e5b72820390006b676151R16-R26) [[2]](diffhunk://#diff-ec34d12362a10b8031f6b09f0cf3e16b78ef6950705e5b72820390006b676151L173-R184); `src/server/routes/rooRoutes.ts`, [[3]](diffhunk://#diff-bc30e470b5656b3c242a07b912ad2630a3597c1f7c0fa4c21dfe2152464ef04aR139).
* Added new utility functions, `getAvailableExtensions` and `addAgentMaestroMcpConfig`, to handle MCP configuration logic (`src/extension.ts`, [src/extension.tsR7-R10](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R7-R10)).

### Minor Adjustments:
* Renamed the MCP tool name from "Execute_Roo_Tasks" to "Execute Roo Tasks" for improved readability and consistency (`src/server/McpServer.ts`, [[1]](diffhunk://#diff-d4755364acbf96cdec9c9a2191b167b661dd54f5ff4272b486a11e7ba1b6a09cL113-R113) [[2]](diffhunk://#diff-d4755364acbf96cdec9c9a2191b167b661dd54f5ff4272b486a11e7ba1b6a09cL124-R124) [[3]](diffhunk://#diff-d4755364acbf96cdec9c9a2191b167b661dd54f5ff4272b486a11e7ba1b6a09cL139-R146).
* Added a placeholder comment to include MCP server info in the global state in the future (`src/server/McpServer.ts`, [src/server/McpServer.tsR166-R167](diffhunk://#diff-d4755364acbf96cdec9c9a2191b167b661dd54f5ff4272b486a11e7ba1b6a09cR166-R167)). 

These changes collectively enhance the functionality and usability of the Agent Maestro extension, making it easier to manage MCP server configurations.