### PR TITLE
Workaround for new tab groups bug when creating multiple Roo tasks

### DIFF
--- a/.changeset/dry-jeans-watch.md
+++ b/.changeset/dry-jeans-watch.md
@@ -1,0 +1,5 @@
+---
+"agent-maestro": patch
+---
+
+Fix new empty tab groups created when executing multiple roo tasks

--- a/src/core/McpTaskManager.ts
+++ b/src/core/McpTaskManager.ts
@@ -1,5 +1,3 @@
-import * as vscode from "vscode";
-
 import { ClineMessage } from "@roo-code/types";
 import { Semaphore } from "es-toolkit";
 import { logger } from "../utils/logger";

--- a/src/core/McpTaskManager.ts
+++ b/src/core/McpTaskManager.ts
@@ -1,3 +1,5 @@
+import * as vscode from "vscode";
+
 import { ClineMessage } from "@roo-code/types";
 import { Semaphore } from "es-toolkit";
 import { logger } from "../utils/logger";
@@ -7,6 +9,7 @@ import {
   areCompletedMessagesEqual,
   isMessageCompleted,
 } from "../server/utils/rooUtils";
+import { closeAllEmptyTabGroups } from "../utils/extension";
 
 export interface TaskRun {
   task: string;
@@ -88,18 +91,33 @@ export class McpTaskManager {
     // Process tasks with concurrency control
     const semaphore = new Semaphore(maxConcurrency);
 
-    const executeTaskWithSemaphore = async (taskQuery: string) => {
-      await semaphore.acquire();
-      try {
-        await this.executeTask(taskQuery, run, streamContent, timeout);
-      } finally {
-        semaphore.release();
-      }
-    };
-
     // Execute all tasks concurrently with semaphore control
     await Promise.allSettled(
-      taskQueries.map((taskQuery) => executeTaskWithSemaphore(taskQuery)),
+      taskQueries.map(async (taskQuery, idx) => {
+        await semaphore.acquire();
+        try {
+          /**
+           * executeRooTasks will launch the max number of tasks at same time,
+           * however this will trigger a bug in Roo Code that create multiple empty editor groups.
+           * We have to wait the first startNewTask returns task id then launch other tasks.
+           */
+          const onTaskCreated =
+            idx === maxConcurrency - 1 || idx === taskQueries.length - 1
+              ? async () => {
+                  await closeAllEmptyTabGroups();
+                }
+              : undefined;
+          await this.executeTask(
+            taskQuery,
+            run,
+            streamContent,
+            timeout,
+            onTaskCreated,
+          );
+        } finally {
+          semaphore.release();
+        }
+      }),
     );
 
     logger.info(`Completed execution of ${taskQueries.length} RooCode tasks`);
@@ -115,6 +133,7 @@ export class McpTaskManager {
     run: { [taskId: string]: TaskRun },
     streamContent?: StreamContentCallback,
     timeout = 300000,
+    onTaskCreated?: (taskId: string) => void,
   ): Promise<void> {
     let taskId = "";
     let lastMessage: ClineMessage | undefined;
@@ -221,6 +240,10 @@ export class McpTaskManager {
             status: "created",
             result: "Task created, waiting to start...",
           };
+
+          if (onTaskCreated) {
+            onTaskCreated(taskId);
+          }
         })
         .catch((error) => {
           clearTimeout(timeoutId);

--- a/src/utils/extension.ts
+++ b/src/utils/extension.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 
 export const closeAllEmptyTabGroups = async (): Promise<void> => {
-  const emptyGroups = [];
+  const emptyGroups: vscode.TabGroup[] = [];
   for (const group of vscode.window.tabGroups.all) {
     if (group.tabs.length === 0) {
       emptyGroups.push(group);

--- a/src/utils/extension.ts
+++ b/src/utils/extension.ts
@@ -1,0 +1,16 @@
+import * as vscode from "vscode";
+
+export const closeAllEmptyTabGroups = async (): Promise<void> => {
+  const emptyGroups = [];
+  for (const group of vscode.window.tabGroups.all) {
+    if (group.tabs.length === 0) {
+      emptyGroups.push(group);
+    }
+  }
+
+  try {
+    await vscode.window.tabGroups.close(emptyGroups);
+  } catch (error) {
+    console.error("Error closing empty tab group:", error);
+  }
+};

--- a/src/utils/extension.ts
+++ b/src/utils/extension.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import { logger } from "./logger";
 
 export const closeAllEmptyTabGroups = async (): Promise<void> => {
   const emptyGroups: vscode.TabGroup[] = [];
@@ -11,6 +12,6 @@ export const closeAllEmptyTabGroups = async (): Promise<void> => {
   try {
     await vscode.window.tabGroups.close(emptyGroups);
   } catch (error) {
-    console.error("Error closing empty tab group:", error);
+    logger.error("Error closing empty tab groups:", error);
   }
 };


### PR DESCRIPTION
This pull request addresses a bug in Roo Code that creates multiple empty editor tab groups when executing multiple tasks concurrently. The changes introduce a new utility function to close empty tab groups and modify the task execution logic to ensure this function is invoked appropriately.

### Bug Fixes and Enhancements:

* **Fix for empty tab groups bug**: Updated the `executeTask` logic in `McpTaskManager` to invoke a callback (`onTaskCreated`) that closes empty tab groups after certain tasks are created. This prevents the accumulation of empty editor groups during concurrent task execution. (`src/core/McpTaskManager.ts`, [[1]](diffhunk://#diff-1882b64a6524f330dc23eafdb53b275159b0d06e0c3b15bcb1641fd14becfb02L91-R120) [[2]](diffhunk://#diff-1882b64a6524f330dc23eafdb53b275159b0d06e0c3b15bcb1641fd14becfb02R136) [[3]](diffhunk://#diff-1882b64a6524f330dc23eafdb53b275159b0d06e0c3b15bcb1641fd14becfb02R243-R246)

* **New utility function**: Added `closeAllEmptyTabGroups` in `src/utils/extension.ts`, which identifies and closes all empty tab groups in the VS Code editor. This function is integrated into the task execution workflow. (`src/utils/extension.ts`, [src/utils/extension.tsR1-R16](diffhunk://#diff-7e0b5b895f4673056d99f0ac42e9ef493da88b0fec24536f6a19c8f69563b035R1-R16))

### Documentation:

* **Changeset update**: Added a changeset file to document the patch fix for the empty tab groups bug. (`.changeset/dry-jeans-watch.md`, [.changeset/dry-jeans-watch.mdR1-R5](diffhunk://#diff-ef5fba15a21c8973cd153b52c80ebcbccbcf6d62ffaec9b79367f4a3cff79bbfR1-R5))