### PR TITLE
Fix use claude-3.5 when choosing non-Claude models like GPT

### DIFF
--- a/.changeset/early-chairs-leave.md
+++ b/.changeset/early-chairs-leave.md
@@ -1,0 +1,5 @@
+---
+"agent-maestro": patch
+---
+
+Fix use claude-3.5 when choosing non-Claude models like GPT

--- a/src/server/routes/anthropicRoutes.ts
+++ b/src/server/routes/anthropicRoutes.ts
@@ -59,9 +59,10 @@ const convertAnthropicModelToVSCodeModel = (modelId: string): string => {
   return "claude-3.5-sonnet";
 };
 
+const ANTHROPIC_MODEL_PREFIX = "claude";
 const getChatModelClient = async (modelId: string) => {
   // Convert official Anthropic API model ID to VSCode LM API model ID
-  const vsCodeModelId = modelId.startsWith("claude")
+  const vsCodeModelId = modelId.startsWith(ANTHROPIC_MODEL_PREFIX)
     ? convertAnthropicModelToVSCodeModel(modelId)
     : modelId;
 

--- a/src/server/routes/anthropicRoutes.ts
+++ b/src/server/routes/anthropicRoutes.ts
@@ -1,10 +1,16 @@
+import Anthropic from "@anthropic-ai/sdk";
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import { Context } from "hono";
+import { streamSSE } from "hono/streaming";
+import * as vscode from "vscode";
+
 import { chatModelsCache } from "../../utils/chatModels";
 import { logger } from "../../utils/logger";
 import {
+  AnthropicCountTokensResponseSchema,
   AnthropicErrorResponseSchema,
   AnthropicMessageCreateParamsSchema,
   AnthropicMessageResponseSchema,
-  AnthropicCountTokensResponseSchema,
 } from "../schemas";
 import {
   convertAnthropicMessagesToVSCode,
@@ -12,11 +18,6 @@ import {
   convertAnthropicToolChoiceToVSCode,
   convertAnthropicToolToVSCode,
 } from "../utils/anthropic";
-import Anthropic from "@anthropic-ai/sdk";
-import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
-import { Context } from "hono";
-import { streamSSE } from "hono/streaming";
-import * as vscode from "vscode";
 
 interface ContentBlock {
   type: "text" | "tool_use" | string;
@@ -60,7 +61,9 @@ const convertAnthropicModelToVSCodeModel = (modelId: string): string => {
 
 const getChatModelClient = async (modelId: string) => {
   // Convert official Anthropic API model ID to VSCode LM API model ID
-  const vsCodeModelId = convertAnthropicModelToVSCodeModel(modelId);
+  const vsCodeModelId = modelId.startsWith("claude")
+    ? convertAnthropicModelToVSCodeModel(modelId)
+    : modelId;
 
   const models = await chatModelsCache.getChatModels();
   const client = models


### PR DESCRIPTION
This pull request addresses a bug where the system incorrectly attempted to use the Claude 3.5 model when a non-Claude model (such as GPT) was selected. The main fix ensures that model IDs are handled correctly so that only Claude models are converted, while other models retain their original IDs.

Bug fix for model selection:

* Updated the logic in `src/server/routes/anthropicRoutes.ts` so that only model IDs starting with `"claude"` are converted using `convertAnthropicModelToVSCodeModel`; other model IDs are passed through unchanged, preventing incorrect usage of Claude-specific logic for non-Claude models.

Other changes:

* Added a patch changelog entry in `.changeset/early-chairs-leave.md` describing the fix for model selection.
* Minor import reordering in `src/server/routes/anthropicRoutes.ts` for clarity and organization.