### PR TITLE
  fix: Validate and clean orphaned tool_result blocks in conversation history

### DIFF
--- a/src/server/routes/anthropicRoutes.ts
+++ b/src/server/routes/anthropicRoutes.ts
@@ -13,6 +13,7 @@ import {
   convertAnthropicSystemToVSCode,
   convertAnthropicToolChoiceToVSCode,
   convertAnthropicToolToVSCode,
+  validateToolPairing,
 } from "../utils/anthropic";
 import { handleErrorWithLogging } from "../utils/errorDiagnostics";
 
@@ -231,14 +232,24 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
 
     try {
       // Parse request body
-      const requestBody =
+      const rawRequestBodyData =
         (await c.req.json()) as Anthropic.Messages.MessageCreateParams;
-      rawRequestBody = requestBody;
+      rawRequestBody = rawRequestBodyData;
+
+      // Validate and clean messages to remove orphaned tool_results
+      const validatedMessages = validateToolPairing(
+        rawRequestBodyData.messages,
+      );
+
+      // Create a new request body with validated messages
+      const requestBody: Anthropic.Messages.MessageCreateParams = {
+        ...rawRequestBodyData,
+        messages: validatedMessages,
+      };
 
       const {
         model: modelId,
         system,
-        messages,
         tools,
         tool_choice,
         ...msgCreateParams
@@ -531,8 +542,19 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
   // POST /v1/messages/count_tokens - Count input tokens
   app.openapi(countTokensRoute, async (c: Context) => {
     try {
-      const requestBody =
+      const rawRequestBodyData =
         (await c.req.json()) as Anthropic.Messages.MessageCreateParams;
+
+      // Validate and clean messages to remove orphaned tool_results
+      const validatedMessages = validateToolPairing(
+        rawRequestBodyData.messages,
+      );
+
+      // Create a new request body with validated messages
+      const requestBody: Anthropic.Messages.MessageCreateParams = {
+        ...rawRequestBodyData,
+        messages: validatedMessages,
+      };
 
       // Apply the same model selection logic as /v1/messages
       const modelId = applyClaudeModelSelection(

--- a/src/server/utils/anthropic.ts
+++ b/src/server/utils/anthropic.ts
@@ -204,7 +204,7 @@ export const convertAnthropicMessageToVSCode = (
  * @param messages - Array of Anthropic MessageParam
  * @returns Cleaned array with orphaned tool_result blocks removed
  */
-const validateToolPairing = (
+export const validateToolPairing = (
   messages: Array<Anthropic.Messages.MessageParam>,
 ): Array<Anthropic.Messages.MessageParam> => {
   const cleanedMessages: Array<Anthropic.Messages.MessageParam> = [];


### PR DESCRIPTION
  ## Summary

 During testing of the agent-maestro, I encountered API errors from the Anthropic API related to orphaned tool_result blocks in the conversation history. The error is like:
```
API Error: 500 {"error":{"message":"Request Failed: 400 {"error":{"message":"messages.0.content.0: unexpected tool_use_id found in tool_result blocks: toolu_01GfGUJpwaJfXeEEzwepCJgW. Each tool_result block must have a corresponding tool_use block in the previous message.","code":"invalid_request_body"}}\n","type":"internal_server_error","log_file":"<PII>"}}
```

 This issue occurred when:

  1. Conversation history was truncated or summarized - As conversations grow longer, the system may need to truncate or summarize earlier messages to stay within token limits
  2. Tool use context was lost - When truncation happens, tool_use blocks might be removed while their corresponding tool_result blocks remain in the history
  3. API validation failures - The Anthropic API requires that every tool_result block must reference a tool_use block that exists in the conversation. Orphaned tool_result blocks (those without matching tool_use blocks) cause API request failures
  


  ## Test plan
  - [X] Verify that orphaned tool_result blocks are properly filtered from conversation history
  - [X] Confirm warning logs appear when orphaned blocks are detected
  - [X] Test that valid tool_result blocks with corresponding tool_use IDs are preserved
  - [X] Ensure no API errors occur when conversation history is truncated

  🤖 Generated with [Claude Code](https://claude.com/claude-code)