### PR TITLE
Fix send message does not work for the inactive chat issue

### DIFF
--- a/.changeset/fluffy-paths-doubt.md
+++ b/.changeset/fluffy-paths-doubt.md
@@ -1,0 +1,5 @@
+---
+"agent-maestro": patch
+---
+
+Fix send message does not work for the inactive chat issue


### PR DESCRIPTION
This pull request introduces several changes aimed at improving task handling, streamlining event management, and addressing specific issues within the `RooCodeAdapter` and `rooRoutes`. The updates include adding cleanup mechanisms for task handlers, enhancing task resumption logic, and implementing disconnect handling for server-sent events (SSE). Additionally, a minor bug fix was introduced to resolve an inactive chat issue.

### Task Handling Improvements:
- Added a new `removeTaskHandlers` method in `RooCodeAdapter` to clean up task-specific event handlers, with logging for remaining handlers. (`src/core/RooCodeAdapter.ts`, [src/core/RooCodeAdapter.tsR212-R229](diffhunk://#diff-93ab7bbde5f6a9563d3471475e787ac0cf69d698581c28999e4c58b6e32ef2cdR212-R229))
- Updated `registerRooRoutes` to store the current task ID and call `removeTaskHandlers` on client disconnect. (`src/server/routes/rooRoutes.ts`, [[1]](diffhunk://#diff-bc30e470b5656b3c242a07b912ad2630a3597c1f7c0fa4c21dfe2152464ef04aR257-R269) [[2]](diffhunk://#diff-bc30e470b5656b3c242a07b912ad2630a3597c1f7c0fa4c21dfe2152464ef04aR393-R402)

### Task Resumption Enhancements:
- Enhanced the `resumeTask` method in `RooCodeAdapter` to verify task presence in `clineStack` using a polling mechanism, ensuring smoother task resumption. (`src/core/RooCodeAdapter.ts`, [src/core/RooCodeAdapter.tsR265-R303](diffhunk://#diff-93ab7bbde5f6a9563d3471475e787ac0cf69d698581c28999e4c58b6e32ef2cdR265-R303))

### SSE Disconnect Handling:
- Modified `setupSSEResponse` to accept an optional `onDisconnect` callback, which is invoked on client disconnect or stream closure. (`src/server/routes/rooRoutes.ts`, [[1]](diffhunk://#diff-bc30e470b5656b3c242a07b912ad2630a3597c1f7c0fa4c21dfe2152464ef04aL32-R36) [[2]](diffhunk://#diff-bc30e470b5656b3c242a07b912ad2630a3597c1f7c0fa4c21dfe2152464ef04aR53-R58) [[3]](diffhunk://#diff-bc30e470b5656b3c242a07b912ad2630a3597c1f7c0fa4c21dfe2152464ef04aR67)

### Bug Fix:
- Fixed an issue where sending messages did not work for inactive chats. (`.changeset/fluffy-paths-doubt.md`, [.changeset/fluffy-paths-doubt.mdR1-R5](diffhunk://#diff-4e3ea7b69938f5b19a68a1688d366f01f17bf4ee22fbcb63ad1e27ba19c37e82R1-R5))