### PR TITLE
Release v1.2.0

### DIFF
--- a/.changeset/good-phones-shop.md
+++ b/.changeset/good-phones-shop.md
@@ -1,5 +1,0 @@
----
-"agent-maestro": minor
----
-
-Support `/fs/write` API

--- a/.changeset/two-meals-relate.md
+++ b/.changeset/two-meals-relate.md
@@ -1,5 +1,0 @@
----
-"agent-maestro": minor
----
-
-New config to allow file access outside the current workspace

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.2.0 - 2025.07.03
+
+- Support `/fs/write` API
+- New config to allow file access outside the current workspace
+
 ## v1.1.0 - 2025.07.03
 
 - Make server ports configurable and code refactoring

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "agent-maestro",
   "displayName": "Agent Maestro",
   "description": "Headless VS Code AI: bring best-in-class AI agents into any workflow — assist, automate tasks, and generate solutions everywhere.",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "icon": "assets/icons/icon.png",
   "publisher": "Joouis",
   "repository": "https://github.com/Joouis/agent-maestro",


### PR DESCRIPTION
This pull request updates the version of `agent-maestro` to `v1.2.0` and introduces new features, including support for the `/fs/write` API and a configuration option to allow file access outside the current workspace. It also updates the changelog to reflect these changes.

### Version update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L5-R5): Updated the version from `1.1.0` to `1.2.0`.

### New features:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R7): Added entries for support of the `/fs/write` API and a new configuration option for file access outside the current workspace.