### PR TITLE
Check CC version and show warning for v2

### DIFF
--- a/.changeset/orange-yaks-vanish.md
+++ b/.changeset/orange-yaks-vanish.md
@@ -1,0 +1,5 @@
+---
+"agent-maestro": patch
+---
+
+Added warning when detecting Claude Code extension versions newer than v1.0.127 (native v2), which ignore LLM Gateway settings and may limit Agent Maestro features.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 Turn VS Code into your compliant AI playground! With Agent Maestro, spin up Cline or Roo on demand and plug Claude Code or Codex straight in through an OpenAI/Anthropic-compatible API.
 
+> ⚠️ **Note:** The Claude Code native extension (versions **later than `v1.0.127`**) **no longer support LLM Gateway settings**. Agent Maestro remains compatible with the **Claude Code CLI** in the terminal and with **legacy extension versions prior to v2**.
+
 ![Claude Code Support](https://media.githubusercontent.com/media/Joouis/agent-maestro/main/assets/configure-claude-code-demo.gif)
 
 ![Agent Maestro Demo](https://media.githubusercontent.com/media/Joouis/agent-maestro/main/assets/agent-maestro-demo.gif)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,6 +10,7 @@ import {
   chatModelsCache,
   getChatModelsQuickPickItems,
 } from "./utils/chatModels";
+import { showClaudeCodeCompatibilityWarning } from "./utils/claudeCode";
 import { readConfiguration } from "./utils/config";
 import { logger } from "./utils/logger";
 import {
@@ -34,6 +35,8 @@ export async function activate(context: vscode.ExtensionContext) {
   if (context.extensionMode === vscode.ExtensionMode.Development) {
     logger.show();
   }
+
+  showClaudeCodeCompatibilityWarning();
 
   // Initialize the extension controller
   controller = new ExtensionController();

--- a/src/utils/claudeCode.ts
+++ b/src/utils/claudeCode.ts
@@ -3,10 +3,10 @@ import * as vscode from "vscode";
 const CLAUDE_CODE_EXTENSION_ID = "anthropic.claude-code";
 const CLAUDE_V1_MAX_VERSION = "1.0.127";
 
-const isVersionGreaterThan = (version: string, baseline: string) => {
-  const normalize = (value: string) =>
-    value.split(/[.-]/).map((segment) => Number.parseInt(segment, 10) || 0);
+const normalize = (value: string) =>
+  value.split(/[.\-]/).map((segment) => Number.parseInt(segment, 10) || 0);
 
+const isVersionGreaterThan = (version: string, baseline: string) => {
   const a = normalize(version);
   const b = normalize(baseline);
   const length = Math.max(a.length, b.length);

--- a/src/utils/claudeCode.ts
+++ b/src/utils/claudeCode.ts
@@ -1,0 +1,51 @@
+import * as vscode from "vscode";
+
+const CLAUDE_CODE_EXTENSION_ID = "anthropic.claude-code";
+const CLAUDE_V1_MAX_VERSION = "1.0.127";
+
+const isVersionGreaterThan = (version: string, baseline: string) => {
+  const normalize = (value: string) =>
+    value.split(/[.-]/).map((segment) => Number.parseInt(segment, 10) || 0);
+
+  const a = normalize(version);
+  const b = normalize(baseline);
+  const length = Math.max(a.length, b.length);
+
+  for (let index = 0; index < length; index += 1) {
+    const left = a[index] ?? 0;
+    const right = b[index] ?? 0;
+
+    if (left > right) {
+      return true;
+    }
+
+    if (left < right) {
+      return false;
+    }
+  }
+
+  return false;
+};
+
+export const showClaudeCodeCompatibilityWarning = () => {
+  const claudeExtension = vscode.extensions.getExtension(
+    CLAUDE_CODE_EXTENSION_ID,
+  );
+
+  if (!claudeExtension) {
+    return;
+  }
+
+  const version = (claudeExtension.packageJSON as { version?: string })
+    ?.version;
+
+  if (!version) {
+    return;
+  }
+
+  if (isVersionGreaterThan(version, CLAUDE_V1_MAX_VERSION)) {
+    vscode.window.showWarningMessage(
+      `Claude Code extension ${version} detected. The native v2 extension ignores LLM Gateway settings — Agent Maestro may not work as expected.`,
+    );
+  }
+};


### PR DESCRIPTION
This pull request introduces a compatibility warning for users running newer versions of the Claude Code VS Code extension, ensuring they are aware of potential limitations with Agent Maestro. The warning is shown automatically if a native v2 extension (version greater than `v1.0.127`) is detected, and relevant documentation has been updated for clarity.

Compatibility warning logic:

* Added a utility function `showClaudeCodeCompatibilityWarning` in `src/utils/claudeCode.ts` to check the installed Claude Code extension version and display a warning if it is newer than `v1.0.127` (native v2), since these versions ignore LLM Gateway settings and may limit Agent Maestro features.
* Integrated the compatibility warning into the extension activation flow by calling `showClaudeCodeCompatibilityWarning()` in `src/extension.ts`. [[1]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R13) [[2]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R39-R40)

Documentation updates:

* Updated `README.md` to inform users about the change in Claude Code extension behavior for versions later than `v1.0.127`, clarifying Agent Maestro compatibility.
* Added a changeset file `.changeset/orange-yaks-vanish.md` documenting the new warning feature for future releases.