### PR TITLE
Release v2.8.5

### DIFF
--- a/.changeset/grumpy-pears-impress.md
+++ b/.changeset/grumpy-pears-impress.md
@@ -1,5 +1,0 @@
----
-"@fake-scope/fake-pkg": patch
----
-
-Change default `codex.contextWindowScaleFactor` from 1.3 to 1 to better align with model context limits.

--- a/.changeset/hip-foxes-warn.md
+++ b/.changeset/hip-foxes-warn.md
@@ -1,5 +1,0 @@
----
-"agent-maestro": patch
----
-
-Auto-upgrade to 1M context variant when input exceeds model's context window

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.8.5 - 2026.03.28
+
+- Change default `codex.contextWindowScaleFactor` from 1.3 to 1 to better align with model context limits.
+- Auto-upgrade to 1M context variant when input exceeds model's context window
+
 ## v2.8.4 - 2026.03.13
 
 - Add image (vision) support to Chat Completions route — convert base64 data URI `image_url` parts to `LanguageModelDataPart` instead of JSON-serializing them as text, fixing token limit errors for vision requests (#154)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "agent-maestro",
   "displayName": "Agent Maestro",
   "description": "Turn VS Code into your compliant AI playground! With Agent Maestro, spin up Cline or Roo on demand and plug Claude Code or Codex straight in through an OpenAI/Anthropic-compatible API.",
-  "version": "2.8.4",
+  "version": "2.8.5",
   "icon": "assets/icons/icon.png",
   "publisher": "Joouis",
   "repository": "https://github.com/Joouis/agent-maestro",


### PR DESCRIPTION
## Summary

  - Change default `codex.contextWindowScaleFactor` from 1.3 to 1 to better align with
  model context limits (#158)
  - Auto-upgrade to 1M context variant when input exceeds model's context window (#159)
  - Improve context window warning messages and request logging (#146)