### PR TITLE
Fix unsupported Claude models issues

### DIFF
--- a/.changeset/every-friends-wink.md
+++ b/.changeset/every-friends-wink.md
@@ -1,0 +1,5 @@
+---
+"agent-maestro": patch
+---
+
+Fix unsupported Claude models issues

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -359,7 +359,7 @@ export async function activate(context: vscode.ExtensionContext) {
           const selectedMainModel = await vscode.window.showQuickPick(
             modelOptions,
             {
-              title: "Select main model (for ANTHROPIC_MODEL)",
+              title: "Select main model (ANTHROPIC_MODEL)",
               placeHolder: "Name of custom model to use",
             },
           );
@@ -371,7 +371,7 @@ export async function activate(context: vscode.ExtensionContext) {
           const selectedFastModel = await vscode.window.showQuickPick(
             modelOptions,
             {
-              title: "Select small fast model (for ANTHROPIC_SMALL_FAST_MODEL)",
+              title: "Select small fast model (ANTHROPIC_SMALL_FAST_MODEL)",
               placeHolder: "Name of Haiku-class model for background tasks",
             },
           );

--- a/src/server/routes/anthropicRoutes.ts
+++ b/src/server/routes/anthropicRoutes.ts
@@ -51,6 +51,9 @@ const convertAnthropicModelToVSCodeModel = (modelId: string): string => {
   }
 
   // If no pattern matches or claude-3-7 models, return a default model ID as fallback
+  logger.warn(
+    `No matching model found for ID: ${modelId}. Falling back to default model ID "claude-3.5-sonnet".`,
+  );
   return "claude-3.5-sonnet";
 };
 

--- a/src/server/routes/anthropicRoutes.ts
+++ b/src/server/routes/anthropicRoutes.ts
@@ -23,15 +23,51 @@ interface ContentBlock {
   toolUse?: vscode.LanguageModelToolCallPart;
 }
 
+const convertAnthropicModelToVSCodeModel = (modelId: string): string => {
+  // Remove date suffix (pattern: -YYYYMMDD at the end) for accurate pattern matching
+  const withoutDate = modelId.replace(/-\d{8}$/, "");
+
+  // Handle different model patterns
+  if (withoutDate === "claude-opus-4-1") {
+    return "claude-opus-41";
+  }
+
+  if (withoutDate === "claude-opus-4") {
+    return "claude-opus-4";
+  }
+
+  if (withoutDate === "claude-sonnet-4") {
+    return "claude-sonnet-4";
+  }
+
+  // Handle claude-3-5-haiku -> claude-3.5-sonnet
+  if (withoutDate === "claude-3-5-haiku") {
+    return "claude-3.5-sonnet";
+  }
+
+  // Handle claude-3-haiku -> claude-3.5-sonnet
+  if (withoutDate === "claude-3-haiku") {
+    return "claude-3.5-sonnet";
+  }
+
+  // If no pattern matches or claude-3-7 models, return a default model ID as fallback
+  return "claude-3.5-sonnet";
+};
+
 const getChatModelClient = async (modelId: string) => {
+  // Convert official Anthropic API model ID to VSCode LM API model ID
+  const vsCodeModelId = convertAnthropicModelToVSCodeModel(modelId);
+
   const models = await vscode.lm.selectChatModels({});
   const client = models
     // Exclude Claude 3.7 models due to model_not_supported error
     .filter((m) => !m.id.includes("claude-3.7"))
-    .find((m) => m.id === modelId);
+    .find((m) => m.id === vsCodeModelId);
 
   if (!client) {
-    logger.error(`No VS Code LM model available for model ID: ${modelId}`);
+    logger.error(
+      `No VS Code LM model available for model ID: ${modelId} (converted to: ${vsCodeModelId})`,
+    );
     return {
       error: {
         error: {

--- a/src/server/routes/anthropicRoutes.ts
+++ b/src/server/routes/anthropicRoutes.ts
@@ -25,7 +25,10 @@ interface ContentBlock {
 
 const getChatModelClient = async (modelId: string) => {
   const models = await vscode.lm.selectChatModels({});
-  const client = models.find((m) => m.id === modelId);
+  const client = models
+    // Exclude Claude 3.7 models due to model_not_supported error
+    .filter((m) => !m.id.includes("claude-3.7"))
+    .find((m) => m.id === modelId);
 
   if (!client) {
     logger.error(`No VS Code LM model available for model ID: ${modelId}`);


### PR DESCRIPTION
This pull request focuses on improving the handling of Anthropic model IDs in the VSCode extension, ensuring better compatibility and error handling between Anthropic API model identifiers and VSCode Language Model API identifiers. The main changes include introducing a conversion function for model IDs, updating the chat model client logic, and clarifying UI labels for model selection.

Two failure cases:

- `model_not_supported` error emitted from Claude 3.7 model clients
- Raw Claude model ids from CC subagent call.

**Model ID handling improvements:**

* Added a new `convertAnthropicModelToVSCodeModel` function in `src/server/routes/anthropicRoutes.ts` to map Anthropic API model IDs to their corresponding VSCode Language Model API model IDs, including logic to strip date suffixes and handle specific model name mappings.
* Updated the `getChatModelClient` function to use the converted VSCode model ID and exclude unsupported Claude 3.7 models, improving error reporting when no matching model is found.

**UI label improvements:**

* Changed the quick pick dialog title for selecting the main model to clarify the mapping to `ANTHROPIC_MODEL`.
* Updated the quick pick dialog title for selecting the small fast model to clarify the mapping to `ANTHROPIC_SMALL_FAST_MODEL`.