### PR TITLE
Fix /v1/messages hang/400 when client sends Anthropic server-side tools (web_search, etc.)

### DIFF
--- a/.changeset/drop-unsupported-server-side-tools.md
+++ b/.changeset/drop-unsupported-server-side-tools.md
@@ -1,0 +1,5 @@
+---
+"agent-maestro": patch
+---
+
+Fix `/v1/messages` failing or hanging when Claude Code (or any client) sends Anthropic server-side tool definitions such as `web_search_20250305`, `computer_20250124`, `bash_20250124`, etc. The previous tool converter stuffed the entire tool object into `inputSchema`, producing invalid JSON Schema (`tools.0.custom.input_schema.type: Input should be 'object'`) and, when no upstream error surfaced, leaving the client waiting forever for a `tool_result` that VS Code's Language Model API cannot produce. These tools are now dropped with a logged warning so the model never sees them and the request proceeds normally. Fixes #163, addresses #150.

--- a/src/server/utils/anthropic.ts
+++ b/src/server/utils/anthropic.ts
@@ -1,6 +1,8 @@
 import Anthropic from "@anthropic-ai/sdk";
 import * as vscode from "vscode";
 
+import { logger } from "../../utils/logger";
+
 const textBlockParamToVSCodePart = (param: Anthropic.Messages.TextBlockParam) =>
   new vscode.LanguageModelTextPart(param.text);
 
@@ -238,25 +240,50 @@ export const convertAnthropicSystemToVSCode = (
   );
 };
 
+/**
+ * Anthropic server-side tools (web_search, code_execution, computer_use,
+ * bash, text_editor, memory, web_fetch, etc.) are executed by Anthropic's
+ * backend, not the client. They are identified by the presence of a `type`
+ * field other than `"custom"` and the absence of `input_schema`.
+ *
+ * VS Code's Language Model API has no way to execute them — forwarding them
+ * causes the upstream to reject the request (`tools.0.custom.input_schema.type:
+ * Input should be 'object'`) or silently hang waiting for a tool result that
+ * never comes. We drop them here so the model is not told they exist.
+ */
+const isUnsupportedServerSideTool = (tool: unknown): boolean => {
+  const t = tool as { type?: string; input_schema?: unknown };
+  return (
+    typeof t.type === "string" && t.type !== "custom" && !t.input_schema
+  );
+};
+
 export const convertAnthropicToolToVSCode = (
   tools?: Anthropic.Messages.ToolUnion[],
-): vscode.LanguageModelChatTool[] | undefined =>
-  tools?.map((tool) => {
-    const t = tool as Anthropic.Messages.Tool;
-    if (t.input_schema) {
-      return {
-        name: t.name,
-        description: t.description || "",
-        inputSchema: t.input_schema,
-      };
+): vscode.LanguageModelChatTool[] | undefined => {
+  if (!tools) {
+    return undefined;
+  }
+
+  const filtered: vscode.LanguageModelChatTool[] = [];
+  for (const tool of tools) {
+    if (isUnsupportedServerSideTool(tool)) {
+      logger.warn(
+        `Dropping unsupported Anthropic server-side tool: ${
+          (tool as { type?: string }).type
+        } — VS Code Language Model API cannot execute it`,
+      );
+      continue;
     }
-    // For built-in tools like ToolBash20250124 that don't have input_schema
-    return {
+    const t = tool as Anthropic.Messages.Tool;
+    filtered.push({
       name: t.name,
-      description: t.description || (tool as { type?: string }).type || "",
-      inputSchema: tool,
-    };
-  });
+      description: t.description || "",
+      inputSchema: t.input_schema,
+    });
+  }
+  return filtered;
+};
 
 export const convertAnthropicToolChoiceToVSCode = (
   toolChoice?: Anthropic.Messages.ToolChoice,

--- a/src/test/server/anthropic.test.ts
+++ b/src/test/server/anthropic.test.ts
@@ -237,7 +237,12 @@ suite("Anthropic Conversion Utils Test Suite", () => {
         {
           name: "lookup",
           type: "custom",
-          input_schema: { type: "object", properties: {} },
+          description: "Look something up",
+          input_schema: {
+            type: "object",
+            properties: { id: { type: "string" } },
+            required: ["id"],
+          },
         },
       ];
 
@@ -246,6 +251,8 @@ suite("Anthropic Conversion Utils Test Suite", () => {
       assert.ok(result);
       assert.strictEqual(result.length, 1);
       assert.strictEqual(result[0].name, "lookup");
+      assert.strictEqual(result[0].description, "Look something up");
+      assert.deepStrictEqual(result[0].inputSchema, tools[0].input_schema);
     });
 
     test("should return undefined for undefined tools", () => {

--- a/src/test/server/anthropic.test.ts
+++ b/src/test/server/anthropic.test.ts
@@ -206,15 +206,46 @@ suite("Anthropic Conversion Utils Test Suite", () => {
       assert.strictEqual(result[0].description, "Get the weather for a city");
     });
 
-    test("should handle built-in tools without input_schema", () => {
-      const tools = [{ name: "bash", type: "bash_20250124" }];
+    test("should drop unsupported server-side tools without input_schema", () => {
+      const tools = [
+        { name: "bash", type: "bash_20250124" },
+        { name: "web_search", type: "web_search_20250305", max_uses: 5 },
+        { name: "computer", type: "computer_20250124" },
+        {
+          name: "get_weather",
+          input_schema: {
+            type: "object",
+            properties: { city: { type: "string" } },
+          },
+        },
+      ];
 
       const result = convertAnthropicToolToVSCode(tools as any);
 
       assert.ok(result);
-      assert.strictEqual(result[0].name, "bash");
-      assert.strictEqual(result[0].description, "bash_20250124");
-      assert.deepStrictEqual(result[0].inputSchema, tools[0]);
+      assert.strictEqual(
+        result.length,
+        1,
+        "server-side tools without input_schema should be dropped",
+      );
+      assert.strictEqual(result[0].name, "get_weather");
+      assert.deepStrictEqual(result[0].inputSchema, tools[3].input_schema);
+    });
+
+    test("should keep custom tools with type: 'custom'", () => {
+      const tools = [
+        {
+          name: "lookup",
+          type: "custom",
+          input_schema: { type: "object", properties: {} },
+        },
+      ];
+
+      const result = convertAnthropicToolToVSCode(tools as any);
+
+      assert.ok(result);
+      assert.strictEqual(result.length, 1);
+      assert.strictEqual(result[0].name, "lookup");
     });
 
     test("should return undefined for undefined tools", () => {


### PR DESCRIPTION
## Summary

When a client (e.g. Claude Code) sends Anthropic server-side tool definitions such as `web_search_20250305`, `computer_*`, `bash_*`, `text_editor_*`, `memory_*`, `web_fetch_*`, etc., `/v1/messages` either:

- returns an upstream **400** — `tools.0.custom.input_schema.type: Input should be 'object'` (#163), or
- **hangs forever** while the client waits for a `tool_result` that the VS Code Language Model API cannot produce (#150).

## Root cause

`convertAnthropicToolToVSCode` in `src/server/utils/anthropic.ts` had a fallback branch for tools without `input_schema` (server-side tools) that stuffed the **entire tool object** into `inputSchema`:

```ts
return {
  name: t.name,
  description: t.description || (tool as { type?: string }).type || "",
  inputSchema: tool, // <-- the whole tool object
};
```

For `{ type: "web_search_20250305", name: "web_search", max_uses: 5 }`, the synthesized `inputSchema` ends up with `type: "web_search_20250305"` instead of a valid JSON Schema object. Anthropic rejects it with the 400 above. Even when no error surfaces, VS Code LM has no implementation for these tools, so the model never emits a `tool_use` for them — and Claude Code keeps waiting.

## Fix

Drop unsupported server-side tools before forwarding so the model is never told they exist. Detection uses an invariant rather than a hardcoded prefix list:

```ts
const isUnsupportedServerSideTool = (tool: unknown): boolean => {
  const t = tool as { type?: string; input_schema?: unknown };
  return typeof t.type === "string" && t.type !== "custom" && !t.input_schema;
};
```

Future-proof: any new server-side tool version added by `@anthropic-ai/sdk` is filtered automatically. Custom tools (`type: "custom"` or no `type`) and any tool with `input_schema` pass through unchanged.

A warning is logged via the existing `logger` so users can see in the output channel why a tool didn't take effect.

## Tests

- Replaced the existing `should handle built-in tools without input_schema` test (which asserted the broken behaviour) with `should drop unsupported server-side tools without input_schema` covering `bash_*`, `web_search_*`, `computer_*`, mixed with a custom tool.
- Added `should keep custom tools with type: 'custom'` to lock the discriminator.

## Follow-up

This PR makes WebSearch a no-op rather than a hang. A separate PR (linked in the umbrella issue) will optionally make WebSearch actually work by having the proxy execute the search and synthesize the `server_tool_use` + `web_search_tool_result` blocks.

## Test plan

- [ ] `pnpm test` passes locally
- [ ] Manual: point Claude Code at the proxy, trigger WebSearch — request now completes with a text answer instead of hanging or 400-ing
- [ ] Manual: `bash_*` / `computer_*` tool definitions also no longer cause failures

Fixes #163
Addresses #150