### PR TITLE
refactor: simplify convertAnthropicToolToVSCode to handle built-in tools generically

### DIFF
--- a/.changeset/thick-lizards-feel.md
+++ b/.changeset/thick-lizards-feel.md
@@ -1,0 +1,5 @@
+---
+"agent-maestro": patch
+---
+
+Fix tool conversion to handle any tool naming convention by detecting built-in tools via input_schema presence instead of hardcoded name matching.

--- a/src/server/utils/anthropic.ts
+++ b/src/server/utils/anthropic.ts
@@ -243,7 +243,7 @@ export const convertAnthropicToolToVSCode = (
 ): vscode.LanguageModelChatTool[] | undefined =>
   tools?.map((tool) => {
     const t = tool as Anthropic.Messages.Tool;
-    if (t.input_schema !== undefined) {
+    if (t.input_schema) {
       return {
         name: t.name,
         description: t.description || "",

--- a/src/test/server/anthropic.test.ts
+++ b/src/test/server/anthropic.test.ts
@@ -214,6 +214,7 @@ suite("Anthropic Conversion Utils Test Suite", () => {
       assert.ok(result);
       assert.strictEqual(result[0].name, "bash");
       assert.strictEqual(result[0].description, "bash_20250124");
+      assert.deepStrictEqual(result[0].inputSchema, tools[0]);
     });
 
     test("should return undefined for undefined tools", () => {


### PR DESCRIPTION
This pull request refactors the handling of Anthropic tool conversion utilities and their corresponding tests. The main improvements include generalizing the conversion logic for tools, simplifying the test suite, and updating test cases to match the new logic. The refactor ensures that built-in tools without an `input_schema` are handled more consistently, and reduces redundant code in both implementation and tests.

Improvements to tool conversion logic:

* Generalized `convertAnthropicToolToVSCode` to handle all tools, including built-in ones without `input_schema`, by using their `description` or `type` as fallback and removing special-case logic for each tool. (`src/server/utils/anthropic.ts`)

Test suite simplification and updates:

* Consolidated and renamed tests to verify handling of built-in tools without `input_schema`, removing redundant special-case tests for specific tools like `bash`, `str_replace_editor`, and `web_search`. (`src/test/server/anthropic.test.ts`)
* Updated assertions and formatting in several tests to match the new conversion logic and improve readability. (`src/test/server/anthropic.test.ts`) [[1]](diffhunk://#diff-bd8b08f4ca81fe04f2be1c492e59ebb95e18c7f1495930f804128938ed02fa4cL23-R23) [[2]](diffhunk://#diff-bd8b08f4ca81fe04f2be1c492e59ebb95e18c7f1495930f804128938ed02fa4cL56-R53) [[3]](diffhunk://#diff-bd8b08f4ca81fe04f2be1c492e59ebb95e18c7f1495930f804128938ed02fa4cL99-R93) [[4]](diffhunk://#diff-bd8b08f4ca81fe04f2be1c492e59ebb95e18c7f1495930f804128938ed02fa4cL161-R154) [[5]](diffhunk://#diff-bd8b08f4ca81fe04f2be1c492e59ebb95e18c7f1495930f804128938ed02fa4cL287-R262)