### PR TITLE
Release v2.3.1

### DIFF
--- a/.changeset/green-phones-chew.md
+++ b/.changeset/green-phones-chew.md
@@ -1,5 +1,0 @@
----
-"agent-maestro": patch
----
-
-Add tool calls to output token counts for `/v1/messages` API

--- a/.changeset/shaky-books-travel.md
+++ b/.changeset/shaky-books-travel.md
@@ -1,5 +1,0 @@
----
-"agent-maestro": patch
----
-
-Aa user prompt to reload the VS Code window after updating or creating the Codex configuration, ensuring that configuration changes take effect immediately.

--- a/.changeset/soft-rice-matter.md
+++ b/.changeset/soft-rice-matter.md
@@ -1,5 +1,0 @@
----
-"agent-maestro": patch
----
-
-Add tool handling for non-streaming `/v1/messages` API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v2.3.1 - 2025.09.28
+
+- Add tool handling support for non-streaming `/v1/messages` API
+- Add tool calls to output token counts for `/v1/messages` API
+- Prompt user to reload VS Code window after updating or creating Codex configuration to ensure changes take effect
+
 ## v2.3.0 - 2025.09.25
 
 - Added **OpenAI-compatible** `POST /chat/completions` endpoint

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "agent-maestro",
   "displayName": "Agent Maestro",
   "description": "Turn VS Code into your compliant AI playground! With Agent Maestro, spin up Cline or Roo on demand and plug Claude Code or Codex straight in through an OpenAI/Anthropic-compatible API.",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "icon": "assets/icons/icon.png",
   "publisher": "Joouis",
   "repository": "https://github.com/Joouis/agent-maestro",


### PR DESCRIPTION
This pull request prepares the `agent-maestro` extension for release v2.3.1, introducing improvements to the `/v1/messages` API and enhancing the user experience when updating Codex configurations. The most important changes are summarized below.

API enhancements:

* Added support for tool handling with the non-streaming `/v1/messages` API, allowing tools to be invoked even when responses are not streamed.
* Added tool calls to output token counts for the `/v1/messages` API, providing better insight into API usage.

User experience improvements:

* Added a prompt for users to reload the VS Code window after updating or creating the Codex configuration, ensuring configuration changes take effect immediately.

Release and documentation:

* Updated `CHANGELOG.md` to document the new features and improvements for version 2.3.1.
* Bumped the extension version to 2.3.1 in `package.json`.