### PR TITLE
Chore: prepare v1.3.0 release and bump version of @roo-code/types

### DIFF
--- a/.changeset/clever-icons-fold.md
+++ b/.changeset/clever-icons-fold.md
@@ -1,5 +1,0 @@
----
-"agent-maestro": minor
----
-
-Enhanced OS data for /info API

--- a/.changeset/fuzzy-feet-film.md
+++ b/.changeset/fuzzy-feet-film.md
@@ -1,5 +1,0 @@
----
-"agent-maestro": minor
----
-
-Support open workspaces and close all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.3.0 - 2025.07.10
+
+- Enhanced OS data for `/info` API
+- Support open VSC workspaces and close all
+
 ## v1.2.0 - 2025.07.03
 
 - Support `/fs/write` API

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "agent-maestro",
   "displayName": "Agent Maestro",
   "description": "Headless VS Code AI: bring best-in-class AI agents into any workflow — assist, automate tasks, and generate solutions everywhere.",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "icon": "assets/icons/icon.png",
   "publisher": "Joouis",
   "repository": "https://github.com/Joouis/agent-maestro",

--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
   "devDependencies": {
     "@anthropic-ai/sdk": "^0.54.0",
     "@changesets/cli": "^2.29.4",
-    "@roo-code/types": "^1.26.0",
+    "@roo-code/types": "^1.31.0",
     "@types/mocha": "^10.0.10",
     "@types/node": "20.x",
     "@types/vscode": "^1.100.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: ^2.29.4
         version: 2.29.4
       "@roo-code/types":
-        specifier: ^1.26.0
-        version: 1.26.0
+        specifier: ^1.31.0
+        version: 1.31.0
       "@types/mocha":
         specifier: ^10.0.10
         version: 10.0.10
@@ -935,10 +935,10 @@ packages:
       }
     engines: { node: ">=14" }
 
-  "@roo-code/types@1.26.0":
+  "@roo-code/types@1.31.0":
     resolution:
       {
-        integrity: sha512-FX+9jl+PRpZG0n+MUFXjlelDdzEVLQULfHAdBCT7npOs0MrC5IaBGxtuZMYRKWYzEvgwRM96oqXgr6CYkNIWZQ==,
+        integrity: sha512-jLT7dC4a577HRgcx1hyHurqndzhQobXAShAljHU4ascF+mZtYFZ2dSCiVh4AP4uqwCvw/BiBAgNrl4Ps3hzsSQ==,
       }
 
   "@sec-ant/readable-stream@0.4.1":
@@ -6549,7 +6549,7 @@ snapshots:
   "@pkgjs/parseargs@0.11.0":
     optional: true
 
-  "@roo-code/types@1.26.0": {}
+  "@roo-code/types@1.31.0": {}
 
   "@sec-ant/readable-stream@0.4.1": {}
 


### PR DESCRIPTION
This pull request updates the `agent-maestro` package to version 1.3.0, introduces new features, and upgrades dependencies. The most important changes include enhancements to the `/info` API, support for managing VS Code workspaces, and updating the `@roo-code/types` dependency to version 1.31.0.

### Feature Updates:
* **Enhanced OS data for `/info` API**: Improved the API to provide more comprehensive OS-related data. (`CHANGELOG.md` - [CHANGELOG.mdR3-R7](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R7))
* **Support for open VS Code workspaces and close all**: Added functionality to manage VS Code workspaces, including opening and closing all workspaces. (`CHANGELOG.md` - [CHANGELOG.mdR3-R7](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R7))

### Version and Dependency Updates:
* **Updated package version to 1.3.0**: The `agent-maestro` package version has been incremented from 1.2.0 to 1.3.0. (`package.json` - [package.jsonL5-R5](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L5-R5))
* **Upgraded `@roo-code/types` dependency**: Updated the dependency from version 1.26.0 to 1.31.0, reflecting changes in `package.json` and `pnpm-lock.yaml`. (`package.json` - [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L151-R151) `pnpm-lock.yaml` - [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL42-R43) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL938-R941) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL6552-R6552)