### PR TITLE
fix(ci): Remove hardcoded pnpm version in deploy workflow

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -21,8 +21,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
Let pnpm/action-setup read version from package.json packageManager field instead of hardcoding version 9