### PR TITLE
Listen on wildcard address by proxy server and supports env variables to specify the ports

### DIFF
--- a/.changeset/floppy-bananas-read.md
+++ b/.changeset/floppy-bananas-read.md
@@ -1,0 +1,5 @@
+---
+"agent-maestro": patch
+---
+
+Change proxy server to listen on wildcard address instead of loopback address

--- a/.changeset/wise-papers-sell.md
+++ b/.changeset/wise-papers-sell.md
@@ -1,0 +1,5 @@
+---
+"agent-maestro": minor
+---
+
+Support for AGENT_MAESTRO_PROXY_PORT and AGENT_MAESTRO_MCP_PORT environment variables to override default server ports

--- a/README.md
+++ b/README.md
@@ -99,26 +99,25 @@ This automatically creates `.claude/settings.json` with Agent Maestro endpoint a
 
 ### Environment Variables
 
-Agent Maestro supports the following environment variables for port configuration:
+You can customize Agent Maestro's server ports using environment variables:
 
-- **`AGENT_MAESTRO_PROXY_PORT`**: Override the default proxy server port (default: 23333)
-- **`AGENT_MAESTRO_MCP_PORT`**: Override the default MCP server port (default: 23334)
+| Variable                   | Description       | Default |
+| -------------------------- | ----------------- | ------- |
+| `AGENT_MAESTRO_PROXY_PORT` | Proxy server port | 23333   |
+| `AGENT_MAESTRO_MCP_PORT`   | MCP server port   | 23334   |
 
-Example usage:
+**Usage:**
 
 ```bash
+# Set custom ports
 export AGENT_MAESTRO_PROXY_PORT=8080
 export AGENT_MAESTRO_MCP_PORT=8081
-# Start VS Code with custom ports
+
+# Launch VS Code
 code .
 ```
 
-### VS Code Settings
-
-You can also configure ports through VS Code workspace settings:
-
-- `agent-maestro.proxyServerPort`: Proxy server port
-- `agent-maestro.mcpServerPort`: MCP server port
+> **Note:** Environment variables take precedence over extension settings.
 
 ## API Overview
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,31 @@ This automatically creates `.claude/settings.json` with Agent Maestro endpoint a
    - **Type Definitions**: [`@roo-code/types`](https://www.npmjs.com/package/@roo-code/types) package
    - **Examples**: Reference implementation in `examples/demo-site` (testing purposes)
 
+## Configuration
+
+### Environment Variables
+
+Agent Maestro supports the following environment variables for port configuration:
+
+- **`AGENT_MAESTRO_PROXY_PORT`**: Override the default proxy server port (default: 23333)
+- **`AGENT_MAESTRO_MCP_PORT`**: Override the default MCP server port (default: 23334)
+
+Example usage:
+
+```bash
+export AGENT_MAESTRO_PROXY_PORT=8080
+export AGENT_MAESTRO_MCP_PORT=8081
+# Start VS Code with custom ports
+code .
+```
+
+### VS Code Settings
+
+You can also configure ports through VS Code workspace settings:
+
+- `agent-maestro.proxyServerPort`: Proxy server port
+- `agent-maestro.mcpServerPort`: MCP server port
+
 ## API Overview
 
 Agent Maestro v2.0.0 provides multiple API interfaces for different integration needs.

--- a/examples/demo-site/src/app/roo/utils/constants.ts
+++ b/examples/demo-site/src/app/roo/utils/constants.ts
@@ -8,8 +8,8 @@ const getPort = () => {
 };
 
 const PORT = getPort();
-export const API_BASE_URL = `http://127.0.0.1:${PORT}/api/v1/roo`;
-const INFO_API_BASE_URL = `http://127.0.0.1:${PORT}/api/v1`;
+export const API_BASE_URL = `http://localhost:${PORT}/api/v1/roo`;
+const INFO_API_BASE_URL = `http://localhost:${PORT}/api/v1`;
 
 export const API_ENDPOINTS = {
   TASK: `${API_BASE_URL}/task`,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,6 +15,13 @@ let controller: ExtensionController;
 let proxy: ProxyServer;
 let mcpServer: McpServer;
 
+const envProxyPort = process.env.AGENT_MAESTRO_PROXY_PORT
+  ? parseInt(process.env.AGENT_MAESTRO_PROXY_PORT, 10)
+  : undefined;
+const envMcpPort = process.env.AGENT_MAESTRO_MCP_PORT
+  ? parseInt(process.env.AGENT_MAESTRO_MCP_PORT, 10)
+  : undefined;
+
 export async function activate(context: vscode.ExtensionContext) {
   // Only show logger automatically in development mode
   const isDevMode = context.extensionMode === vscode.ExtensionMode.Development;
@@ -38,12 +45,12 @@ export async function activate(context: vscode.ExtensionContext) {
 
   mcpServer = new McpServer({
     controller,
-    port: isDevMode ? 33334 : config.mcpServerPort,
+    port: envMcpPort ? envMcpPort : isDevMode ? 33334 : config.mcpServerPort,
   });
 
   proxy = new ProxyServer(
     controller,
-    isDevMode ? 33333 : config.proxyServerPort,
+    envProxyPort ? envProxyPort : isDevMode ? 33333 : config.proxyServerPort,
     context,
   );
 

--- a/src/server/McpServer.ts
+++ b/src/server/McpServer.ts
@@ -158,7 +158,7 @@ export class McpServer {
       this.port = actualPort;
       this.isRunning = true;
 
-      logger.info(`MCP Server started on http://127.0.0.1:${this.port}`);
+      logger.info(`MCP Server started on http://0.0.0.0:${this.port}`);
       logger.info(`MCP Server is ready to accept tool calls`);
 
       // TODO: Add MCP server info to global state
@@ -216,7 +216,7 @@ export class McpServer {
     return {
       isRunning: this.isRunning,
       port: this.port,
-      url: `http://127.0.0.1:${this.port}`,
+      url: `http://0.0.0.0:${this.port}`,
     };
   }
 }

--- a/src/server/ProxyServer.ts
+++ b/src/server/ProxyServer.ts
@@ -77,7 +77,7 @@ export class ProxyServer {
       },
       servers: [
         {
-          url: `http://127.0.0.1:${this.port}`,
+          url: `http://0.0.0.0:${this.port}`,
           description: "Development server",
         },
       ],
@@ -136,12 +136,11 @@ export class ProxyServer {
           this.server = serve({
             fetch: this.app.fetch,
             port: this.port,
-            hostname: "127.0.0.1",
           });
           this.isRunning = true;
-          logger.info(`Server started on http://127.0.0.1:${this.port}`);
+          logger.info(`Server started on http://0.0.0.0:${this.port}`);
           logger.info(
-            `API documentation: http://127.0.0.1:${this.port}/openapi.json`,
+            `API documentation: http://0.0.0.0:${this.port}/openapi.json`,
           );
           return {
             started: true,
@@ -156,7 +155,7 @@ export class ProxyServer {
       case "skip":
         // Another instance of our server is already running, skip silently
         logger.info(
-          `${analysis.message}. API available at http://127.0.0.1:${this.port}/openapi.json`,
+          `${analysis.message}. API available at http://0.0.0.0:${this.port}/openapi.json`,
         );
         return {
           started: false,
@@ -209,11 +208,11 @@ export class ProxyServer {
     return {
       isRunning: this.isRunning,
       port: this.port,
-      url: `http://localhost:${this.port}`,
+      url: `http://0.0.0.0:${this.port}`,
     };
   }
 
   getOpenApiUrl(): string {
-    return `http://localhost:${this.port}/openapi.json`;
+    return `http://0.0.0.0:${this.port}/openapi.json`;
   }
 }

--- a/src/server/schemas.ts
+++ b/src/server/schemas.ts
@@ -347,13 +347,6 @@ export const ProfileResponseSchema = z
   })
   .openapi("ProfileResponse");
 
-export const ProfileListResponseSchema = z
-  .object({
-    profiles: z.array(ProviderSettingsEntrySchema),
-    activeProfile: z.string().optional(),
-  })
-  .openapi("ProfileListResponse");
-
 // ============================================================================
 // SYSTEM INFORMATION SCHEMAS
 // ============================================================================

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -25,8 +25,11 @@ export const CONFIG_KEYS = {
 export const DEFAULT_CONFIG: AgentMaestroConfiguration = {
   rooVariantIdentifiers: ["kilocode.kilo-code"],
   defaultRooIdentifier: "rooveterinaryinc.roo-cline",
-  proxyServerPort: 23333,
-  mcpServerPort: 23334,
+  proxyServerPort: parseInt(
+    process.env.AGENT_MAESTRO_PROXY_PORT || "23333",
+    10,
+  ),
+  mcpServerPort: parseInt(process.env.AGENT_MAESTRO_MCP_PORT || "23334", 10),
   allowOutsideWorkspaceAccess: false,
 };
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -25,11 +25,8 @@ export const CONFIG_KEYS = {
 export const DEFAULT_CONFIG: AgentMaestroConfiguration = {
   rooVariantIdentifiers: ["kilocode.kilo-code"],
   defaultRooIdentifier: "rooveterinaryinc.roo-cline",
-  proxyServerPort: parseInt(
-    process.env.AGENT_MAESTRO_PROXY_PORT || "23333",
-    10,
-  ),
-  mcpServerPort: parseInt(process.env.AGENT_MAESTRO_MCP_PORT || "23334", 10),
+  proxyServerPort: 23333,
+  mcpServerPort: 23334,
   allowOutsideWorkspaceAccess: false,
 };
 

--- a/src/utils/portUtils.ts
+++ b/src/utils/portUtils.ts
@@ -9,7 +9,7 @@ export function isPortAvailable(port: number): Promise<boolean> {
   return new Promise((resolve) => {
     const server = net.createServer();
 
-    server.listen(port, "127.0.0.1", () => {
+    server.listen(port, () => {
       server.close(() => {
         resolve(true);
       });
@@ -27,7 +27,7 @@ export function isPortAvailable(port: number): Promise<boolean> {
 export function isOurProxyServer(port: number): Promise<boolean> {
   return new Promise((resolve) => {
     const req = http.get(
-      `http://127.0.0.1:${port}/api/v1/info`,
+      `http://0.0.0.0:${port}/api/v1/info`,
       {
         timeout: 2000,
       },


### PR DESCRIPTION
This pull request introduces several improvements to Agent Maestro's server configuration and API. The main changes are support for environment variables to override default server ports, updating the proxy and MCP servers to listen on all network interfaces (wildcard address), and simplifying the profiles API response structure. These updates enhance flexibility for deployment and make the API more consistent and easier to use.

**Server configuration and deployment improvements:**

* Added support for `AGENT_MAESTRO_PROXY_PORT` and `AGENT_MAESTRO_MCP_PORT` environment variables, allowing users to override default ports for the proxy and MCP servers. [[1]](diffhunk://#diff-04f8249d40c394b96f4cffca4642f88148ed31c8d61478ff6207a0c88c56cb8fR1-R5) [[2]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R18-R24) [[3]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626L41-R53) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R98-R121)
* Changed both proxy and MCP servers to listen on the wildcard address (`0.0.0.0`) instead of the loopback address (`127.0.0.1`), making them accessible from outside the local machine. [[1]](diffhunk://#diff-a2ae8e6375fc4a94c175b53a6fb11ff007684cbe039ed989705d42717d24c3f4R1-R5) [[2]](diffhunk://#diff-d4755364acbf96cdec9c9a2191b167b661dd54f5ff4272b486a11e7ba1b6a09cL161-R161) [[3]](diffhunk://#diff-d4755364acbf96cdec9c9a2191b167b661dd54f5ff4272b486a11e7ba1b6a09cL219-R219) [[4]](diffhunk://#diff-ec34d12362a10b8031f6b09f0cf3e16b78ef6950705e5b72820390006b676151L80-R80) [[5]](diffhunk://#diff-ec34d12362a10b8031f6b09f0cf3e16b78ef6950705e5b72820390006b676151L143-R147) [[6]](diffhunk://#diff-ec34d12362a10b8031f6b09f0cf3e16b78ef6950705e5b72820390006b676151L163-R162) [[7]](diffhunk://#diff-ec34d12362a10b8031f6b09f0cf3e16b78ef6950705e5b72820390006b676151L216-R220) [[8]](diffhunk://#diff-a3054a65eb73acbe1806fbbe3c3e3d8e5c0ba391c3e0899dc229327408279778L11-R12) [[9]](diffhunk://#diff-a7acfb70e35e5b304fcf471e1918aae7e015a652222790a73f852db134d1f82eL12-R12) [[10]](diffhunk://#diff-a7acfb70e35e5b304fcf471e1918aae7e015a652222790a73f852db134d1f82eL30-R30)

**API and documentation updates:**

* Updated the `/roo/profiles` API endpoint to always return all profiles and the active profile object, removing the `state` query parameter and simplifying the response schema. [[1]](diffhunk://#diff-bc30e470b5656b3c242a07b912ad2630a3597c1f7c0fa4c21dfe2152464ef04aL396-R413) [[2]](diffhunk://#diff-bc30e470b5656b3c242a07b912ad2630a3597c1f7c0fa4c21dfe2152464ef04aL1021-R1016) [[3]](diffhunk://#diff-bc30e470b5656b3c242a07b912ad2630a3597c1f7c0fa4c21dfe2152464ef04aL1032-L1056) [[4]](diffhunk://#diff-bc30e470b5656b3c242a07b912ad2630a3597c1f7c0fa4c21dfe2152464ef04aR1046-R1054) [[5]](diffhunk://#diff-407d7d63894511bdadf348534c2ce412e76a9ebd9d03dd9fa8ef8095fddd0ed4L350-L356) [[6]](diffhunk://#diff-bc30e470b5656b3c242a07b912ad2630a3597c1f7c0fa4c21dfe2152464ef04aL17)
* Improved documentation in `README.md` to describe the new environment variable configuration options for server ports.