### PR TITLE
Release v2.3.2

### DIFF
--- a/.changeset/orange-yaks-vanish.md
+++ b/.changeset/orange-yaks-vanish.md
@@ -1,5 +1,0 @@
----
-"agent-maestro": patch
----
-
-Added warning when detecting Claude Code extension versions newer than v1.0.127 (native v2), which ignore LLM Gateway settings and may limit Agent Maestro features.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v2.3.2 - 2025.09.30
+
+- **Added warning** when detecting Claude Code extension versions newer than `v1.0.127` (native v2), which ignore LLM Gateway settings and may limit Agent Maestro features.
+- **Updated README note** to clarify compatibility:
+  - Agent Maestro continues to work with the Claude Code CLI (terminal).
+  - Supported on legacy extension versions prior to v2.
+
 ## v2.3.1 - 2025.09.28
 
 - Add tool handling support for non-streaming `/v1/messages` API

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "agent-maestro",
   "displayName": "Agent Maestro",
   "description": "Turn VS Code into your compliant AI playground! With Agent Maestro, spin up Cline or Roo on demand and plug Claude Code or Codex straight in through an OpenAI/Anthropic-compatible API.",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "icon": "assets/icons/icon.png",
   "publisher": "Joouis",
   "repository": "https://github.com/Joouis/agent-maestro",


### PR DESCRIPTION
This pull request introduces a patch release for `agent-maestro` focused on improving compatibility messaging for users of the Claude Code extension. The main update is a warning for users running newer extension versions that may not support all Agent Maestro features. Documentation has also been updated to clarify compatibility, and the version number has been incremented.

Compatibility and user messaging:

* Added a warning when detecting Claude Code extension versions newer than `v1.0.127` (native v2), which ignore LLM Gateway settings and may limit Agent Maestro features. (`.changeset/orange-yaks-vanish.md`, [.changeset/orange-yaks-vanish.mdL1-L5](diffhunk://#diff-009c9e78905e24eb80a0dc65220185b0868e458c9a3a83f9b37c0a7078c9c924L1-L5))
* Updated the README note in the changelog to clarify that Agent Maestro continues to work with the Claude Code CLI (terminal) and is supported on legacy extension versions prior to v2. (`CHANGELOG.md`, [CHANGELOG.mdR3-R9](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R9))

Release management:

* Incremented the package version to `2.3.2` in `package.json`.