### PR TITLE
Support for configuring user settings of Claude Code and bugfix

### DIFF
--- a/.changeset/dirty-spoons-divide.md
+++ b/.changeset/dirty-spoons-divide.md
@@ -1,0 +1,5 @@
+---
+"agent-maestro": minor
+---
+
+Support configure user settings for Claude Code

--- a/.changeset/fluffy-jars-fold.md
+++ b/.changeset/fluffy-jars-fold.md
@@ -1,0 +1,5 @@
+---
+"agent-maestro": patch
+---
+
+Set CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC to true for CC settings file by default

--- a/.changeset/loose-ghosts-throw.md
+++ b/.changeset/loose-ghosts-throw.md
@@ -1,0 +1,5 @@
+---
+"agent-maestro": patch
+---
+
+Treat Anthropic System prompt as user message instead of assistant message

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,3 +1,4 @@
+import os from "os";
 import * as vscode from "vscode";
 
 import { ExtensionController } from "./core/controller";
@@ -350,7 +351,6 @@ export async function activate(context: vscode.ExtensionContext) {
 
           if (settingsType.label === "User Settings") {
             // Use user's home directory
-            const os = require("os");
             const homePath = os.homedir();
             claudeDir = vscode.Uri.file(homePath).with({
               path: homePath + "/.claude",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -409,6 +409,8 @@ export async function activate(context: vscode.ExtensionContext) {
               ANTHROPIC_AUTH_TOKEN: authToken,
               ANTHROPIC_MODEL: selectedMainModel.modelId,
               ANTHROPIC_SMALL_FAST_MODEL: selectedFastModel.modelId,
+              // Equivalent of setting `DISABLE_AUTOUPDATER`, `DISABLE_BUG_COMMAND`, `DISABLE_ERROR_REPORTING`, and `DISABLE_TELEMETRY` to true
+              CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1",
             },
           };
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -321,20 +321,58 @@ export async function activate(context: vscode.ExtensionContext) {
       "agent-maestro.configureClaudeCode",
       async () => {
         try {
-          const workspaceRoot =
-            vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
-          if (!workspaceRoot) {
-            vscode.window.showErrorMessage(
-              "No workspace folder found. Please open a workspace to configure Claude Code settings.",
-            );
+          // Ask user whether to configure user settings or project settings
+          const settingsType = await vscode.window.showQuickPick(
+            [
+              {
+                label: "User Settings",
+                description:
+                  "Personal global settings for all projects (~/.claude/settings.json)",
+              },
+              {
+                label: "Project Settings",
+                description:
+                  "Team-shared project settings in source control (.claude/settings.json)",
+              },
+            ],
+            {
+              title: "Configure Claude Code Settings",
+              placeHolder: "Choose where to save Claude Code settings",
+            },
+          );
+
+          if (!settingsType) {
             return;
           }
 
-          const claudeDir = vscode.Uri.joinPath(
-            vscode.Uri.file(workspaceRoot),
-            ".claude",
-          );
-          const settingsFile = vscode.Uri.joinPath(claudeDir, "settings.json");
+          let claudeDir: vscode.Uri;
+          let settingsFile: vscode.Uri;
+
+          if (settingsType.label === "User Settings") {
+            // Use user's home directory
+            const os = require("os");
+            const homePath = os.homedir();
+            claudeDir = vscode.Uri.file(homePath).with({
+              path: homePath + "/.claude",
+            });
+            settingsFile = vscode.Uri.joinPath(claudeDir, "settings.json");
+          } else {
+            // Use project directory
+            const workspaceRoot =
+              vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+            if (!workspaceRoot) {
+              vscode.window.showErrorMessage(
+                "No workspace folder found. Please open a workspace to configure project Claude Code settings.",
+              );
+              return;
+            }
+
+            claudeDir = vscode.Uri.joinPath(
+              vscode.Uri.file(workspaceRoot),
+              ".claude",
+            );
+            settingsFile = vscode.Uri.joinPath(claudeDir, "settings.json");
+          }
 
           // Check if settings file exists and confirm override
           let existingSettings: any = {};

--- a/src/server/utils/anthropic.ts
+++ b/src/server/utils/anthropic.ts
@@ -204,7 +204,7 @@ export const convertAnthropicMessagesToVSCode = (
 
 /**
  * Convert Anthropic system prompt to VS Code LanguageModelChatMessage array
- * System prompts are treated as Assistant messages in VS Code LM API
+ * System prompts are treated as User messages in VS Code LM API
  *
  * @param system - Anthropic system prompt (string or array of TextBlockParam)
  * @returns Array of VS Code LanguageModelChatMessage for system content
@@ -217,12 +217,12 @@ export const convertAnthropicSystemToVSCode = (
   }
 
   if (typeof system === "string") {
-    return [vscode.LanguageModelChatMessage.Assistant(system)];
+    return [vscode.LanguageModelChatMessage.User(system)];
   }
 
   // Handle array of TextBlockParam
   return system.map((block) =>
-    vscode.LanguageModelChatMessage.Assistant(block.text),
+    vscode.LanguageModelChatMessage.User(block.text),
   );
 };
 


### PR DESCRIPTION
This pull request introduces new support for configuring Claude Code settings at both the user and project levels, improves privacy defaults, and addresses how Anthropic system prompts are handled. The most important changes are:

**Settings Configuration Improvements:**

* Added a prompt allowing users to choose between configuring Claude Code settings in user (`~/.claude/settings.json`) or project (`.claude/settings.json`) scope, enhancing flexibility for personal and team use. [[1]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R324-R375) [[2]](diffhunk://#diff-a423f4149daff5d5be783065aff35951a1edd4c9794e2f8e2d8331654312f051R1-R5)

* By default, the `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` setting is now enabled in the settings file, reducing non-essential network traffic for improved privacy and compliance. [[1]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R450-R451) [[2]](diffhunk://#diff-3a73aebc1862f15c2ef4d1d668b1c299f2e406dab197969ea29c4b7b6fda2acfR1-R5)

**Anthropic System Prompt Handling:**

* Anthropic system prompts are now treated as user messages (instead of assistant messages) in the VS Code Language Model API, ensuring more accurate context handling. [[1]](diffhunk://#diff-883e2326c29d4c55c46e9128aa750e3ea11d81c5888e5e0dd26e0dc81b420ef9L207-R207) [[2]](diffhunk://#diff-883e2326c29d4c55c46e9128aa750e3ea11d81c5888e5e0dd26e0dc81b420ef9L220-R225) [[3]](diffhunk://#diff-c3bbc51ef1452072162fc9844e82f6dd01e3f900ee11fdb060ae1b2d21e8d591R1-R5)