### PR TITLE
Do not show error message when no Roo ext installed

### DIFF
--- a/.changeset/stupid-spiders-dig.md
+++ b/.changeset/stupid-spiders-dig.md
@@ -1,0 +1,5 @@
+---
+"agent-maestro": patch
+---
+
+Handle mcp server start failure gracefully when no Roo extension activated

--- a/src/core/controller.ts
+++ b/src/core/controller.ts
@@ -100,7 +100,8 @@ export class ExtensionController extends EventEmitter {
       );
 
     if (!hasActiveAdapter) {
-      throw new Error(
+      // throw new Error(
+      logger.error(
         "No active extension found. This may be due to missing installations or activation issues.",
       );
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,9 +28,8 @@ export async function activate(context: vscode.ExtensionContext) {
   try {
     await controller.initialize();
   } catch (error) {
-    logger.error("Failed to initialize extension controller:", error);
     vscode.window.showErrorMessage(
-      `Agent Maestro: Failed to initialize - ${(error as Error).message}`,
+      `Failed to initialize extension controller: ${(error as Error).message}`,
     );
   }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -37,14 +37,10 @@ export async function activate(context: vscode.ExtensionContext) {
   // Get configuration
   const config = readConfiguration();
 
-  try {
-    mcpServer = new McpServer({
-      controller,
-      port: isDevMode ? 33334 : config.mcpServerPort,
-    });
-  } catch (error) {
-    logger.error("Failed to initialize MCP server:", error);
-  }
+  mcpServer = new McpServer({
+    controller,
+    port: isDevMode ? 33334 : config.mcpServerPort,
+  });
 
   proxy = new ProxyServer(
     controller,
@@ -172,11 +168,6 @@ export async function activate(context: vscode.ExtensionContext) {
       "agent-maestro.startMcpServer",
       async () => {
         try {
-          if (!mcpServer) {
-            vscode.window.showErrorMessage("MCP server not initialized");
-            return;
-          }
-
           const result = await mcpServer.start();
 
           if (result.started) {
@@ -184,9 +175,10 @@ export async function activate(context: vscode.ExtensionContext) {
               `Agent Maestro MCP Server started successfully on port ${result.port}`,
             );
           } else {
-            vscode.window.showInformationMessage(
-              `MCP Server startup: ${result.reason}`,
-            );
+            // vscode.window.showInformationMessage(
+            //   `MCP Server startup: ${result.reason}`,
+            // );
+            logger.error(`MCP Server startup failed: ${result.reason}`);
           }
         } catch (error) {
           logger.error("Failed to start MCP server:", error);

--- a/src/server/McpServer.ts
+++ b/src/server/McpServer.ts
@@ -31,7 +31,7 @@ export interface McpServerConfig {
 }
 
 export class McpServer {
-  private taskManager: McpTaskManager;
+  private taskManager?: McpTaskManager;
   private controller: ExtensionController;
   private port: number;
   private server: FastMCP;
@@ -50,9 +50,7 @@ export class McpServer {
 
     const rooAdapter = this.controller.getRooAdapter();
     if (!rooAdapter) {
-      throw new Error(
-        "MCP Server will not start because RooCode adapter is not available",
-      );
+      return;
     }
     this.taskManager = new McpTaskManager(rooAdapter);
   }
@@ -62,8 +60,19 @@ export class McpServer {
    */
   async start(): Promise<{ started: boolean; reason: string; port?: number }> {
     if (this.isRunning) {
-      logger.warn("MCP Server is already running");
       return { started: false, reason: "MCP Server is already running" };
+    }
+
+    if (!this.taskManager) {
+      const rooAdapter = this.controller.getRooAdapter();
+      if (!rooAdapter) {
+        return {
+          started: false,
+          reason:
+            "MCP Server will not start because task manager is not available, this could be no Roo extension is installed nor active.",
+        };
+      }
+      this.taskManager = new McpTaskManager(rooAdapter);
     }
 
     // Analyze the current port usage
@@ -120,7 +129,7 @@ export class McpServer {
 
           try {
             // Execute tasks through task manager with streaming
-            const taskResults = await this.taskManager.executeRooTasks(tasks, {
+            const taskResults = await this.taskManager!.executeRooTasks(tasks, {
               maxConcurrency,
               streamContent,
             });
@@ -169,8 +178,7 @@ export class McpServer {
    * Stop the MCP server
    */
   async stop(): Promise<void> {
-    if (!this.isRunning) {
-      logger.warn("MCP Server is not running");
+    if (!this.isRunning || !this.taskManager) {
       return;
     }
 
@@ -210,19 +218,5 @@ export class McpServer {
       port: this.port,
       url: `http://127.0.0.1:${this.port}`,
     };
-  }
-
-  /**
-   * Get task manager for direct access
-   */
-  getTaskManager(): McpTaskManager {
-    return this.taskManager;
-  }
-
-  /**
-   * Cleanup resources
-   */
-  async dispose(): Promise<void> {
-    await this.stop();
   }
 }


### PR DESCRIPTION
This pull request improves the robustness of the MCP server startup process by handling cases where the required Roo extension is not installed or activated. Instead of throwing errors that could crash the extension, the code now logs errors and fails gracefully, ensuring a better user experience and easier debugging.

**Graceful handling of MCP server startup and missing dependencies:**

* The MCP server now checks for the Roo extension before starting, and if it's missing, it does not throw an error but logs the issue and avoids starting the server. [[1]](diffhunk://#diff-d4755364acbf96cdec9c9a2191b167b661dd54f5ff4272b486a11e7ba1b6a09cL53-R53) [[2]](diffhunk://#diff-d4755364acbf96cdec9c9a2191b167b661dd54f5ff4272b486a11e7ba1b6a09cL65-R77)
* The `taskManager` in `McpServer` is now optional, and all usages are updated to handle the case where it may be undefined. [[1]](diffhunk://#diff-d4755364acbf96cdec9c9a2191b167b661dd54f5ff4272b486a11e7ba1b6a09cL34-R34) [[2]](diffhunk://#diff-d4755364acbf96cdec9c9a2191b167b661dd54f5ff4272b486a11e7ba1b6a09cL123-R132) [[3]](diffhunk://#diff-d4755364acbf96cdec9c9a2191b167b661dd54f5ff4272b486a11e7ba1b6a09cL172-R181)
* Removed direct throwing of errors when no active extension is found in `ExtensionController`, replacing it with logging for better error reporting.
* The extension activation logic no longer throws or logs errors during MCP server initialization, relying on startup checks and error messages for the user.
* On MCP server startup command, errors are now logged instead of shown as information messages, and missing server initialization is handled more gracefully.

**Codebase cleanup:**

* Removed unused methods from `McpServer`, such as `getTaskManager` and `dispose`, to simplify the class.

These changes ensure that the extension and MCP server fail gracefully when dependencies are missing, improving stability and user feedback.