### PR TITLE
Fix wrong version in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v1.0.0 - 2025.07.01-beta.0
+## v1.0.0-beta.0 - 2025.07.01
 
 - Enable parallel roo tasks execution feature by self-hosting MCP server
 - New extension config to use Roo extension variants like Kilo Code


### PR DESCRIPTION
This pull request updates the versioning format in the changelog to align with semantic versioning conventions.

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL3-R3): Adjusted the versioning format from `v1.0.0 - 2025.07.01-beta.0` to `v1.0.0-beta.0 - 2025.07.01` for consistency and clarity.