### PR TITLE
Add tool handling for non-streaming /v1/messages API and update token count logic

### DIFF
--- a/.changeset/green-phones-chew.md
+++ b/.changeset/green-phones-chew.md
@@ -1,0 +1,5 @@
+---
+"agent-maestro": patch
+---
+
+Add tool calls to output token counts for `/v1/messages` API

--- a/.changeset/soft-rice-matter.md
+++ b/.changeset/soft-rice-matter.md
@@ -1,0 +1,5 @@
+---
+"agent-maestro": patch
+---
+
+Add tool handling for non-streaming `/v1/messages` API

--- a/src/server/routes/anthropicRoutes.ts
+++ b/src/server/routes/anthropicRoutes.ts
@@ -219,15 +219,36 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
         cancellationToken,
       );
 
-      // 5. Non-streaming response: collect full text
+      // 5. Non-streaming response: collect content blocks using unified approach
       if (!msgCreateParams.stream) {
-        let fullText = "";
-        for await (const fragment of response.text) {
-          fullText += fragment;
+        const content: Anthropic.Messages.ContentBlock[] = [];
+        let accumulatedText = "";
+
+        for await (const chunk of response.stream) {
+          if (chunk instanceof vscode.LanguageModelTextPart) {
+            let lastBlock = content.at(-1);
+            if (!lastBlock || lastBlock.type !== "text") {
+              lastBlock = { type: "text", text: "", citations: null };
+              content.push(lastBlock);
+            }
+            lastBlock.text += chunk.value;
+            accumulatedText += chunk.value;
+          } else if (chunk instanceof vscode.LanguageModelToolCallPart) {
+            content.push({
+              type: "tool_use",
+              id: chunk.callId,
+              name: chunk.name,
+              input: chunk.input,
+            });
+
+            accumulatedText += JSON.stringify(chunk);
+          }
         }
 
         // Count output tokens
-        const outputTokenCount = await client.countTokens(fullText);
+        const outputTokenCount = accumulatedText
+          ? await client.countTokens(accumulatedText)
+          : 1;
 
         // https://docs.anthropic.com/en/api/messages#response-id
         const resp: Anthropic.Messages.Message = {
@@ -235,9 +256,9 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
           type: "message",
           role: "assistant",
           model: modelId,
-          // TODO: what about other ContentBlock like ToolUseBlock or ThinkingBlock?
-          content: [{ type: "text", text: fullText, citations: null }],
-          stop_reason: "end_turn",
+          content,
+          stop_reason:
+            content.at(-1)?.type === "tool_use" ? "tool_use" : "end_turn",
           stop_sequence: null,
           usage: {
             // cache_creation: null,
@@ -324,8 +345,6 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
                   delta: { type: "text_delta", text: chunk.value },
                 });
               } else if (chunk instanceof vscode.LanguageModelToolCallPart) {
-                // TODO: accumulatedText does not include tool calls yet
-
                 // Every tool call is a new content block
                 if (lastBlock) {
                   await writeSSE({
@@ -354,6 +373,8 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
                     partial_json: JSON.stringify(chunk.input),
                   },
                 });
+
+                accumulatedText += JSON.stringify(chunk);
               }
             }
 


### PR DESCRIPTION
This pull request introduces improvements to the `/v1/messages` API in the `agent-maestro` package, focusing on enhanced tool call handling and accurate output token counting for both streaming and non-streaming responses. The main changes unify content block processing, ensure tool calls are included in responses, and update token counting logic.

**API enhancements:**

* Added support for tool call content blocks in non-streaming `/v1/messages` API responses, ensuring that tool calls are now properly included in the output alongside text blocks. [[1]](diffhunk://#diff-b3caf1242bf6057e8620748655a8ea49ffb50dde1a5ed188f3e5bc345d68f52bR1-R5) [[2]](diffhunk://#diff-3021471c130441101ac814090592923a2cd5c0f689e499ab4914fcc21898ee5dL222-R261)
* Updated output token counting logic to account for both text and tool call content in non-streaming responses, improving the accuracy of usage reporting. [[1]](diffhunk://#diff-c5db3aaa0830f5ff1507f3cc29cf0828169b0903a3639ca8829851c52897a867R1-R5) [[2]](diffhunk://#diff-3021471c130441101ac814090592923a2cd5c0f689e499ab4914fcc21898ee5dL222-R261) [[3]](diffhunk://#diff-3021471c130441101ac814090592923a2cd5c0f689e499ab4914fcc21898ee5dR376-R377)

**Internal implementation improvements:**

* Refactored non-streaming response handling to use a unified approach for collecting content blocks, matching the streaming response structure and simplifying code maintenance.
* Ensured that the `stop_reason` field in responses correctly reflects the presence of tool calls, setting it to `"tool_use"` when appropriate.

**Changeset documentation:**

* Added changeset files documenting the patch-level changes for tool call handling and token counting in the `agent-maestro` package. [[1]](diffhunk://#diff-c5db3aaa0830f5ff1507f3cc29cf0828169b0903a3639ca8829851c52897a867R1-R5) [[2]](diffhunk://#diff-b3caf1242bf6057e8620748655a8ea49ffb50dde1a5ed188f3e5bc345d68f52bR1-R5)