### PR TITLE
roo code configurations endpoints for create, update, delete, list and activate

### DIFF
--- a/.changeset/olive-lizards-own.md
+++ b/.changeset/olive-lizards-own.md
@@ -1,0 +1,5 @@
+---
+"agent-maestro": minor
+---
+
+New Roo Code configurations endpoints for create, update, delete, list and activate

--- a/src/server/ProxyServer.ts
+++ b/src/server/ProxyServer.ts
@@ -1,20 +1,20 @@
 import * as vscode from "vscode";
+import { ExtensionController } from "../core/controller";
+import { DEFAULT_CONFIG } from "../utils/config";
 import { logger } from "../utils/logger";
 import { analyzePortUsage } from "../utils/portUtils";
-import { ExtensionController } from "../core/controller";
-import { registerRooRoutes } from "./routes/rooRoutes";
+import { registerAnthropicRoutes } from "./routes/anthropicRoutes";
 import { registerClineRoutes } from "./routes/clineRoutes";
 import { registerFsRoutes } from "./routes/fsRoutes";
 import { registerInfoRoutes } from "./routes/infoRoutes";
-import { registerWorkspaceRoutes } from "./routes/workspaceRoutes";
 import { registerLmRoutes } from "./routes/lmRoutes";
-import { registerAnthropicRoutes } from "./routes/anthropicRoutes";
-import { DEFAULT_CONFIG } from "../utils/config";
+import { registerRooRoutes } from "./routes/rooRoutes";
+import { registerWorkspaceRoutes } from "./routes/workspaceRoutes";
 
-import { OpenAPIHono } from "@hono/zod-openapi";
-import { cors } from "hono/cors";
-import { compress } from "hono/compress";
 import { serve, ServerType } from "@hono/node-server";
+import { OpenAPIHono } from "@hono/zod-openapi";
+import { compress } from "hono/compress";
+import { cors } from "hono/cors";
 
 export class ProxyServer {
   private app: OpenAPIHono;
@@ -110,6 +110,10 @@ export class ProxyServer {
         {
           name: "MCP Configuration",
           description: "MCP server configuration operations",
+        },
+        {
+          name: "Configuration",
+          description: "Profile and configuration management",
         },
         {
           name: "Documentation",

--- a/src/server/routes/rooRoutes.ts
+++ b/src/server/routes/rooRoutes.ts
@@ -708,27 +708,6 @@ export function registerRooRoutes(
   controller: ExtensionController,
   context?: vscode.ExtensionContext,
 ) {
-  // Debug logging to verify profile routes are being registered
-  logger.info("Registering RooCode routes...");
-
-  // Log the profile route definitions to ensure they exist
-  const profileRoutes = [
-    { name: "listProfilesRoute", route: listProfilesRoute },
-    { name: "getProfileRoute", route: getProfileRoute },
-    { name: "createProfileRoute", route: createProfileRoute },
-    { name: "updateProfileRoute", route: updateProfileRoute },
-    { name: "deleteProfileRoute", route: deleteProfileRoute },
-    { name: "getActiveProfileRoute", route: getActiveProfileRoute },
-    { name: "setActiveProfileRoute", route: setActiveProfileRoute },
-  ];
-
-  profileRoutes.forEach(({ name, route }) => {
-    if (route) {
-      logger.info(`Profile route ${name} is defined with path: ${route.path}`);
-    } else {
-      logger.error(`Profile route ${name} is NOT defined!`);
-    }
-  });
   // POST /api/v1/roo/task - Create new RooCode task with SSE stream
   app.openapi(createRooTaskRoute, async (c) => {
     try {
@@ -1050,7 +1029,6 @@ export function registerRooRoutes(
   });
 
   // GET /api/v1/roo/profiles - List all profiles
-  logger.info("Registering GET /roo/profiles route");
   app.openapi(listProfilesRoute, async (c) => {
     try {
       const { extensionId } = c.req.query();
@@ -1096,7 +1074,6 @@ export function registerRooRoutes(
   });
 
   // GET /api/v1/roo/profiles/:name - Get specific profile
-  logger.info("Registering GET /roo/profiles/:name route");
   app.openapi(getProfileRoute, async (c) => {
     try {
       const { name } = c.req.param();
@@ -1162,7 +1139,6 @@ export function registerRooRoutes(
   });
 
   // POST /api/v1/roo/profiles - Create new profile
-  logger.info("Registering POST /roo/profiles route");
   app.openapi(createProfileRoute, async (c) => {
     try {
       const { name, profile, activate, extensionId } = await c.req.json();
@@ -1201,7 +1177,6 @@ export function registerRooRoutes(
   });
 
   // PUT /api/v1/roo/profiles/:name - Update profile
-  logger.info("Registering PUT /roo/profiles/:name route");
   app.openapi(updateProfileRoute, async (c) => {
     try {
       const { name } = c.req.param();
@@ -1241,7 +1216,6 @@ export function registerRooRoutes(
   });
 
   // DELETE /api/v1/roo/profiles/:name - Delete profile
-  logger.info("Registering DELETE /roo/profiles/:name route");
   app.openapi(deleteProfileRoute, async (c) => {
     try {
       const { name } = c.req.param();
@@ -1284,7 +1258,6 @@ export function registerRooRoutes(
   });
 
   // GET /api/v1/roo/profiles/active - Get active profile
-  logger.info("Registering GET /roo/profiles/active route");
   app.openapi(getActiveProfileRoute, async (c) => {
     try {
       const { extensionId } = c.req.query();
@@ -1324,7 +1297,6 @@ export function registerRooRoutes(
   });
 
   // PUT /api/v1/roo/profiles/active/:name - Set active profile
-  logger.info("Registering PUT /roo/profiles/active/:name route");
   app.openapi(setActiveProfileRoute, async (c) => {
     try {
       const { name } = c.req.param();

--- a/src/server/schemas.ts
+++ b/src/server/schemas.ts
@@ -253,6 +253,108 @@ export const FileWriteResponseSchema = z.object({
 });
 
 // ============================================================================
+// PROFILE MANAGEMENT SCHEMAS
+// ============================================================================
+
+export const ProviderSettingsSchema = z
+  .object({
+    apiProvider: z
+      .enum([
+        "anthropic",
+        "openai",
+        "bedrock",
+        "vertex",
+        "ollama",
+        "gemini",
+        "openrouter",
+        "deepseek",
+        "mistral",
+        "groq",
+        "fireworks",
+        "glama",
+        "vscode-lm",
+        "lmstudio",
+        "openai-native",
+        "unbound",
+        "requesty",
+        "human-relay",
+        "fake-ai",
+        "xai",
+        "chutes",
+        "litellm",
+        "kilocode",
+      ])
+      .optional(),
+    apiKey: z.string().optional(),
+    apiModelId: z.string().optional(),
+    modelTemperature: z.number().optional(),
+    modelMaxTokens: z.number().optional(),
+    modelMaxThinkingTokens: z.number().optional(),
+    includeMaxTokens: z.boolean().optional(),
+    reasoningEffort: z.enum(["low", "medium", "high"]).optional(),
+    diffEnabled: z.boolean().optional(),
+    fuzzyMatchThreshold: z.number().optional(),
+    rateLimitSeconds: z.number().optional(),
+    // Add other provider-specific fields as needed
+  })
+  .openapi("ProviderSettings");
+
+export const ProviderSettingsEntrySchema = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+    apiProvider: z.string().optional(),
+  })
+  .openapi("ProviderSettingsEntry");
+
+export const CreateProfileRequestSchema = z
+  .object({
+    name: z.string().min(1).describe("Profile name"),
+    profile: ProviderSettingsSchema.optional().describe("Provider settings"),
+    activate: z
+      .boolean()
+      .optional()
+      .default(true)
+      .describe("Activate profile after creation"),
+    extensionId: z.string().optional().describe("Target extension ID"),
+  })
+  .openapi("CreateProfileRequest");
+
+export const UpdateProfileRequestSchema = z
+  .object({
+    profile: ProviderSettingsSchema.describe("Updated provider settings"),
+    activate: z
+      .boolean()
+      .optional()
+      .default(true)
+      .describe("Activate profile after update"),
+    extensionId: z.string().optional().describe("Target extension ID"),
+  })
+  .openapi("UpdateProfileRequest");
+
+export const SetActiveProfileRequestSchema = z
+  .object({
+    extensionId: z.string().optional().describe("Target extension ID"),
+  })
+  .openapi("SetActiveProfileRequest");
+
+export const ProfileResponseSchema = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+    profile: ProviderSettingsSchema,
+    isActive: z.boolean(),
+  })
+  .openapi("ProfileResponse");
+
+export const ProfileListResponseSchema = z
+  .object({
+    profiles: z.array(ProviderSettingsEntrySchema),
+    activeProfile: z.string().optional(),
+  })
+  .openapi("ProfileListResponse");
+
+// ============================================================================
 // SYSTEM INFORMATION SCHEMAS
 // ============================================================================
 export const ExtensionInfoSchema = z.object({


### PR DESCRIPTION
This PR adds the following 7 new REST endpoints for RooCode profile management:

GET /api/v1/roo/profiles - List all profiles
GET /api/v1/roo/profiles/{name} - Get specific profile
POST /api/v1/roo/profiles - Create new profile
PUT /api/v1/roo/profiles/{name} - Update existing profile
DELETE /api/v1/roo/profiles/{name} - Delete profile
GET /api/v1/roo/profiles/active - Get active profile
PUT /api/v1/roo/profiles/active/{name} - Set active profile

Zod schemas for request/response validation
Integrates with existing RooCodeAdapter profile management methods
APIs are added "Configuration" tag to OpenAPI documentation

Enables programmatic management of RooCode configuration profiles through REST API, allowing external tools and UIs to create, update, delete, and switch between different provider configurations without manual VS Code interaction.

Attached is screenshot from postman import of the openapi spec
<img width="496" height="425" alt="image" src="https://github.com/user-attachments/assets/5fd9eefb-7bf1-4de4-990a-ffc322a731c9" />