### PR TITLE
fix: repair broken tool_use/tool_result pairing in Anthropic proxy

### DIFF
--- a/src/server/routes/anthropicRoutes.ts
+++ b/src/server/routes/anthropicRoutes.ts
@@ -13,6 +13,8 @@ import {
   convertAnthropicToolChoiceToVSCode,
   convertAnthropicToolToVSCode,
   countAnthropicMessageTokens,
+  repairToolUseResultPairing,
+  repairVSCodeToolPairing,
 } from "../utils/anthropic";
 import { handleErrorWithLogging } from "../utils/errorDiagnostics";
 
@@ -32,6 +34,11 @@ const prepareAnthropicMessages = async ({
     ...convertAnthropicSystemToVSCode(system),
     ...convertAnthropicMessagesToVSCode(messages),
   ];
+
+  // Repair tool pairing in the final VS Code message array.
+  // System prompts are prepended as User messages, which can break the
+  // tool_use/tool_result pairing that the Copilot backend enforces.
+  repairVSCodeToolPairing(vsCodeLmMessages);
 
   const cancellationToken = new vscode.CancellationTokenSource().token;
   const inputTokenCount = await countAnthropicMessageTokens(
@@ -214,10 +221,17 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
         return c.json(clientError, 404);
       }
 
-      // 3. Map Anthropic messages to VS Code LM API messages and count input tokens
+      // 3. Repair tool_use/tool_result pairing before conversion
+      const repairedMessages = repairToolUseResultPairing(messages);
+      const repairedRequestBody = {
+        ...requestBody,
+        messages: repairedMessages,
+      };
+
+      // 4. Map Anthropic messages to VS Code LM API messages and count input tokens
       const { vsCodeLmMessages, inputTokenCount, cancellationToken } =
         await prepareAnthropicMessages({
-          requestBody,
+          requestBody: repairedRequestBody,
           client,
         });
       lmChatMessages = vsCodeLmMessages;
@@ -229,7 +243,7 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
         } | input: ${inputTokenCount.original} → ${inputTokenCount.calibrated}`,
       );
 
-      // 4. Build VS Code Language Model request options
+      // 5. Build VS Code Language Model request options
       const lmRequestOptions: vscode.LanguageModelChatRequestOptions = {
         justification:
           "Anthropic-compatible /v1/messages endpoint with streaming support using VS Code Language Model API",
@@ -238,14 +252,38 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
         toolMode: convertAnthropicToolChoiceToVSCode(tool_choice),
       };
 
-      // 5. Send request to the VS Code LM API
+      // 6. Send request to the VS Code LM API
+      // Log message structure for debugging tool pairing issues
+      const msgStructure = vsCodeLmMessages.map((m, idx) => {
+        const role =
+          m.role === vscode.LanguageModelChatMessageRole.User
+            ? "User"
+            : "Assistant";
+        const parts = m.content.map((p: any) => {
+          if (p instanceof vscode.LanguageModelToolResultPart) {
+            return `ToolResult(${p.callId})`;
+          }
+          if (p instanceof vscode.LanguageModelToolCallPart) {
+            return `ToolCall(${p.callId})`;
+          }
+          if (p instanceof vscode.LanguageModelTextPart) {
+            return `Text(${p.value.length}ch)`;
+          }
+          return `Unknown(${p.constructor?.name})`;
+        });
+        return `[${idx}] ${role}: ${parts.join(", ")}`;
+      });
+      logger.debug(
+        `vsCodeLmMessages structure (${vsCodeLmMessages.length} msgs):\n${msgStructure.join("\n")}`,
+      );
+
       const response = await client.sendRequest(
         vsCodeLmMessages,
         lmRequestOptions,
         cancellationToken,
       );
 
-      // 6. Non-streaming response: collect content blocks using unified approach
+      // 7. Non-streaming response: collect content blocks using unified approach
       if (!msgCreateParams.stream) {
         const content: Anthropic.Messages.ContentBlock[] = [];
         let accumulatedText = "";
@@ -306,7 +344,7 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
         return c.json(resp);
       }
 
-      // 7. If streaming, pipe chunks as SSE
+      // 8. If streaming, pipe chunks as SSE
       return streamSSE(
         c,
         async (stream) => {
@@ -478,12 +516,33 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
       const errorMessage =
         error instanceof Error ? error.message : JSON.stringify(error);
 
+      const isToolUseIdError = errorMessage.includes(
+        "unexpected `tool_use_id` found in `tool_result` blocks",
+      );
+
+      // The VS Code Language Model API (Copilot backend) may return generic
+      // "400 Bad Request" errors when tool_use/tool_result pairings are broken.
+      // The Copilot Chat extension strips the detailed error body, so we only
+      // see "Request Failed: 400 Bad Request" without the specific
+      // "unexpected tool_use_id" message. When we detect a 400 error and the
+      // request contains tool_result blocks, treat it as a context window /
+      // pairing issue and return model_context_window_exceeded to trigger
+      // auto-compact on the client side.
+      const hasToolResults =
+        rawRequestBody?.messages?.some(
+          (m: Anthropic.Messages.MessageParam) =>
+            Array.isArray(m.content) &&
+            m.content.some(
+              (b: Anthropic.Messages.ContentBlockParam) =>
+                b.type === "tool_result" || b.type === "web_search_tool_result",
+            ),
+        ) ?? false;
+      const is400BadRequest = errorMessage.includes("400 Bad Request");
+
       const isContextWindowExceeded =
-        errorMessage.includes(
-          "unexpected `tool_use_id` found in `tool_result` blocks",
-        ) &&
-        maxInputTokens > 0 &&
-        inputTokens > maxInputTokens;
+        isToolUseIdError ||
+        (is400BadRequest && hasToolResults) ||
+        (maxInputTokens > 0 && inputTokens > maxInputTokens);
 
       if (isContextWindowExceeded) {
         const model = rawRequestBody?.model ?? effectiveModelId;

--- a/src/server/utils/anthropic.ts
+++ b/src/server/utils/anthropic.ts
@@ -1,6 +1,334 @@
 import Anthropic from "@anthropic-ai/sdk";
 import * as vscode from "vscode";
 
+import { logger } from "../../utils/logger";
+
+/**
+ * Collect tool_use IDs from an assistant message's content blocks.
+ */
+function getToolUseIds(
+  content: string | Array<Anthropic.Messages.ContentBlockParam>,
+): Set<string> {
+  const ids = new Set<string>();
+  if (typeof content === "string") {
+    return ids;
+  }
+  for (const block of content) {
+    if (block.type === "tool_use" || block.type === "server_tool_use") {
+      ids.add((block as Anthropic.Messages.ToolUseBlockParam).id);
+    }
+  }
+  return ids;
+}
+
+/**
+ * Collect tool_result tool_use_ids from a user message's content blocks.
+ */
+function getToolResultIds(
+  content: string | Array<Anthropic.Messages.ContentBlockParam>,
+): Set<string> {
+  const ids = new Set<string>();
+  if (typeof content === "string") {
+    return ids;
+  }
+  for (const block of content) {
+    if (
+      block.type === "tool_result" ||
+      block.type === "web_search_tool_result"
+    ) {
+      ids.add((block as Anthropic.Messages.ToolResultBlockParam).tool_use_id);
+    }
+  }
+  return ids;
+}
+
+/**
+ * Repair tool_use / tool_result pairing in Anthropic message arrays.
+ *
+ * The Anthropic API requires that every tool_result in a user message references
+ * a tool_use_id from the immediately preceding assistant message. This function
+ * ensures that invariant holds by:
+ *
+ * 1. Removing orphaned tool_result blocks (no matching tool_use in prev assistant msg)
+ *    and converting their content to plain text blocks so the context is preserved.
+ * 2. Adding synthetic tool_result blocks for orphaned tool_use blocks (assistant has
+ *    tool_use but the next user message has no matching tool_result).
+ *
+ * This is necessary because the VS Code Language Model API backend may reject
+ * messages with broken pairings even though Agent Maestro faithfully forwards them.
+ */
+export function repairToolUseResultPairing(
+  messages: Array<Anthropic.Messages.MessageParam>,
+): Array<Anthropic.Messages.MessageParam> {
+  const result: Array<Anthropic.Messages.MessageParam> = [];
+  let repairCount = 0;
+
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+
+    if (msg.role === "user") {
+      // Find the preceding assistant message (if any)
+      const prevMsg = result.length > 0 ? result[result.length - 1] : null;
+
+      if (prevMsg && prevMsg.role === "assistant") {
+        const assistantToolUseIds = getToolUseIds(prevMsg.content);
+        const userToolResultIds = getToolResultIds(msg.content);
+
+        // --- Fix orphaned tool_results ---
+        // tool_result blocks whose tool_use_id is NOT in the previous assistant message
+        if (typeof msg.content !== "string") {
+          const fixedContent: Array<Anthropic.Messages.ContentBlockParam> = [];
+          for (const block of msg.content) {
+            if (
+              (block.type === "tool_result" ||
+                block.type === "web_search_tool_result") &&
+              !assistantToolUseIds.has(
+                (block as Anthropic.Messages.ToolResultBlockParam).tool_use_id,
+              )
+            ) {
+              // Convert orphaned tool_result to text so context is not lost
+              const trBlock = block as Anthropic.Messages.ToolResultBlockParam;
+              const textContent =
+                typeof trBlock.content === "string"
+                  ? trBlock.content
+                  : Array.isArray(trBlock.content)
+                    ? trBlock.content
+                        .map((c) =>
+                          c.type === "text"
+                            ? (c as Anthropic.Messages.TextBlockParam).text
+                            : JSON.stringify(c),
+                        )
+                        .join("\n")
+                    : "";
+              if (textContent) {
+                fixedContent.push({
+                  type: "text",
+                  text: `[Tool result for ${trBlock.tool_use_id}]: ${textContent}`,
+                } as Anthropic.Messages.TextBlockParam);
+              }
+              logger.debug(
+                `repairToolUseResultPairing: converted orphaned tool_result ${trBlock.tool_use_id} to text at message index ${i}`,
+              );
+              repairCount++;
+            } else {
+              fixedContent.push(block);
+            }
+          }
+
+          // Ensure the user message has at least some content
+          if (fixedContent.length === 0) {
+            fixedContent.push({
+              type: "text",
+              text: "",
+            } as Anthropic.Messages.TextBlockParam);
+          }
+
+          result.push({ ...msg, content: fixedContent });
+        } else {
+          result.push(msg);
+        }
+
+        // --- Fix orphaned tool_use blocks ---
+        // tool_use blocks in the assistant message with no matching tool_result
+        const orphanedToolUseIds = new Set<string>();
+        for (const id of assistantToolUseIds) {
+          // Check against the (possibly fixed) user message's tool_result ids
+          const currentUserResultIds = getToolResultIds(
+            result[result.length - 1].content,
+          );
+          if (!currentUserResultIds.has(id)) {
+            orphanedToolUseIds.add(id);
+          }
+        }
+
+        if (orphanedToolUseIds.size > 0) {
+          // Inject synthetic tool_result blocks into the user message
+          const userMsg = result[result.length - 1];
+          const userContent =
+            typeof userMsg.content === "string"
+              ? [
+                  {
+                    type: "text",
+                    text: userMsg.content,
+                  } as Anthropic.Messages.TextBlockParam,
+                ]
+              : [...userMsg.content];
+
+          // Add synthetic results BEFORE other content
+          const syntheticResults: Array<Anthropic.Messages.ContentBlockParam> =
+            [];
+          for (const id of orphanedToolUseIds) {
+            syntheticResults.push({
+              type: "tool_result",
+              tool_use_id: id,
+              content: "[No output captured]",
+            } as Anthropic.Messages.ToolResultBlockParam);
+            repairCount++;
+          }
+
+          result[result.length - 1] = {
+            ...userMsg,
+            content: [...syntheticResults, ...userContent],
+          };
+        }
+      } else {
+        // No preceding assistant message — just drop any tool_result blocks
+        if (typeof msg.content !== "string") {
+          const droppedIds: string[] = [];
+          const fixedContent = msg.content.filter((block) => {
+            if (
+              block.type === "tool_result" ||
+              block.type === "web_search_tool_result"
+            ) {
+              droppedIds.push(
+                (block as Anthropic.Messages.ToolResultBlockParam).tool_use_id,
+              );
+              return false;
+            }
+            return true;
+          });
+          if (droppedIds.length > 0) {
+            logger.warn(
+              `repairToolUseResultPairing: dropped ${droppedIds.length} orphaned tool_result(s) at message index ${i} (no preceding assistant): ${droppedIds.join(", ")}`,
+            );
+            repairCount += droppedIds.length;
+          }
+          result.push({
+            ...msg,
+            content:
+              fixedContent.length > 0
+                ? fixedContent
+                : [
+                    {
+                      type: "text",
+                      text: "",
+                    } as Anthropic.Messages.TextBlockParam,
+                  ],
+          });
+          repairCount++;
+        } else {
+          result.push(msg);
+        }
+      }
+    } else {
+      result.push(msg);
+    }
+  }
+
+  // Also handle the case where the last message is an assistant message with tool_use
+  // but there's no following user message with tool_result (edge case for the final message)
+  // This is fine — the API only requires tool_result to reference a preceding tool_use,
+  // not that every tool_use has a tool_result.
+
+  if (repairCount > 0) {
+    logger.warn(
+      `repairToolUseResultPairing: fixed ${repairCount} broken tool_use/tool_result pairings`,
+    );
+  }
+
+  return result;
+}
+
+/**
+ * Repair tool_use/tool_result pairing in the final VS Code message array.
+ *
+ * After conversion, system prompts are prepended as User messages, which can
+ * break the tool pairing invariant (every LanguageModelToolResultPart in a User
+ * message must have a matching LanguageModelToolCallPart in the immediately
+ * preceding Assistant message).
+ *
+ * This function scans the converted messages and converts any orphaned
+ * LanguageModelToolResultPart into LanguageModelTextPart so the Copilot
+ * backend won't reject the request.
+ */
+export function repairVSCodeToolPairing(
+  messages: vscode.LanguageModelChatMessage[],
+): vscode.LanguageModelChatMessage[] {
+  let repairCount = 0;
+
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+
+    // Only check User messages (role === 1 for User in VS Code API)
+    if (msg.role !== vscode.LanguageModelChatMessageRole.User) {
+      continue;
+    }
+
+    // Collect tool_call IDs from the preceding Assistant message
+    const prevMsg = i > 0 ? messages[i - 1] : null;
+    const assistantToolCallIds = new Set<string>();
+    if (
+      prevMsg &&
+      prevMsg.role === vscode.LanguageModelChatMessageRole.Assistant
+    ) {
+      for (const part of prevMsg.content) {
+        if (part instanceof vscode.LanguageModelToolCallPart) {
+          assistantToolCallIds.add(part.callId);
+        }
+      }
+    }
+
+    // Check each part of the user message
+    let hasOrphanedToolResults = false;
+    for (const part of msg.content) {
+      if (part instanceof vscode.LanguageModelToolResultPart) {
+        if (!assistantToolCallIds.has(part.callId)) {
+          hasOrphanedToolResults = true;
+          break;
+        }
+      }
+    }
+
+    if (!hasOrphanedToolResults) {
+      continue;
+    }
+
+    // Rebuild the content array, converting orphaned tool results to text
+    const newContent: Array<
+      vscode.LanguageModelTextPart | vscode.LanguageModelToolResultPart
+    > = [];
+    for (const part of msg.content) {
+      if (part instanceof vscode.LanguageModelToolResultPart) {
+        if (!assistantToolCallIds.has(part.callId)) {
+          // Convert orphaned tool result to text
+          const textContent =
+            part.content
+              ?.map((c: any) =>
+                c instanceof vscode.LanguageModelTextPart
+                  ? c.value
+                  : JSON.stringify(c),
+              )
+              .join("\n") || "";
+          newContent.push(
+            new vscode.LanguageModelTextPart(
+              `[Tool result for ${part.callId}]: ${textContent}`,
+            ),
+          );
+          logger.debug(
+            `repairVSCodeToolPairing: converted orphaned tool result ${part.callId} to text at vsCode message index ${i}`,
+          );
+          repairCount++;
+        } else {
+          newContent.push(part);
+        }
+      } else {
+        newContent.push(part as vscode.LanguageModelTextPart);
+      }
+    }
+
+    // Replace the message in-place
+    messages[i] = vscode.LanguageModelChatMessage.User(newContent);
+  }
+
+  if (repairCount > 0) {
+    logger.warn(
+      `repairVSCodeToolPairing: converted ${repairCount} orphaned tool result(s) to text in VS Code messages`,
+    );
+  }
+
+  return messages;
+}
+
 const textBlockParamToVSCodePart = (param: Anthropic.Messages.TextBlockParam) =>
   new vscode.LanguageModelTextPart(param.text);
 


### PR DESCRIPTION
## Summary

- Fixes `400 Bad Request: unexpected tool_use_id found in tool_result blocks` errors that occur when long conversations with tool use are proxied through Agent Maestro to the VS Code Language Model API (Copilot backend)
- Adds **two layers** of tool_use/tool_result pairing repair:
  1. **Pre-conversion** (`repairToolUseResultPairing`): fixes orphaned tool_result/tool_use blocks at the Anthropic message level before conversion to VS Code format
  2. **Post-conversion** (`repairVSCodeToolPairing`): fixes orphaned `LanguageModelToolResultPart` entries in the final VS Code message array, which get broken when `convertAnthropicSystemToVSCode()` prepends system prompts as User messages
- Broadens error catch to handle generic "400 Bad Request" responses (Copilot Chat extension strips detailed error bodies) and trigger auto-compact
- Adds debug logging of VS Code message structure before `sendRequest` for easier diagnosis

## Root Cause

The Copilot backend enforces strict tool pairing: every `ToolResultPart` in a User message must have a matching `ToolCallPart` in the **immediately preceding** Assistant message. This invariant breaks in two ways:

1. Clients (e.g., OpenClaw) send long conversation histories where tool_result blocks reference tool_use IDs from non-adjacent assistant messages
2. `convertAnthropicSystemToVSCode()` prepends system prompts as User messages, shifting the message array so that `messages[0]` becomes a system-prompt User message and the original first user message (which may contain tool_results) no longer has the correct preceding Assistant message

## Test plan

- [x] Verified with OpenClaw via Slack — previously failing conversations now succeed
- [x] Verified Claude Code still works through Agent Maestro
- [ ] Long conversations with heavy tool use should no longer trigger 400 errors

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)