### PR TITLE
feat: Add LLM provider selector and configuration APIs for Roomote Control

### DIFF
--- a/examples/demo-site/src/app/roo/components/ChatInput.tsx
+++ b/examples/demo-site/src/app/roo/components/ChatInput.tsx
@@ -1,12 +1,24 @@
-import React, { useRef, useEffect } from "react";
+import React, { useEffect, useRef } from "react";
+
 import {
   autoResizeTextarea,
-  resetTextarea,
   focusTextarea,
+  resetTextarea,
 } from "../utils/chatHelpers";
 import { UI_CONFIG } from "../utils/constants";
-import { ModeSelector } from "./ModeSelector";
 import { ExtensionSelector } from "./ExtensionSelector";
+import { ModeSelector } from "./ModeSelector";
+import { ProviderSelector } from "./ProviderSelector";
+
+interface Mode {
+  slug: string;
+  name: string;
+  roleDefinition?: string;
+  customInstructions?: string;
+  groups?: any[];
+  source?: "builtin" | "custom";
+  whenToUse?: string;
+}
 
 interface ChatInputProps {
   value: string;
@@ -19,6 +31,13 @@ interface ChatInputProps {
   selectedExtension: string;
   onExtensionChange: (extension: string) => void;
   hasMessages: boolean;
+  modes?: Mode[];
+  isLoadingModes?: boolean;
+  apiBaseUrl?: string | null;
+  currentProvider?: string;
+  currentModel?: string;
+  providers?: string[];
+  isLoadingProviders?: boolean;
 }
 
 export const ChatInput: React.FC<ChatInputProps> = ({
@@ -32,6 +51,13 @@ export const ChatInput: React.FC<ChatInputProps> = ({
   selectedExtension,
   onExtensionChange,
   hasMessages,
+  modes,
+  isLoadingModes,
+  apiBaseUrl,
+  currentProvider,
+  currentModel,
+  providers = [],
+  isLoadingProviders = false,
 }) => {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -63,10 +89,34 @@ export const ChatInput: React.FC<ChatInputProps> = ({
   const canSend = value.trim() && !disabled;
 
   return (
-    <div className="bg-white/95 backdrop-blur-md pl-20 pr-15 py-5 border-t border-black/10">
+    <div className="bg-white/95 backdrop-blur-md px-3 sm:px-6 md:pl-20 md:pr-15 py-3 sm:py-5 border-t border-black/10 safe-area-bottom">
       <div className="max-w-4xl mx-auto">
+        {/* Mode selectors - stacked on mobile, inline on desktop */}
+        <div className="flex flex-wrap gap-2 mb-3 sm:hidden">
+          <ModeSelector
+            selectedMode={selectedMode}
+            onModeChange={onModeChange}
+            disabled={disabled || hasMessages}
+            modes={modes}
+            isLoadingModes={isLoadingModes}
+          />
+          <ProviderSelector
+            currentProvider={currentProvider}
+            currentModel={currentModel}
+            providers={providers}
+            isLoading={isLoadingProviders}
+            disabled={disabled}
+          />
+          <ExtensionSelector
+            selectedExtension={selectedExtension}
+            onExtensionChange={onExtensionChange}
+            disabled={disabled || hasMessages}
+            apiBaseUrl={apiBaseUrl}
+          />
+        </div>
+
         {/* Input Area */}
-        <div className="flex gap-3 items-end">
+        <div className="flex gap-2 sm:gap-3 items-end">
           <textarea
             ref={textareaRef}
             value={value}
@@ -75,26 +125,36 @@ export const ChatInput: React.FC<ChatInputProps> = ({
             disabled={disabled}
             placeholder={disabled ? "Waiting for response..." : placeholder}
             rows={1}
-            className="flex-1 max-h-30 px-4 py-2 border-2 border-gray-200 rounded-3xl text-black text-sm resize-none outline-none transition-colors focus:border-blue-500 disabled:bg-gray-100 disabled:text-gray-500 disabled:cursor-not-allowed scrollbar-hide"
+            className="flex-1 max-h-30 px-3 sm:px-4 py-2 border-2 border-gray-200 rounded-2xl sm:rounded-3xl text-black text-base sm:text-sm resize-none outline-none transition-colors focus:border-blue-500 disabled:bg-gray-100 disabled:text-gray-500 disabled:cursor-not-allowed scrollbar-hide"
           />
           <button
             onClick={handleSend}
             disabled={!canSend}
-            className="size-9 rounded-full bg-blue-500 text-white flex items-center justify-center text-lg transition-all hover:bg-blue-600 hover:scale-105 disabled:bg-gray-400 disabled:cursor-not-allowed disabled:transform-none"
+            className="size-10 sm:size-9 rounded-full bg-blue-500 text-white flex items-center justify-center text-lg transition-all hover:bg-blue-600 active:scale-95 sm:hover:scale-105 disabled:bg-gray-400 disabled:cursor-not-allowed disabled:transform-none flex-shrink-0"
           >
             ➤
           </button>
-          <div className="flex items-center gap-4 ml-2">
-            {/* <span className="text-sm text-gray-600 font-medium whitespace-nowrap">Mode:</span> */}
+          {/* Desktop mode selectors */}
+          <div className="hidden sm:flex items-center gap-4 ml-2">
             <ModeSelector
               selectedMode={selectedMode}
               onModeChange={onModeChange}
               disabled={disabled || hasMessages}
+              modes={modes}
+              isLoadingModes={isLoadingModes}
+            />
+            <ProviderSelector
+              currentProvider={currentProvider}
+              currentModel={currentModel}
+              providers={providers}
+              isLoading={isLoadingProviders}
+              disabled={disabled}
             />
             <ExtensionSelector
               selectedExtension={selectedExtension}
               onExtensionChange={onExtensionChange}
               disabled={disabled || hasMessages}
+              apiBaseUrl={apiBaseUrl}
             />
           </div>
         </div>

--- a/examples/demo-site/src/app/roo/components/ConnectionSetup.tsx
+++ b/examples/demo-site/src/app/roo/components/ConnectionSetup.tsx
@@ -1,0 +1,281 @@
+import React, { useEffect, useState } from "react";
+
+import { usePortScanner } from "../hooks/usePortScanner";
+import { DEFAULT_API_BASE_URL } from "../utils/constants";
+import { SavedWorkspace, storage } from "../utils/storage";
+
+interface ConnectionSetupProps {
+  onConnect: (url: string) => Promise<boolean>;
+  isChecking: boolean;
+  error: string | null;
+  savedUrl: string | null;
+  lastConnected: string | null;
+}
+
+export const ConnectionSetup: React.FC<ConnectionSetupProps> = ({
+  onConnect,
+  isChecking,
+  error,
+  savedUrl,
+  lastConnected,
+}) => {
+  const [url, setUrl] = useState(savedUrl || DEFAULT_API_BASE_URL);
+  const [showManualInput, setShowManualInput] = useState(false);
+  const [savedWorkspaces, setSavedWorkspaces] = useState<SavedWorkspace[]>([]);
+  const {
+    instances,
+    isScanning,
+    scanPorts,
+    error: scanError,
+  } = usePortScanner();
+
+  // Load saved workspaces and auto-scan on mount
+  useEffect(() => {
+    setSavedWorkspaces(storage.getSavedWorkspaces());
+    scanPorts(); // Auto-scan on load
+  }, [scanPorts]);
+
+  useEffect(() => {
+    if (savedUrl) {
+      setUrl(savedUrl);
+    }
+  }, [savedUrl]);
+
+  const handleConnect = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!url.trim()) return;
+    await onConnect(url.trim());
+  };
+
+  const handleQuickConnect = async (preset: string) => {
+    setUrl(preset);
+    await onConnect(preset);
+  };
+
+  const handleRemoveSaved = (workspaceUrl: string) => {
+    storage.removeWorkspace(workspaceUrl);
+    setSavedWorkspaces(storage.getSavedWorkspaces());
+  };
+
+  const formatLastConnected = (dateStr: string) => {
+    const date = new Date(dateStr);
+    const now = new Date();
+    const diff = now.getTime() - date.getTime();
+    const minutes = Math.floor(diff / 60000);
+    const hours = Math.floor(minutes / 60);
+    const days = Math.floor(hours / 24);
+
+    if (minutes < 1) return "Just now";
+    if (minutes < 60) return `${minutes}m ago`;
+    if (hours < 24) return `${hours}h ago`;
+    if (days < 7) return `${days}d ago`;
+    return date.toLocaleDateString();
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-indigo-500 to-purple-600 flex items-center justify-center p-4">
+      <div className="bg-white rounded-2xl shadow-2xl w-full max-w-md p-6 sm:p-8">
+        <div className="text-center mb-6">
+          <div className="text-4xl mb-3">🎮</div>
+          <h1 className="text-2xl font-bold text-gray-900">Roomote Control</h1>
+          <p className="text-gray-600 mt-2 text-sm">
+            Select a workspace to connect
+          </p>
+        </div>
+
+        {/* Discovered Instances */}
+        <div className="mb-4">
+          <div className="flex items-center justify-between mb-2">
+            <h3 className="text-sm font-medium text-gray-700">
+              Available Workspaces
+            </h3>
+            <button
+              onClick={scanPorts}
+              disabled={isScanning}
+              className="text-xs text-indigo-600 hover:text-indigo-700 flex items-center gap-1"
+            >
+              {isScanning ? (
+                <>
+                  <svg className="animate-spin h-3 w-3" viewBox="0 0 24 24">
+                    <circle
+                      className="opacity-25"
+                      cx="12"
+                      cy="12"
+                      r="10"
+                      stroke="currentColor"
+                      strokeWidth="4"
+                      fill="none"
+                    />
+                    <path
+                      className="opacity-75"
+                      fill="currentColor"
+                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                    />
+                  </svg>
+                  Scanning...
+                </>
+              ) : (
+                <>
+                  <span>🔄</span>
+                  Rescan
+                </>
+              )}
+            </button>
+          </div>
+
+          {isScanning && instances.length === 0 && (
+            <div className="bg-gray-50 rounded-lg p-4 text-center">
+              <p className="text-sm text-gray-600">Scanning local ports...</p>
+            </div>
+          )}
+
+          {!isScanning && instances.length === 0 && (
+            <div className="bg-yellow-50 rounded-lg p-3 text-sm text-yellow-700">
+              {scanError || "No Agent Maestro instances found on localhost"}
+            </div>
+          )}
+
+          {instances.length > 0 && (
+            <div className="space-y-2 max-h-48 overflow-y-auto">
+              {instances.map((instance) => (
+                <button
+                  key={instance.port}
+                  onClick={() => handleQuickConnect(instance.url)}
+                  disabled={isChecking}
+                  className="w-full text-left p-3 bg-green-50 hover:bg-green-100 rounded-lg border border-green-200 disabled:opacity-50 transition-colors"
+                >
+                  <div className="flex items-center gap-2">
+                    <span className="text-green-600">📁</span>
+                    <span className="font-medium text-gray-900">
+                      {instance.workspaceName}
+                    </span>
+                    <span className="text-xs bg-green-100 text-green-700 px-1.5 py-0.5 rounded">
+                      :{instance.port}
+                    </span>
+                  </div>
+                  <div className="text-xs text-gray-500 mt-1 truncate">
+                    {instance.workspace}
+                  </div>
+                  <div className="text-xs text-gray-400 mt-0.5">
+                    v{instance.version}
+                  </div>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Saved Workspaces (Remote/Previous) */}
+        {savedWorkspaces.length > 0 && (
+          <div className="mb-4">
+            <h3 className="text-sm font-medium text-gray-700 mb-2">
+              Recent Connections
+            </h3>
+            <div className="space-y-2 max-h-32 overflow-y-auto">
+              {savedWorkspaces
+                .filter((w) => !instances.some((i) => i.url === w.url))
+                .sort(
+                  (a, b) =>
+                    new Date(b.lastConnected).getTime() -
+                    new Date(a.lastConnected).getTime(),
+                )
+                .slice(0, 3)
+                .map((workspace) => (
+                  <div
+                    key={workspace.url}
+                    className="flex items-center gap-2 p-2 bg-blue-50 rounded-lg"
+                  >
+                    <button
+                      onClick={() => handleQuickConnect(workspace.url)}
+                      disabled={isChecking}
+                      className="flex-1 text-left disabled:opacity-50"
+                    >
+                      <div className="flex items-center gap-2">
+                        <span className="text-blue-600">📁</span>
+                        <span className="font-medium text-gray-900 text-sm">
+                          {workspace.workspaceName}
+                        </span>
+                      </div>
+                      <div className="text-xs text-gray-500 truncate">
+                        {workspace.url}
+                      </div>
+                      <div className="text-xs text-gray-400">
+                        {formatLastConnected(workspace.lastConnected)}
+                      </div>
+                    </button>
+                    <button
+                      onClick={() => handleRemoveSaved(workspace.url)}
+                      className="text-gray-400 hover:text-red-500 p-1"
+                      title="Remove"
+                    >
+                      ✕
+                    </button>
+                  </div>
+                ))}
+            </div>
+          </div>
+        )}
+
+        {/* Manual URL Input Toggle */}
+        <div className="mt-4">
+          <button
+            onClick={() => setShowManualInput(!showManualInput)}
+            className="text-sm text-gray-500 hover:text-gray-700 flex items-center gap-1"
+          >
+            <span>{showManualInput ? "▼" : "▶"}</span>
+            Enter URL Manually
+          </button>
+
+          {showManualInput && (
+            <form onSubmit={handleConnect} className="mt-3 space-y-3">
+              <input
+                type="url"
+                value={url}
+                onChange={(e) => setUrl(e.target.value)}
+                placeholder="https://your-tunnel.ngrok.io"
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 text-gray-900 text-sm"
+                disabled={isChecking}
+              />
+              <button
+                type="submit"
+                disabled={isChecking || !url.trim()}
+                className="w-full bg-indigo-600 text-white py-2 px-4 rounded-lg font-medium hover:bg-indigo-700 disabled:bg-indigo-300 transition-colors flex items-center justify-center gap-2 text-sm"
+              >
+                {isChecking ? "Connecting..." : "Connect"}
+              </button>
+            </form>
+          )}
+        </div>
+
+        {error && (
+          <div className="mt-4 bg-red-50 text-red-700 p-3 rounded-lg text-sm">
+            {error}
+          </div>
+        )}
+
+        <div className="mt-6 pt-4 border-t border-gray-200">
+          <p className="text-xs text-gray-500 text-center">
+            Need a tunnel? Try{" "}
+            <a
+              href="https://ngrok.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-indigo-600 hover:underline"
+            >
+              ngrok
+            </a>{" "}
+            or{" "}
+            <a
+              href="https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-indigo-600 hover:underline"
+            >
+              Cloudflare Tunnel
+            </a>
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/examples/demo-site/src/app/roo/components/ModeSelector.tsx
+++ b/examples/demo-site/src/app/roo/components/ModeSelector.tsx
@@ -1,20 +1,49 @@
 import React, { useState } from "react";
+
 import { MODES } from "../utils/constants";
+
+interface Mode {
+  slug: string;
+  name: string;
+  roleDefinition?: string;
+  customInstructions?: string;
+  groups?: any[];
+  source?: "builtin" | "custom";
+  whenToUse?: string;
+}
 
 interface ModeSelectorProps {
   selectedMode: string;
   onModeChange: (mode: string) => void;
   disabled: boolean;
+  modes?: Mode[];
+  isLoadingModes?: boolean;
 }
 
 export const ModeSelector: React.FC<ModeSelectorProps> = ({
   selectedMode,
   onModeChange,
   disabled,
+  modes,
+  isLoadingModes = false,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
 
-  const selectedModeData = MODES.find((mode) => mode.slug === selectedMode);
+  // Use provided modes or fallback to hardcoded MODES
+  const availableModes: Mode[] =
+    modes && modes.length > 0
+      ? modes
+      : MODES.map((m) => ({
+          slug: m.slug,
+          name: m.name,
+          whenToUse: m.whenToUse,
+          groups: m.groups as any[],
+          source: "builtin" as const,
+        }));
+
+  const selectedModeData = availableModes.find(
+    (mode) => mode.slug === selectedMode,
+  );
 
   const formatGroups = (groups: readonly any[]): string => {
     return groups
@@ -37,11 +66,20 @@ export const ModeSelector: React.FC<ModeSelectorProps> = ({
       <button
         type="button"
         onClick={() => setIsOpen(!isOpen)}
-        disabled={disabled}
+        disabled={disabled || isLoadingModes}
         className="flex items-center gap-2 px-3 py-2 text-sm text-black bg-gray-100 border border-gray-300 rounded-lg hover:bg-gray-200 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-        title={selectedModeData?.whenToUse}
+        title={selectedModeData?.whenToUse || selectedModeData?.roleDefinition}
       >
-        <span>{selectedModeData?.name || selectedMode}</span>
+        <span>
+          {isLoadingModes
+            ? "Loading..."
+            : selectedModeData?.name || selectedMode}
+        </span>
+        {selectedModeData?.source === "custom" && (
+          <span className="text-xs bg-purple-100 text-purple-700 px-1.5 py-0.5 rounded">
+            Custom
+          </span>
+        )}
         <svg
           className={`w-4 h-4 transition-transform ${isOpen ? "rotate-180" : ""}`}
           fill="none"
@@ -57,7 +95,7 @@ export const ModeSelector: React.FC<ModeSelectorProps> = ({
         </svg>
       </button>
 
-      {isOpen && !disabled && (
+      {isOpen && !disabled && !isLoadingModes && (
         <>
           {/* Backdrop to close dropdown */}
           <div
@@ -66,10 +104,10 @@ export const ModeSelector: React.FC<ModeSelectorProps> = ({
           />
 
           {/* Dropdown menu */}
-          <div className="absolute bottom-full left-0 mb-2 w-80 bg-white border border-gray-300 rounded-lg shadow-lg z-20 max-h-96 overflow-y-auto">
-            {MODES.map((mode) => (
+          <div className="absolute bottom-full left-0 mb-2 w-80 sm:w-96 bg-white border border-gray-300 rounded-lg shadow-lg z-20 max-h-96 overflow-y-auto">
+            {availableModes.map((mode, index) => (
               <button
-                key={mode.slug}
+                key={`${mode.slug}-${mode.source || "builtin"}-${index}`}
                 type="button"
                 onClick={() => {
                   onModeChange(mode.slug);
@@ -81,13 +119,22 @@ export const ModeSelector: React.FC<ModeSelectorProps> = ({
                     : "text-gray-700"
                 }`}
               >
-                <div className="font-medium mb-1">{mode.name}</div>
-                <div className="text-xs text-gray-600 mb-2 leading-relaxed">
-                  {mode.whenToUse}
+                <div className="flex items-center gap-2 mb-1">
+                  <span className="font-medium">{mode.name}</span>
+                  {mode.source === "custom" && (
+                    <span className="text-xs bg-purple-100 text-purple-700 px-1.5 py-0.5 rounded">
+                      Custom
+                    </span>
+                  )}
                 </div>
-                {mode.groups.length > 0 && (
+                <div className="text-xs text-gray-600 mb-2 leading-relaxed">
+                  {mode.whenToUse ||
+                    mode.roleDefinition ||
+                    "No description available"}
+                </div>
+                {mode.groups && mode.groups.length > 0 && (
                   <div className="text-xs text-gray-500">
-                    <span className="font-medium">Permissions required:</span>{" "}
+                    <span className="font-medium">Permissions:</span>{" "}
                     {formatGroups(mode.groups)}
                   </div>
                 )}

--- a/examples/demo-site/src/app/roo/components/ProviderSelector.tsx
+++ b/examples/demo-site/src/app/roo/components/ProviderSelector.tsx
@@ -1,0 +1,190 @@
+import React, { useState } from "react";
+
+interface Provider {
+  id: string;
+  name: string;
+  description: string;
+  isConfigured: boolean;
+  isCurrent: boolean;
+  configStatus?: string;
+}
+
+interface ProviderSelectorProps {
+  currentProvider?: string;
+  currentModel?: string;
+  providers: Provider[];
+  isLoading: boolean;
+  disabled: boolean;
+}
+
+export const ProviderSelector: React.FC<ProviderSelectorProps> = ({
+  currentProvider,
+  currentModel,
+  providers,
+  isLoading,
+  disabled,
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center gap-2 px-3 py-2 text-sm bg-gray-100 border border-gray-300 rounded-lg opacity-50">
+        <span>Loading...</span>
+      </div>
+    );
+  }
+
+  if (providers.length === 0) {
+    return (
+      <div className="flex items-center gap-2 px-3 py-2 text-sm bg-yellow-50 border border-yellow-300 rounded-lg text-yellow-700">
+        <span>No providers</span>
+      </div>
+    );
+  }
+
+  // Find current provider from the list
+  const currentProviderData = providers.find((p) => p.isCurrent);
+  const providerInfo = currentProviderData || {
+    id: "unknown",
+    name: "Not set",
+    description: "No provider configured",
+    isConfigured: false,
+    isCurrent: false,
+    configStatus: "Not configured",
+  };
+
+  // Get configuration badge color for the main button
+  const getButtonStatusColor = () => {
+    if (providerInfo.isCurrent) return "text-green-600";
+    if (providerInfo.isConfigured) return "text-blue-600";
+    return "text-gray-400";
+  };
+
+  // Get status icon for the main button
+  const getButtonStatusIcon = () => {
+    if (providerInfo.isCurrent) return "✓";
+    if (providerInfo.isConfigured) return "✓";
+    return "○";
+  };
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={() => setIsOpen(!isOpen)}
+        disabled={disabled}
+        className="flex items-center gap-2 px-3 py-2 text-sm text-black bg-gray-100 border border-gray-300 rounded-lg hover:bg-gray-200 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        title={`${providerInfo.name} - ${providerInfo.configStatus}${currentModel ? ` | Model: ${currentModel}` : ""}`}
+      >
+        <span className={`font-bold ${getButtonStatusColor()}`}>
+          {getButtonStatusIcon()}
+        </span>
+        <span className="truncate max-w-[100px]">{providerInfo.name}</span>
+        {providerInfo.isCurrent && currentModel && (
+          <span className="text-xs text-gray-500 truncate max-w-[80px]">
+            {currentModel.split("/").pop()}
+          </span>
+        )}
+        <svg
+          className={`w-4 h-4 transition-transform ${isOpen ? "rotate-180" : ""}`}
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M19 9l-7 7-7-7"
+          />
+        </svg>
+      </button>
+
+      {isOpen && !disabled && (
+        <>
+          {/* Backdrop to close dropdown */}
+          <div
+            className="fixed inset-0 z-10"
+            onClick={() => setIsOpen(false)}
+          />
+
+          {/* Dropdown menu */}
+          <div className="absolute bottom-full left-0 mb-2 w-72 bg-white border border-gray-300 rounded-lg shadow-lg z-20 max-h-64 overflow-y-auto">
+            <div className="p-3 border-b border-gray-200 bg-gray-50">
+              <div className="text-xs font-medium text-gray-500 mb-1">
+                Current Configuration
+              </div>
+              <div className="font-medium text-gray-900">
+                {providerInfo.name}
+              </div>
+              <div className="text-xs text-gray-600">
+                {providerInfo.description}
+              </div>
+              {providerInfo.isCurrent && currentModel && (
+                <div className="text-xs text-purple-600 mt-1 truncate">
+                  Model: {currentModel}
+                </div>
+              )}
+            </div>
+
+            <div className="p-2">
+              <div className="text-xs font-medium text-gray-500 mb-2 px-1">
+                Available Providers ({providers.length})
+              </div>
+              <div className="space-y-1">
+                {providers.map((provider) => {
+                  const getProviderStatusColor = () => {
+                    if (provider.isCurrent) return "text-green-600";
+                    if (provider.isConfigured) return "text-blue-600";
+                    return "text-gray-400";
+                  };
+
+                  const getProviderStatusIcon = () => {
+                    if (provider.isCurrent) return "✓";
+                    if (provider.isConfigured) return "✓";
+                    return "○";
+                  };
+
+                  return (
+                    <div
+                      key={provider.id}
+                      className={`p-2 rounded text-sm ${
+                        provider.isCurrent
+                          ? "bg-purple-50 text-purple-700 border border-purple-200"
+                          : "text-gray-600"
+                      }`}
+                      title={provider.configStatus}
+                    >
+                      <div className="flex items-center gap-2">
+                        <span
+                          className={`font-bold w-4 ${getProviderStatusColor()}`}
+                        >
+                          {getProviderStatusIcon()}
+                        </span>
+                        <span className="font-medium">{provider.name}</span>
+                        {provider.isCurrent && (
+                          <span className="text-xs bg-purple-100 text-purple-700 px-1.5 py-0.5 rounded">
+                            Active
+                          </span>
+                        )}
+                      </div>
+                      <div className="text-xs text-gray-500 ml-6">
+                        {provider.description}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+
+            <div className="p-3 border-t border-gray-200 bg-gray-50">
+              <div className="text-xs text-gray-500">
+                Configure providers in VS Code extension settings
+              </div>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+};

--- a/examples/demo-site/src/app/roo/hooks/useApiConfig.ts
+++ b/examples/demo-site/src/app/roo/hooks/useApiConfig.ts
@@ -1,0 +1,149 @@
+import { useCallback, useEffect, useState } from "react";
+
+import { storage } from "../utils/storage";
+
+interface ApiConfig {
+  baseUrl: string | null;
+  isConnected: boolean;
+  isChecking: boolean;
+  error: string | null;
+  lastConnected: string | null;
+  workspace: string | null;
+  agentMaestroVersion: string | null;
+}
+
+export const useApiConfig = () => {
+  const [config, setConfig] = useState<ApiConfig>({
+    baseUrl: null,
+    isConnected: false,
+    isChecking: false,
+    error: null,
+    lastConnected: null,
+    workspace: null,
+    agentMaestroVersion: null,
+  });
+
+  // Load saved URL on mount
+  useEffect(() => {
+    const savedUrl = storage.getApiBaseUrl();
+    const lastConnected = storage.getLastConnected();
+    if (savedUrl) {
+      setConfig((prev) => ({
+        ...prev,
+        baseUrl: savedUrl,
+        lastConnected,
+      }));
+    }
+  }, []);
+
+  const checkConnection = useCallback(
+    async (
+      url: string,
+    ): Promise<{ ok: boolean; workspace?: string; version?: string }> => {
+      try {
+        // Remove trailing slash if present
+        const cleanUrl = url.replace(/\/+$/, "");
+        const infoUrl = `${cleanUrl}/api/v1/info`;
+
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), 5000);
+
+        const response = await fetch(infoUrl, {
+          method: "GET",
+          signal: controller.signal,
+        });
+
+        clearTimeout(timeoutId);
+
+        if (response.ok) {
+          const data = await response.json();
+          return {
+            ok: true,
+            workspace: data.workspace || null,
+            version: data.version || null,
+          };
+        }
+        return { ok: false };
+      } catch (error) {
+        console.error("Connection check failed:", error);
+        return { ok: false };
+      }
+    },
+    [],
+  );
+
+  const connect = useCallback(
+    async (url: string): Promise<boolean> => {
+      setConfig((prev) => ({ ...prev, isChecking: true, error: null }));
+
+      const cleanUrl = url.replace(/\/+$/, "");
+      const connectionResult = await checkConnection(cleanUrl);
+
+      if (connectionResult.ok) {
+        storage.setApiBaseUrl(cleanUrl);
+
+        // Save workspace info for future selection
+        if (connectionResult.workspace) {
+          const workspaceParts = connectionResult.workspace.split("/");
+          const workspaceName =
+            workspaceParts[workspaceParts.length - 1] ||
+            connectionResult.workspace;
+
+          storage.saveWorkspace({
+            url: cleanUrl,
+            workspace: connectionResult.workspace,
+            workspaceName,
+            version: connectionResult.version || "unknown",
+            lastConnected: new Date().toISOString(),
+          });
+        }
+
+        setConfig({
+          baseUrl: cleanUrl,
+          isConnected: true,
+          isChecking: false,
+          error: null,
+          lastConnected: new Date().toISOString(),
+          workspace: connectionResult.workspace || null,
+          agentMaestroVersion: connectionResult.version || null,
+        });
+        return true;
+      } else {
+        setConfig((prev) => ({
+          ...prev,
+          isChecking: false,
+          error:
+            "Unable to connect. Check URL and ensure Agent Maestro is running.",
+        }));
+        return false;
+      }
+    },
+    [checkConnection],
+  );
+
+  const disconnect = useCallback(() => {
+    storage.clearApiBaseUrl();
+    setConfig({
+      baseUrl: null,
+      isConnected: false,
+      isChecking: false,
+      error: null,
+      lastConnected: null,
+      workspace: null,
+      agentMaestroVersion: null,
+    });
+  }, []);
+
+  const reconnect = useCallback(async (): Promise<boolean> => {
+    if (!config.baseUrl) return false;
+    return connect(config.baseUrl);
+  }, [config.baseUrl, connect]);
+
+  return {
+    ...config,
+    connect,
+    disconnect,
+    reconnect,
+    checkConnection,
+  };
+};

--- a/examples/demo-site/src/app/roo/hooks/useModes.ts
+++ b/examples/demo-site/src/app/roo/hooks/useModes.ts
@@ -1,0 +1,114 @@
+import { useCallback, useEffect, useState } from "react";
+
+import {
+  DEFAULT_API_BASE_URL,
+  MODES,
+  createApiEndpoints,
+} from "../utils/constants";
+
+interface Mode {
+  slug: string;
+  name: string;
+  roleDefinition?: string;
+  customInstructions?: string;
+  groups?: any[];
+  source?: "builtin" | "custom";
+  whenToUse?: string;
+}
+
+interface UseModesOptions {
+  apiBaseUrl?: string | null;
+  extensionId?: string;
+}
+
+export const useModes = (options: UseModesOptions = {}) => {
+  const { apiBaseUrl = null, extensionId } = options;
+  const [modes, setModes] = useState<Mode[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchModes = useCallback(async () => {
+    // Don't fetch if no extension is selected yet
+    if (!extensionId) {
+      setIsLoading(false);
+      setError("No extension selected");
+      // Return default modes while waiting for extension selection
+      const fallbackModes: Mode[] = MODES.map((mode) => ({
+        slug: mode.slug,
+        name: mode.name,
+        whenToUse: mode.whenToUse,
+        groups: mode.groups as any[],
+        source: "builtin" as const,
+      }));
+      setModes(fallbackModes);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    const baseUrl = apiBaseUrl || DEFAULT_API_BASE_URL;
+
+    // Construct modes URL
+    const modesUrl = new URL(`${baseUrl}/api/v1/roo/modes`);
+    modesUrl.searchParams.set("extensionId", extensionId);
+
+    try {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), 5000);
+
+      const response = await fetch(modesUrl.toString(), {
+        method: "GET",
+        signal: controller.signal,
+      });
+
+      clearTimeout(timeoutId);
+
+      if (response.ok) {
+        const data = await response.json();
+        if (data.modes && Array.isArray(data.modes)) {
+          // Merge with local mode data for additional fields like whenToUse
+          const mergedModes = data.modes.map((apiMode: Mode) => {
+            const localMode = MODES.find((m) => m.slug === apiMode.slug);
+            return {
+              ...apiMode,
+              whenToUse: localMode?.whenToUse || apiMode.roleDefinition || "",
+              groups: apiMode.groups || localMode?.groups || [],
+            };
+          });
+          setModes(mergedModes);
+          setIsLoading(false);
+          return;
+        }
+      }
+
+      // Fallback to hardcoded modes if API fails or returns invalid data
+      throw new Error("Invalid API response");
+    } catch (err) {
+      console.warn("Failed to fetch modes from API, using defaults:", err);
+      // Fallback to hardcoded modes
+      const fallbackModes: Mode[] = MODES.map((mode) => ({
+        slug: mode.slug,
+        name: mode.name,
+        whenToUse: mode.whenToUse,
+        groups: mode.groups as any[],
+        source: "builtin" as const,
+      }));
+      setModes(fallbackModes);
+      setError("Using default modes (API unavailable)");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [apiBaseUrl, extensionId]);
+
+  useEffect(() => {
+    fetchModes();
+  }, [fetchModes]);
+
+  return {
+    modes,
+    isLoading,
+    error,
+    refetch: fetchModes,
+  };
+};

--- a/examples/demo-site/src/app/roo/hooks/usePortScanner.ts
+++ b/examples/demo-site/src/app/roo/hooks/usePortScanner.ts
@@ -1,0 +1,105 @@
+import { useCallback, useState } from "react";
+
+interface DiscoveredInstance {
+  url: string;
+  port: number;
+  workspace: string;
+  workspaceName: string;
+  version: string;
+}
+
+interface UsePortScannerResult {
+  instances: DiscoveredInstance[];
+  isScanning: boolean;
+  scanPorts: () => Promise<void>;
+  error: string | null;
+}
+
+// Common ports to scan for Agent Maestro instances
+const PORTS_TO_SCAN = [
+  23333, // Default Agent Maestro port
+  33333, // Common alternative
+  43333,
+  53333,
+  8080,
+  8081,
+  3333,
+  4444,
+  5555,
+];
+
+export const usePortScanner = (): UsePortScannerResult => {
+  const [instances, setInstances] = useState<DiscoveredInstance[]>([]);
+  const [isScanning, setIsScanning] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const checkPort = useCallback(
+    async (port: number): Promise<DiscoveredInstance | null> => {
+      try {
+        const url = `http://localhost:${port}`;
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), 2000);
+
+        const response = await fetch(`${url}/api/v1/info`, {
+          method: "GET",
+          signal: controller.signal,
+        });
+
+        clearTimeout(timeoutId);
+
+        if (response.ok) {
+          const data = await response.json();
+          if (data.workspace) {
+            const workspaceParts = data.workspace.split("/");
+            const workspaceName =
+              workspaceParts[workspaceParts.length - 1] || data.workspace;
+
+            return {
+              url,
+              port,
+              workspace: data.workspace,
+              workspaceName,
+              version: data.version || "unknown",
+            };
+          }
+        }
+        return null;
+      } catch {
+        // Port not available or not Agent Maestro
+        return null;
+      }
+    },
+    [],
+  );
+
+  const scanPorts = useCallback(async () => {
+    setIsScanning(true);
+    setError(null);
+    setInstances([]);
+
+    try {
+      const results = await Promise.all(PORTS_TO_SCAN.map(checkPort));
+      const found = results.filter(
+        (result): result is DiscoveredInstance => result !== null,
+      );
+
+      if (found.length === 0) {
+        setError("No Agent Maestro instances found on localhost");
+      }
+
+      setInstances(found);
+    } catch (err) {
+      setError("Failed to scan ports");
+      console.error("Port scan error:", err);
+    } finally {
+      setIsScanning(false);
+    }
+  }, [checkPort]);
+
+  return {
+    instances,
+    isScanning,
+    scanPorts,
+    error,
+  };
+};

--- a/examples/demo-site/src/app/roo/hooks/useProviders.ts
+++ b/examples/demo-site/src/app/roo/hooks/useProviders.ts
@@ -1,0 +1,84 @@
+import { useCallback, useEffect, useState } from "react";
+
+import { DEFAULT_API_BASE_URL } from "../utils/constants";
+
+interface UseProvidersOptions {
+  apiBaseUrl?: string | null;
+  extensionId?: string;
+}
+
+interface ProvidersData {
+  currentProvider?: string;
+  currentModel?: string;
+  providers: string[];
+}
+
+export const useProviders = (options: UseProvidersOptions = {}) => {
+  const { apiBaseUrl = null, extensionId } = options;
+  const [providersData, setProvidersData] = useState<ProvidersData>({
+    providers: [],
+  });
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchProviders = useCallback(async () => {
+    // Don't fetch if no extension is selected yet
+    if (!extensionId) {
+      setIsLoading(false);
+      setError("No extension selected");
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    const baseUrl = apiBaseUrl || DEFAULT_API_BASE_URL;
+
+    // Construct providers URL
+    const providersUrl = new URL(`${baseUrl}/api/v1/roo/providers`);
+    providersUrl.searchParams.set("extensionId", extensionId);
+
+    try {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), 5000);
+
+      const response = await fetch(providersUrl.toString(), {
+        method: "GET",
+        signal: controller.signal,
+      });
+
+      clearTimeout(timeoutId);
+
+      if (response.ok) {
+        const data = await response.json();
+        setProvidersData({
+          currentProvider: data.currentProvider,
+          currentModel: data.currentModel,
+          providers: data.providers || [],
+        });
+        setIsLoading(false);
+        return;
+      }
+
+      throw new Error("Failed to fetch providers");
+    } catch (err) {
+      console.warn("Failed to fetch providers from API:", err);
+      setError("Providers API unavailable");
+      // Set empty providers list on error
+      setProvidersData({ providers: [] });
+    } finally {
+      setIsLoading(false);
+    }
+  }, [apiBaseUrl, extensionId]);
+
+  useEffect(() => {
+    fetchProviders();
+  }, [fetchProviders]);
+
+  return {
+    ...providersData,
+    isLoading,
+    error,
+    refetch: fetchProviders,
+  };
+};

--- a/examples/demo-site/src/app/roo/utils/constants.ts
+++ b/examples/demo-site/src/app/roo/utils/constants.ts
@@ -8,15 +8,25 @@ const getPort = () => {
 };
 
 const PORT = getPort();
-export const API_BASE_URL = `http://localhost:${PORT}/api/v1/roo`;
-const INFO_API_BASE_URL = `http://localhost:${PORT}/api/v1`;
+export const DEFAULT_API_BASE_URL = `http://localhost:${PORT}`;
 
-export const API_ENDPOINTS = {
-  TASK: `${API_BASE_URL}/task`,
-  TASK_MESSAGE: (taskId: string) => `${API_BASE_URL}/task/${taskId}/message`,
-  TASK_ACTION: (taskId: string) => `${API_BASE_URL}/task/${taskId}/action`,
-  INFO: `${INFO_API_BASE_URL}/info`,
-} as const;
+// Dynamic API endpoint factory - uses stored URL or falls back to default
+export const createApiEndpoints = (baseUrl: string = DEFAULT_API_BASE_URL) => {
+  const cleanUrl = baseUrl.replace(/\/+$/, "");
+  const rooApiBase = `${cleanUrl}/api/v1/roo`;
+  const infoApiBase = `${cleanUrl}/api/v1`;
+
+  return {
+    TASK: `${rooApiBase}/task`,
+    TASK_MESSAGE: (taskId: string) => `${rooApiBase}/task/${taskId}/message`,
+    TASK_ACTION: (taskId: string) => `${rooApiBase}/task/${taskId}/action`,
+    INFO: `${infoApiBase}/info`,
+  };
+};
+
+// Legacy support - will be replaced by dynamic endpoints
+export const API_BASE_URL = `${DEFAULT_API_BASE_URL}/api/v1/roo`;
+export const API_ENDPOINTS = createApiEndpoints(DEFAULT_API_BASE_URL);
 
 export const SUGGESTION_ACTIONS = {
   APPROVE: "Approve",

--- a/examples/demo-site/src/app/roo/utils/storage.ts
+++ b/examples/demo-site/src/app/roo/utils/storage.ts
@@ -1,0 +1,74 @@
+const STORAGE_KEYS = {
+  API_BASE_URL: "roomote_api_base_url",
+  LAST_CONNECTED: "roomote_last_connected",
+  SAVED_WORKSPACES: "roomote_saved_workspaces",
+} as const;
+
+export interface SavedWorkspace {
+  url: string;
+  workspace: string;
+  workspaceName: string; // Just the folder name
+  version: string;
+  lastConnected: string;
+}
+
+export const storage = {
+  getApiBaseUrl(): string | null {
+    if (typeof window === "undefined") return null;
+    return localStorage.getItem(STORAGE_KEYS.API_BASE_URL);
+  },
+
+  setApiBaseUrl(url: string): void {
+    if (typeof window === "undefined") return;
+    localStorage.setItem(STORAGE_KEYS.API_BASE_URL, url);
+    localStorage.setItem(STORAGE_KEYS.LAST_CONNECTED, new Date().toISOString());
+  },
+
+  clearApiBaseUrl(): void {
+    if (typeof window === "undefined") return;
+    localStorage.removeItem(STORAGE_KEYS.API_BASE_URL);
+    localStorage.removeItem(STORAGE_KEYS.LAST_CONNECTED);
+  },
+
+  getLastConnected(): string | null {
+    if (typeof window === "undefined") return null;
+    return localStorage.getItem(STORAGE_KEYS.LAST_CONNECTED);
+  },
+
+  getSavedWorkspaces(): SavedWorkspace[] {
+    if (typeof window === "undefined") return [];
+    const saved = localStorage.getItem(STORAGE_KEYS.SAVED_WORKSPACES);
+    if (!saved) return [];
+    try {
+      return JSON.parse(saved);
+    } catch {
+      return [];
+    }
+  },
+
+  saveWorkspace(workspace: SavedWorkspace): void {
+    if (typeof window === "undefined") return;
+    const workspaces = this.getSavedWorkspaces();
+    // Update existing or add new
+    const index = workspaces.findIndex((w) => w.url === workspace.url);
+    if (index >= 0) {
+      workspaces[index] = workspace;
+    } else {
+      workspaces.push(workspace);
+    }
+    localStorage.setItem(
+      STORAGE_KEYS.SAVED_WORKSPACES,
+      JSON.stringify(workspaces),
+    );
+  },
+
+  removeWorkspace(url: string): void {
+    if (typeof window === "undefined") return;
+    const workspaces = this.getSavedWorkspaces();
+    const filtered = workspaces.filter((w) => w.url !== url);
+    localStorage.setItem(
+      STORAGE_KEYS.SAVED_WORKSPACES,
+      JSON.stringify(filtered),
+    );
+  },
+};


### PR DESCRIPTION
## Summary
- Add `GET /api/v1/roo/providers` endpoint with profile-based provider configuration status
- Add `GET /api/v1/roo/modes` endpoint for fetching custom modes from RooCode extensions
- Create `ProviderSelector` component displaying active provider with configuration indicators
- Implement workspace discovery via localhost port scanning for easy connection
- Add dynamic API configuration with localStorage persistence

## Features
- **Provider Selector**: Shows active provider (✓ icon), model info, and all configured profiles
- **Mode Selector**: Lists builtin + custom modes with "Custom" badge and role definitions
- **Workspace Discovery**: Auto-scans ports to find running Agent Maestro instances
- **Connection Management**: Saves recent connections, supports remote URLs (ngrok/Cloudflare)

## Files Changed
- `src/server/routes/rooRoutes.ts` - New `/providers` and `/modes` API endpoints
- `ProviderSelector.tsx` - Provider selector UI component
- `useProviders.ts` - Hook for fetching provider data
- `useModes.ts` - Hook for fetching mode data
- `useApiConfig.ts` - Hook for API connection management
- `ConnectionSetup.tsx` - Workspace discovery UI
- `usePortScanner.ts` - Port scanning for service discovery
- `storage.ts` - LocalStorage utilities
- `ChatInput.tsx` - Integration of provider/mode selectors
- `page.tsx` - Hook orchestration