### PR TITLE
Execute Anthropic web_search server-tool via third-party search API (Tavily/Brave)

### DIFF
--- a/.changeset/enable-web-search-execution.md
+++ b/.changeset/enable-web-search-execution.md
@@ -2,6 +2,6 @@
 "agent-maestro": minor
 ---
 
-Add opt-in execution of Anthropic's `web_search` server-side tool. When enabled, the proxy intercepts `web_search_20250305` tool calls from clients (e.g. Claude Code's WebSearch), runs the query against a third-party search API (Tavily by default, Brave optional), and synthesizes the `server_tool_use` + `web_search_tool_result` blocks Anthropic's backend would have returned. Multi-turn loop honors `max_uses` and respects `allowed_domains` / `blocked_domains`. Disabled by default — when off, web_search tool definitions are silently dropped (existing behavior from #167).
+Add opt-in execution of Anthropic's `web_search` server-side tool. When enabled, the proxy intercepts `web_search_20250305` tool calls from clients (e.g. Claude Code's WebSearch), runs the query against a third-party search API (Tavily by default, Brave optional), and synthesizes the `server_tool_use` + `web_search_tool_result` blocks Anthropic's backend would have returned. Multi-turn loop honors `max_uses` and respects `allowed_domains` / `blocked_domains`. Disabled by default — when off, web_search tool definitions are dropped with a logged warning (existing behavior from #167).
 
 New settings: `agent-maestro.webSearch.enabled`, `.provider`, `.apiKey`, `.maxResults`, `.maxUsesPerRequest`, `.timeoutMs`. API key may also be supplied via `AGENT_MAESTRO_WEBSEARCH_API_KEY`.

--- a/.changeset/enable-web-search-execution.md
+++ b/.changeset/enable-web-search-execution.md
@@ -1,0 +1,7 @@
+---
+"agent-maestro": minor
+---
+
+Add opt-in execution of Anthropic's `web_search` server-side tool. When enabled, the proxy intercepts `web_search_20250305` tool calls from clients (e.g. Claude Code's WebSearch), runs the query against a third-party search API (Tavily by default, Brave optional), and synthesizes the `server_tool_use` + `web_search_tool_result` blocks Anthropic's backend would have returned. Multi-turn loop honors `max_uses` and respects `allowed_domains` / `blocked_domains`. Disabled by default — when off, web_search tool definitions are silently dropped (existing behavior from #167).
+
+New settings: `agent-maestro.webSearch.enabled`, `.provider`, `.apiKey`, `.maxResults`, `.maxUsesPerRequest`, `.timeoutMs`. API key may also be supplied via `AGENT_MAESTRO_WEBSEARCH_API_KEY`.

--- a/package.json
+++ b/package.json
@@ -101,6 +101,52 @@
           "maximum": 2,
           "description": "Scale factor applied to token counts from VS Code's API to approximate Anthropic's actual token usage. Higher values provide more buffer against context window limits but reduce usable context. Default 1.25 means VS Code token counts are multiplied by 1.25.",
           "scope": "application"
+        },
+        "agent-maestro.webSearch.enabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable execution of Anthropic's web_search server-side tool by routing it to a third-party search API. When disabled, web_search tool definitions sent by clients are dropped (no hang, no error, but no search either).",
+          "scope": "application"
+        },
+        "agent-maestro.webSearch.provider": {
+          "type": "string",
+          "enum": [
+            "tavily",
+            "brave"
+          ],
+          "default": "tavily",
+          "description": "Search backend used when web_search is enabled. Tavily (https://tavily.com) and Brave Search (https://brave.com/search/api/) both offer free tiers.",
+          "scope": "application"
+        },
+        "agent-maestro.webSearch.apiKey": {
+          "type": "string",
+          "default": "",
+          "description": "API key for the selected web search provider. Can also be supplied via the AGENT_MAESTRO_WEBSEARCH_API_KEY environment variable.",
+          "scope": "application"
+        },
+        "agent-maestro.webSearch.maxResults": {
+          "type": "number",
+          "default": 5,
+          "minimum": 1,
+          "maximum": 20,
+          "description": "Maximum number of search results returned per query.",
+          "scope": "application"
+        },
+        "agent-maestro.webSearch.maxUsesPerRequest": {
+          "type": "number",
+          "default": 5,
+          "minimum": 1,
+          "maximum": 20,
+          "description": "Maximum number of web_search calls allowed per /v1/messages request, regardless of what max_uses the client requests.",
+          "scope": "application"
+        },
+        "agent-maestro.webSearch.timeoutMs": {
+          "type": "number",
+          "default": 8000,
+          "minimum": 1000,
+          "maximum": 60000,
+          "description": "Per-search HTTP timeout in milliseconds.",
+          "scope": "application"
         }
       }
     },

--- a/src/server/routes/anthropicRoutes.ts
+++ b/src/server/routes/anthropicRoutes.ts
@@ -15,6 +15,13 @@ import {
   countAnthropicMessageTokens,
 } from "../utils/anthropic";
 import { handleErrorWithLogging } from "../utils/errorDiagnostics";
+import {
+  getProvider,
+  getWebSearchConfig,
+  isWebSearchActive,
+  logWebSearchActivation,
+} from "../utils/webSearch";
+import { runWebSearchLoop } from "../utils/webSearchLoop";
 
 const prepareAnthropicMessages = async ({
   requestBody,
@@ -285,13 +292,271 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
       );
 
       // 4. Build VS Code Language Model request options
+      const webSearchCfg = getWebSearchConfig();
+      const webSearchActive =
+        isWebSearchActive(webSearchCfg) &&
+        (tools ?? []).some(
+          (t) =>
+            typeof (t as { type?: string }).type === "string" &&
+            (t as { type?: string }).type!.startsWith("web_search_"),
+        );
+      if (webSearchActive) {
+        logWebSearchActivation(webSearchCfg);
+      }
+
       const lmRequestOptions: vscode.LanguageModelChatRequestOptions = {
         justification:
           "Anthropic-compatible /v1/messages endpoint with streaming support using VS Code Language Model API",
         modelOptions: msgCreateParams,
-        tools: convertAnthropicToolToVSCode(tools),
+        tools: convertAnthropicToolToVSCode(tools, { webSearchActive }),
         toolMode: convertAnthropicToolChoiceToVSCode(tool_choice),
       };
+
+      // 5. Send request to the VS Code LM API (or, when web_search is active,
+      //    drive a multi-turn loop that intercepts web_search calls and
+      //    synthesizes Anthropic-shape server_tool_use / web_search_tool_result
+      //    blocks for the client.)
+      if (webSearchActive) {
+        const provider = getProvider(webSearchCfg);
+
+        if (!msgCreateParams.stream) {
+          const content: Anthropic.Messages.ContentBlock[] = [];
+          let accumulatedText = "";
+
+          const result = await runWebSearchLoop({
+            client,
+            initialMessages: vsCodeLmMessages,
+            initialOptions: lmRequestOptions,
+            cancellationToken,
+            cfg: webSearchCfg,
+            provider,
+            tools,
+            onModelChunk: async (chunk) => {
+              if (chunk instanceof vscode.LanguageModelTextPart) {
+                let lastBlock = content.at(-1);
+                if (!lastBlock || lastBlock.type !== "text") {
+                  lastBlock = { type: "text", text: "", citations: null };
+                  content.push(lastBlock);
+                }
+                lastBlock.text += chunk.value;
+                accumulatedText += chunk.value;
+              } else if (chunk instanceof vscode.LanguageModelToolCallPart) {
+                content.push({
+                  type: "tool_use",
+                  id: chunk.callId,
+                  name: chunk.name,
+                  input: chunk.input,
+                });
+                accumulatedText += JSON.stringify(chunk);
+              }
+            },
+            onWebSearchBlock: async ({ block }) => {
+              content.push(block);
+              accumulatedText += JSON.stringify(block);
+            },
+          });
+
+          const outputTokenCount = accumulatedText
+            ? await countAnthropicMessageTokens(accumulatedText, client)
+            : { original: 1, calibrated: 1 };
+
+          const resp: Anthropic.Messages.Message = {
+            id: `msg_${Date.now()}`,
+            type: "message",
+            role: "assistant",
+            model,
+            content,
+            stop_reason:
+              content.at(-1)?.type === "tool_use" ? "tool_use" : "end_turn",
+            stop_sequence: null,
+            usage: {
+              cache_creation: null,
+              cache_creation_input_tokens: null,
+              cache_read_input_tokens: null,
+              input_tokens: inputTokenCount.calibrated,
+              output_tokens: outputTokenCount.calibrated,
+              server_tool_use: result.used
+                ? { web_search_requests: result.webSearchRequests }
+                : null,
+              service_tier: null,
+            },
+          };
+
+          logger.info(
+            `← /v1/messages | input: ${inputTokenCount.original} → ${
+              inputTokenCount.calibrated
+            } | output: ${outputTokenCount.original} → ${
+              outputTokenCount.calibrated
+            } | web_search: ${result.webSearchRequests}`,
+          );
+
+          return c.json(resp);
+        }
+
+        // Streaming + web_search active
+        return streamSSE(
+          c,
+          async (stream) => {
+            const writeSSE = async (
+              message: Anthropic.Messages.RawMessageStreamEvent,
+            ) => {
+              await stream.writeSSE({
+                event: message.type,
+                data: JSON.stringify(message),
+              });
+            };
+
+            await writeSSE({
+              type: "message_start",
+              message: {
+                id: `msg_${Date.now()}`,
+                type: "message",
+                role: "assistant",
+                model,
+                content: [],
+                stop_reason: null,
+                stop_sequence: null,
+                usage: {
+                  cache_creation: null,
+                  input_tokens: inputTokenCount.calibrated,
+                  output_tokens: 1,
+                  cache_creation_input_tokens: null,
+                  cache_read_input_tokens: null,
+                  server_tool_use: null,
+                  service_tier: "standard",
+                },
+              },
+            });
+
+            const contentBlocks: Anthropic.Messages.ContentBlock[] = [];
+            let accumulatedText = "";
+
+            const closeLastBlock = async () => {
+              if (contentBlocks.length === 0) {
+                return;
+              }
+              await writeSSE({
+                type: "content_block_stop",
+                index: contentBlocks.length - 1,
+              });
+            };
+
+            const startBlock = async (
+              block: Anthropic.Messages.ContentBlock,
+            ) => {
+              contentBlocks.push(block);
+              await writeSSE({
+                type: "content_block_start",
+                index: contentBlocks.length - 1,
+                content_block: block,
+              });
+            };
+
+            const result = await runWebSearchLoop({
+              client,
+              initialMessages: vsCodeLmMessages,
+              initialOptions: lmRequestOptions,
+              cancellationToken,
+              cfg: webSearchCfg,
+              provider,
+              tools,
+              onModelChunk: async (chunk) => {
+                const lastBlock = contentBlocks.at(-1);
+                if (chunk instanceof vscode.LanguageModelTextPart) {
+                  if (lastBlock && lastBlock.type !== "text") {
+                    await closeLastBlock();
+                  }
+                  if (!lastBlock || lastBlock.type !== "text") {
+                    await startBlock({
+                      type: "text",
+                      text: "",
+                      citations: null,
+                    });
+                  }
+                  (contentBlocks.at(-1) as Anthropic.Messages.TextBlock).text +=
+                    chunk.value;
+                  await writeSSE({
+                    type: "content_block_delta",
+                    index: contentBlocks.length - 1,
+                    delta: { type: "text_delta", text: chunk.value },
+                  });
+                  accumulatedText += chunk.value;
+                } else if (chunk instanceof vscode.LanguageModelToolCallPart) {
+                  if (lastBlock) {
+                    await closeLastBlock();
+                  }
+                  await startBlock({
+                    type: "tool_use",
+                    id: chunk.callId,
+                    name: chunk.name,
+                    input: {},
+                  });
+                  await writeSSE({
+                    type: "content_block_delta",
+                    index: contentBlocks.length - 1,
+                    delta: {
+                      type: "input_json_delta",
+                      partial_json: JSON.stringify(chunk.input),
+                    },
+                  });
+                  (
+                    contentBlocks.at(-1) as Anthropic.Messages.ToolUseBlock
+                  ).input = chunk.input;
+                  accumulatedText += JSON.stringify(chunk);
+                }
+              },
+              onWebSearchBlock: async ({ block }) => {
+                if (contentBlocks.length > 0) {
+                  await closeLastBlock();
+                }
+                await startBlock(block);
+                accumulatedText += JSON.stringify(block);
+              },
+            });
+
+            await closeLastBlock();
+
+            const outputTokenCount = accumulatedText
+              ? await countAnthropicMessageTokens(accumulatedText, client)
+              : { original: 1, calibrated: 1 };
+
+            await writeSSE({
+              type: "message_delta",
+              delta: {
+                stop_reason:
+                  contentBlocks.at(-1)?.type === "tool_use"
+                    ? "tool_use"
+                    : "end_turn",
+                stop_sequence: null,
+              },
+              usage: {
+                input_tokens: inputTokenCount.calibrated,
+                output_tokens: outputTokenCount.calibrated,
+                cache_creation_input_tokens: 0,
+                cache_read_input_tokens: 0,
+                server_tool_use: result.used
+                  ? { web_search_requests: result.webSearchRequests }
+                  : null,
+              },
+            });
+
+            await writeSSE({ type: "message_stop" });
+
+            logger.info(
+              `← /v1/messages (stream) | input: ${
+                inputTokenCount.original
+              } → ${inputTokenCount.calibrated} | output: ${
+                outputTokenCount.original
+              } → ${outputTokenCount.calibrated} | web_search: ${
+                result.webSearchRequests
+              }`,
+            );
+          },
+          async (error, _stream) => {
+            logger.error("✕ /v1/messages |", error);
+          },
+        );
+      }
 
       // 5. Send request to the VS Code LM API
       const response = await client.sendRequest(

--- a/src/server/utils/anthropic.ts
+++ b/src/server/utils/anthropic.ts
@@ -285,10 +285,21 @@ export const convertAnthropicToolToVSCode = (
       continue;
     }
     const t = tool as Anthropic.Messages.Tool;
+    const schema =
+      t.input_schema &&
+      typeof t.input_schema === "object" &&
+      (t.input_schema as { type?: unknown }).type === "object"
+        ? t.input_schema
+        : undefined;
+    if (!schema) {
+      logger.warn(
+        `Tool '${t.name}' has missing or invalid input_schema; substituting empty object schema`,
+      );
+    }
     filtered.push({
       name: t.name,
       description: t.description || "",
-      inputSchema: t.input_schema,
+      inputSchema: schema ?? { type: "object", properties: {} },
     });
   }
   return filtered;

--- a/src/server/utils/anthropic.ts
+++ b/src/server/utils/anthropic.ts
@@ -2,6 +2,10 @@ import Anthropic from "@anthropic-ai/sdk";
 import * as vscode from "vscode";
 
 import { logger } from "../../utils/logger";
+import {
+  buildWebSearchVSCodeTool,
+  isWebSearchToolDefinition,
+} from "./webSearch";
 
 const textBlockParamToVSCodePart = (param: Anthropic.Messages.TextBlockParam) =>
   new vscode.LanguageModelTextPart(param.text);
@@ -255,13 +259,12 @@ export const convertAnthropicSystemToVSCode = (
  */
 const isUnsupportedServerSideTool = (tool: unknown): boolean => {
   const t = tool as { type?: string; input_schema?: unknown };
-  return (
-    typeof t.type === "string" && t.type !== "custom" && !t.input_schema
-  );
+  return typeof t.type === "string" && t.type !== "custom" && !t.input_schema;
 };
 
 export const convertAnthropicToolToVSCode = (
   tools?: Anthropic.Messages.ToolUnion[],
+  options: { webSearchActive?: boolean } = {},
 ): vscode.LanguageModelChatTool[] | undefined => {
   if (!tools) {
     return undefined;
@@ -269,6 +272,10 @@ export const convertAnthropicToolToVSCode = (
 
   const filtered: vscode.LanguageModelChatTool[] = [];
   for (const tool of tools) {
+    if (isWebSearchToolDefinition(tool) && options.webSearchActive) {
+      filtered.push(buildWebSearchVSCodeTool());
+      continue;
+    }
     if (isUnsupportedServerSideTool(tool)) {
       logger.warn(
         `Dropping unsupported Anthropic server-side tool: ${

--- a/src/server/utils/webSearch/index.ts
+++ b/src/server/utils/webSearch/index.ts
@@ -29,16 +29,44 @@ export const DEFAULT_WEB_SEARCH_CONFIG: WebSearchConfig = {
   timeoutMs: 8000,
 };
 
+const SUPPORTED_PROVIDERS = ["tavily", "brave"] as const;
+type SupportedProvider = (typeof SUPPORTED_PROVIDERS)[number];
+
+const isSupportedProvider = (v: unknown): v is SupportedProvider =>
+  typeof v === "string" &&
+  (SUPPORTED_PROVIDERS as readonly string[]).includes(v);
+
 export const getWebSearchConfig = (): WebSearchConfig => {
   const cfg = vscode.workspace.getConfiguration("agent-maestro.webSearch");
   const apiKey =
     process.env.AGENT_MAESTRO_WEBSEARCH_API_KEY ||
     cfg.get<string>("apiKey", "");
-  const provider =
-    (process.env.AGENT_MAESTRO_WEBSEARCH_PROVIDER as
-      | "tavily"
-      | "brave"
-      | undefined) || cfg.get<"tavily" | "brave">("provider", "tavily");
+
+  const settingProvider = cfg.get<string>(
+    "provider",
+    DEFAULT_WEB_SEARCH_CONFIG.provider,
+  );
+  const envProviderRaw = process.env.AGENT_MAESTRO_WEBSEARCH_PROVIDER;
+  let provider: SupportedProvider;
+  if (envProviderRaw !== undefined) {
+    if (isSupportedProvider(envProviderRaw)) {
+      provider = envProviderRaw;
+    } else {
+      logger.warn(
+        `Ignoring AGENT_MAESTRO_WEBSEARCH_PROVIDER='${envProviderRaw}' (not one of ${SUPPORTED_PROVIDERS.join(
+          "/",
+        )}); falling back to setting`,
+      );
+      provider = isSupportedProvider(settingProvider)
+        ? settingProvider
+        : DEFAULT_WEB_SEARCH_CONFIG.provider;
+    }
+  } else {
+    provider = isSupportedProvider(settingProvider)
+      ? settingProvider
+      : DEFAULT_WEB_SEARCH_CONFIG.provider;
+  }
+
   return {
     enabled: cfg.get<boolean>("enabled", DEFAULT_WEB_SEARCH_CONFIG.enabled),
     provider,

--- a/src/server/utils/webSearch/index.ts
+++ b/src/server/utils/webSearch/index.ts
@@ -1,0 +1,113 @@
+import * as vscode from "vscode";
+
+import { logger } from "../../../utils/logger";
+import { BraveSearchProvider } from "./providers/brave";
+import { TavilyProvider } from "./providers/tavily";
+import { WebSearchProvider } from "./types";
+
+export type {
+  WebSearchProvider,
+  WebSearchResult,
+  WebSearchOptions,
+} from "./types";
+
+export interface WebSearchConfig {
+  enabled: boolean;
+  provider: "tavily" | "brave";
+  apiKey: string;
+  maxResults: number;
+  maxUsesPerRequest: number;
+  timeoutMs: number;
+}
+
+export const DEFAULT_WEB_SEARCH_CONFIG: WebSearchConfig = {
+  enabled: false,
+  provider: "tavily",
+  apiKey: "",
+  maxResults: 5,
+  maxUsesPerRequest: 5,
+  timeoutMs: 8000,
+};
+
+export const getWebSearchConfig = (): WebSearchConfig => {
+  const cfg = vscode.workspace.getConfiguration("agent-maestro.webSearch");
+  const apiKey =
+    process.env.AGENT_MAESTRO_WEBSEARCH_API_KEY ||
+    cfg.get<string>("apiKey", "");
+  const provider =
+    (process.env.AGENT_MAESTRO_WEBSEARCH_PROVIDER as
+      | "tavily"
+      | "brave"
+      | undefined) || cfg.get<"tavily" | "brave">("provider", "tavily");
+  return {
+    enabled: cfg.get<boolean>("enabled", DEFAULT_WEB_SEARCH_CONFIG.enabled),
+    provider,
+    apiKey,
+    maxResults: cfg.get<number>(
+      "maxResults",
+      DEFAULT_WEB_SEARCH_CONFIG.maxResults,
+    ),
+    maxUsesPerRequest: cfg.get<number>(
+      "maxUsesPerRequest",
+      DEFAULT_WEB_SEARCH_CONFIG.maxUsesPerRequest,
+    ),
+    timeoutMs: cfg.get<number>(
+      "timeoutMs",
+      DEFAULT_WEB_SEARCH_CONFIG.timeoutMs,
+    ),
+  };
+};
+
+export const isWebSearchActive = (cfg: WebSearchConfig): boolean =>
+  cfg.enabled && cfg.apiKey.length > 0;
+
+export const getProvider = (cfg: WebSearchConfig): WebSearchProvider => {
+  switch (cfg.provider) {
+    case "brave":
+      return new BraveSearchProvider(cfg.apiKey, cfg.timeoutMs);
+    case "tavily":
+    default:
+      return new TavilyProvider(cfg.apiKey, cfg.timeoutMs);
+  }
+};
+
+/**
+ * Internal name for the web_search tool when it's exposed to VS Code LM as a
+ * regular custom tool. Chosen to be unlikely to collide with any user tool.
+ */
+export const WEB_SEARCH_TOOL_NAME = "web_search";
+
+export const WEB_SEARCH_TOOL_DESCRIPTION =
+  "Search the public web for current information. Use this when you need facts, news, documentation, or anything not in your training data. Returns titles, URLs, and snippets — cite the source URLs in your final answer.";
+
+export const WEB_SEARCH_INPUT_SCHEMA = {
+  type: "object",
+  properties: {
+    query: {
+      type: "string",
+      description: "The search query. Be specific and concise.",
+    },
+  },
+  required: ["query"],
+} as const;
+
+export const isWebSearchToolDefinition = (tool: unknown): boolean => {
+  const t = tool as { type?: string; name?: string };
+  return (
+    typeof t.type === "string" &&
+    t.type.startsWith("web_search_") &&
+    t.name === "web_search"
+  );
+};
+
+export const buildWebSearchVSCodeTool = (): vscode.LanguageModelChatTool => ({
+  name: WEB_SEARCH_TOOL_NAME,
+  description: WEB_SEARCH_TOOL_DESCRIPTION,
+  inputSchema: WEB_SEARCH_INPUT_SCHEMA,
+});
+
+export const logWebSearchActivation = (cfg: WebSearchConfig): void => {
+  logger.info(
+    `web_search active | provider=${cfg.provider} | maxResults=${cfg.maxResults} | maxUsesPerRequest=${cfg.maxUsesPerRequest}`,
+  );
+};

--- a/src/server/utils/webSearch/providers/brave.ts
+++ b/src/server/utils/webSearch/providers/brave.ts
@@ -63,21 +63,26 @@ export class BraveSearchProvider implements WebSearchProvider {
       }
 
       const data = (await res.json()) as BraveResponse;
+      const normalize = (d: string) =>
+        d.toLowerCase().replace(/^\.+/, "").replace(/\/+$/, "");
+      const matchesDomain = (host: string, domain: string) =>
+        host === domain || host.endsWith("." + domain);
+
       const allowed = opts.allowedDomains
-        ? new Set(opts.allowedDomains.map((d) => d.toLowerCase()))
+        ? opts.allowedDomains.map(normalize)
         : null;
       const blocked = opts.blockedDomains
-        ? new Set(opts.blockedDomains.map((d) => d.toLowerCase()))
+        ? opts.blockedDomains.map(normalize)
         : null;
 
       return (data.web?.results ?? [])
         .filter((r) => {
           try {
             const host = new URL(r.url).hostname.toLowerCase();
-            if (allowed && !Array.from(allowed).some((d) => host.endsWith(d))) {
+            if (allowed && !allowed.some((d) => matchesDomain(host, d))) {
               return false;
             }
-            if (blocked && Array.from(blocked).some((d) => host.endsWith(d))) {
+            if (blocked && blocked.some((d) => matchesDomain(host, d))) {
               return false;
             }
             return true;

--- a/src/server/utils/webSearch/providers/brave.ts
+++ b/src/server/utils/webSearch/providers/brave.ts
@@ -1,0 +1,109 @@
+import {
+  WebSearchError,
+  WebSearchOptions,
+  WebSearchProvider,
+  WebSearchResult,
+} from "../types";
+
+interface BraveResponse {
+  web?: {
+    results?: Array<{
+      title: string;
+      url: string;
+      description: string;
+      page_age?: string;
+    }>;
+  };
+}
+
+export class BraveSearchProvider implements WebSearchProvider {
+  readonly name = "brave";
+
+  constructor(
+    private readonly apiKey: string,
+    private readonly timeoutMs: number,
+  ) {}
+
+  async search(
+    query: string,
+    opts: WebSearchOptions,
+  ): Promise<WebSearchResult[]> {
+    if (!query || query.length === 0) {
+      throw new WebSearchError("Empty query", "invalid_input");
+    }
+    if (query.length > 400) {
+      throw new WebSearchError("Query too long", "query_too_long");
+    }
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    const params = new URLSearchParams({
+      q: query,
+      count: String(Math.min(opts.maxResults, 20)),
+    });
+
+    try {
+      const res = await fetch(
+        `https://api.search.brave.com/res/v1/web/search?${params.toString()}`,
+        {
+          headers: {
+            Accept: "application/json",
+            "X-Subscription-Token": this.apiKey,
+          },
+          signal: controller.signal,
+        },
+      );
+
+      if (res.status === 429) {
+        throw new WebSearchError("Rate limited", "too_many_requests");
+      }
+      if (!res.ok) {
+        throw new WebSearchError(`Brave returned ${res.status}`, "unavailable");
+      }
+
+      const data = (await res.json()) as BraveResponse;
+      const allowed = opts.allowedDomains
+        ? new Set(opts.allowedDomains.map((d) => d.toLowerCase()))
+        : null;
+      const blocked = opts.blockedDomains
+        ? new Set(opts.blockedDomains.map((d) => d.toLowerCase()))
+        : null;
+
+      return (data.web?.results ?? [])
+        .filter((r) => {
+          try {
+            const host = new URL(r.url).hostname.toLowerCase();
+            if (allowed && !Array.from(allowed).some((d) => host.endsWith(d))) {
+              return false;
+            }
+            if (blocked && Array.from(blocked).some((d) => host.endsWith(d))) {
+              return false;
+            }
+            return true;
+          } catch {
+            return false;
+          }
+        })
+        .map((r) => ({
+          title: r.title,
+          url: r.url,
+          snippet: r.description,
+          publishedDate: r.page_age,
+        }));
+    } catch (err) {
+      if (err instanceof WebSearchError) {
+        throw err;
+      }
+      if ((err as Error).name === "AbortError") {
+        throw new WebSearchError("Search timed out", "unavailable");
+      }
+      throw new WebSearchError(
+        (err as Error).message || "Unknown search error",
+        "unavailable",
+      );
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}

--- a/src/server/utils/webSearch/providers/tavily.ts
+++ b/src/server/utils/webSearch/providers/tavily.ts
@@ -1,0 +1,93 @@
+import {
+  WebSearchError,
+  WebSearchOptions,
+  WebSearchProvider,
+  WebSearchResult,
+} from "../types";
+
+interface TavilyResponse {
+  results?: Array<{
+    title: string;
+    url: string;
+    content: string;
+    score?: number;
+    published_date?: string;
+  }>;
+  error?: string;
+}
+
+export class TavilyProvider implements WebSearchProvider {
+  readonly name = "tavily";
+
+  constructor(
+    private readonly apiKey: string,
+    private readonly timeoutMs: number,
+  ) {}
+
+  async search(
+    query: string,
+    opts: WebSearchOptions,
+  ): Promise<WebSearchResult[]> {
+    if (!query || query.length === 0) {
+      throw new WebSearchError("Empty query", "invalid_input");
+    }
+    if (query.length > 400) {
+      throw new WebSearchError("Query too long", "query_too_long");
+    }
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    try {
+      const res = await fetch("https://api.tavily.com/search", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${this.apiKey}`,
+        },
+        body: JSON.stringify({
+          query,
+          max_results: Math.min(opts.maxResults, 20),
+          include_domains: opts.allowedDomains,
+          exclude_domains: opts.blockedDomains,
+          search_depth: "basic",
+        }),
+        signal: controller.signal,
+      });
+
+      if (res.status === 429) {
+        throw new WebSearchError("Rate limited", "too_many_requests");
+      }
+      if (!res.ok) {
+        throw new WebSearchError(
+          `Tavily returned ${res.status}`,
+          "unavailable",
+        );
+      }
+
+      const data = (await res.json()) as TavilyResponse;
+      if (data.error) {
+        throw new WebSearchError(data.error, "unavailable");
+      }
+      return (data.results ?? []).map((r) => ({
+        title: r.title,
+        url: r.url,
+        snippet: r.content,
+        publishedDate: r.published_date,
+      }));
+    } catch (err) {
+      if (err instanceof WebSearchError) {
+        throw err;
+      }
+      if ((err as Error).name === "AbortError") {
+        throw new WebSearchError("Search timed out", "unavailable");
+      }
+      throw new WebSearchError(
+        (err as Error).message || "Unknown search error",
+        "unavailable",
+      );
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}

--- a/src/server/utils/webSearch/synth.ts
+++ b/src/server/utils/webSearch/synth.ts
@@ -1,0 +1,88 @@
+import Anthropic from "@anthropic-ai/sdk";
+
+import { WebSearchError, WebSearchResult } from "./types";
+
+let counter = 0;
+const newId = () =>
+  `srvtoolu_${Date.now().toString(36)}_${(counter++).toString(36)}`;
+
+export const newServerToolUseId = newId;
+
+/**
+ * Build the `server_tool_use` content block that Anthropic emits when its
+ * backend calls web_search internally.
+ */
+export const buildServerToolUseBlock = (
+  query: string,
+  id: string = newId(),
+): Anthropic.Messages.ServerToolUseBlock => ({
+  type: "server_tool_use",
+  id,
+  name: "web_search",
+  input: { query },
+});
+
+/**
+ * Wrap our search results into the `web_search_tool_result` block shape
+ * Anthropic returns. `encrypted_content` is opaque to the client — Claude Code
+ * never feeds it back to a real Anthropic backend, only to us — so we use a
+ * deterministic base64 payload.
+ */
+export const buildWebSearchResultBlock = (
+  toolUseId: string,
+  results: WebSearchResult[],
+): Anthropic.Messages.WebSearchToolResultBlock => ({
+  type: "web_search_tool_result",
+  tool_use_id: toolUseId,
+  content: results.map((r) => ({
+    type: "web_search_result",
+    url: r.url,
+    title: r.title,
+    encrypted_content: Buffer.from(
+      JSON.stringify({ snippet: r.snippet, url: r.url, title: r.title }),
+    ).toString("base64"),
+    page_age: r.publishedDate ?? null,
+  })),
+});
+
+export const buildWebSearchErrorBlock = (
+  toolUseId: string,
+  err: unknown,
+): Anthropic.Messages.WebSearchToolResultBlock => {
+  const code = err instanceof WebSearchError ? err.code : "unavailable";
+  return {
+    type: "web_search_tool_result",
+    tool_use_id: toolUseId,
+    content: {
+      type: "web_search_tool_result_error",
+      error_code: code,
+    },
+  } as Anthropic.Messages.WebSearchToolResultBlock;
+};
+
+/**
+ * Render results as plain text for the model's next turn (separate from the
+ * on-the-wire `web_search_tool_result` block, which is for the client).
+ */
+export const renderResultsAsToolResultText = (
+  results: WebSearchResult[],
+): string => {
+  if (results.length === 0) {
+    return "No results.";
+  }
+  return results
+    .map(
+      (r, i) =>
+        `[${i + 1}] ${r.title}\n${r.url}${
+          r.publishedDate ? ` (${r.publishedDate})` : ""
+        }\n${r.snippet}`,
+    )
+    .join("\n\n");
+};
+
+export const renderErrorAsToolResultText = (err: unknown): string => {
+  if (err instanceof WebSearchError) {
+    return `Search failed: ${err.code} (${err.message})`;
+  }
+  return `Search failed: ${(err as Error).message ?? "unknown error"}`;
+};

--- a/src/server/utils/webSearch/types.ts
+++ b/src/server/utils/webSearch/types.ts
@@ -1,0 +1,32 @@
+export interface WebSearchResult {
+  title: string;
+  url: string;
+  snippet: string;
+  publishedDate?: string;
+}
+
+export interface WebSearchOptions {
+  maxResults: number;
+  allowedDomains?: string[];
+  blockedDomains?: string[];
+}
+
+export interface WebSearchProvider {
+  readonly name: string;
+  search(query: string, opts: WebSearchOptions): Promise<WebSearchResult[]>;
+}
+
+export class WebSearchError extends Error {
+  constructor(
+    message: string,
+    public code:
+      | "too_many_requests"
+      | "invalid_input"
+      | "max_uses_exceeded"
+      | "query_too_long"
+      | "unavailable",
+  ) {
+    super(message);
+    this.name = "WebSearchError";
+  }
+}

--- a/src/server/utils/webSearchLoop.ts
+++ b/src/server/utils/webSearchLoop.ts
@@ -15,7 +15,11 @@ import {
   renderErrorAsToolResultText,
   renderResultsAsToolResultText,
 } from "./webSearch/synth";
-import { WebSearchProvider, WebSearchResult } from "./webSearch/types";
+import {
+  WebSearchError,
+  WebSearchProvider,
+  WebSearchResult,
+} from "./webSearch/types";
 
 export interface WebSearchTurnEvent {
   /**
@@ -153,10 +157,15 @@ export const runWebSearchLoop = async ({
         return { webSearchRequests, used };
       }
 
-      const query = String((call.input as { query?: unknown }).query ?? "");
+      const rawInput =
+        typeof call.input === "object" && call.input !== null
+          ? (call.input as { query?: unknown })
+          : null;
+      const query = String(rawInput?.query ?? "").trim();
       const srvToolUseId = newServerToolUseId();
 
-      // Surface server_tool_use block
+      // Surface server_tool_use block (always, even on guard failure, so the
+      // client can correlate our tool_use_id with the upcoming result block).
       await onWebSearchBlock({
         block: buildServerToolUseBlock(query, srvToolUseId),
       });
@@ -165,15 +174,22 @@ export const runWebSearchLoop = async ({
       let results: WebSearchResult[] = [];
       let errored = false;
 
-      if (webSearchRequests >= budget) {
+      if (!query) {
+        const err = new WebSearchError("Empty query", "invalid_input");
         await onWebSearchBlock({
-          block: buildWebSearchErrorBlock(srvToolUseId, {
-            name: "WebSearchError",
-            message: "Per-request budget exhausted",
-            code: "max_uses_exceeded",
-          } as unknown as Error),
+          block: buildWebSearchErrorBlock(srvToolUseId, err),
         });
-        resultText = "Search quota exhausted for this request.";
+        resultText = renderErrorAsToolResultText(err);
+        errored = true;
+      } else if (webSearchRequests >= budget) {
+        const err = new WebSearchError(
+          "Per-request budget exhausted",
+          "max_uses_exceeded",
+        );
+        await onWebSearchBlock({
+          block: buildWebSearchErrorBlock(srvToolUseId, err),
+        });
+        resultText = renderErrorAsToolResultText(err);
         errored = true;
       } else {
         webSearchRequests++;

--- a/src/server/utils/webSearchLoop.ts
+++ b/src/server/utils/webSearchLoop.ts
@@ -1,0 +1,227 @@
+import Anthropic from "@anthropic-ai/sdk";
+import * as vscode from "vscode";
+
+import { logger } from "../../utils/logger";
+import {
+  WEB_SEARCH_TOOL_NAME,
+  WebSearchConfig,
+  isWebSearchToolDefinition,
+} from "./webSearch";
+import {
+  buildServerToolUseBlock,
+  buildWebSearchErrorBlock,
+  buildWebSearchResultBlock,
+  newServerToolUseId,
+  renderErrorAsToolResultText,
+  renderResultsAsToolResultText,
+} from "./webSearch/synth";
+import { WebSearchProvider, WebSearchResult } from "./webSearch/types";
+
+export interface WebSearchTurnEvent {
+  /**
+   * Synthetic Anthropic content block to surface to the client. The caller is
+   * responsible for emitting this either as part of `content[]` (non-streaming)
+   * or as `content_block_start`/`content_block_stop` SSE events (streaming).
+   */
+  block: Anthropic.Messages.ContentBlock;
+}
+
+export interface RunWebSearchLoopParams {
+  client: vscode.LanguageModelChat;
+  initialMessages: vscode.LanguageModelChatMessage[];
+  initialOptions: vscode.LanguageModelChatRequestOptions;
+  cancellationToken: vscode.CancellationToken;
+  cfg: WebSearchConfig;
+  provider: WebSearchProvider;
+  tools: Anthropic.Messages.ToolUnion[] | undefined;
+  /**
+   * Called for each chunk produced by the model — text/tool_use parts that
+   * are NOT our internal web_search call. The caller renders these normally.
+   */
+  onModelChunk: (
+    chunk: vscode.LanguageModelTextPart | vscode.LanguageModelToolCallPart,
+  ) => Promise<void>;
+  /**
+   * Called when the loop produces a synthesized server_tool_use or
+   * web_search_tool_result block (i.e. we executed a search ourselves).
+   */
+  onWebSearchBlock: (event: WebSearchTurnEvent) => Promise<void>;
+}
+
+export interface WebSearchLoopResult {
+  webSearchRequests: number;
+  /** True if we executed at least one search (caller may want to expose in usage). */
+  used: boolean;
+}
+
+/**
+ * Runs a multi-turn loop with the VS Code Language Model: when the model calls
+ * `web_search`, we execute it ourselves, feed the results back as a
+ * tool_result, and re-issue the request. We surface the synthesized
+ * `server_tool_use` and `web_search_tool_result` blocks to the caller so they
+ * can be emitted to the client in Anthropic protocol shape.
+ *
+ * The loop terminates when the model produces a turn with no further
+ * web_search calls, when the per-request budget is exhausted, or on cancel.
+ */
+export const runWebSearchLoop = async ({
+  client,
+  initialMessages,
+  initialOptions,
+  cancellationToken,
+  cfg,
+  provider,
+  tools,
+  onModelChunk,
+  onWebSearchBlock,
+}: RunWebSearchLoopParams): Promise<WebSearchLoopResult> => {
+  const wsTool = (tools ?? []).find(isWebSearchToolDefinition) as
+    | (Anthropic.Messages.WebSearchTool20250305 & { max_uses?: number })
+    | undefined;
+  const requestedMaxUses = wsTool?.max_uses;
+  const budget = Math.min(
+    typeof requestedMaxUses === "number"
+      ? requestedMaxUses
+      : cfg.maxUsesPerRequest,
+    cfg.maxUsesPerRequest,
+  );
+  const allowedDomains = wsTool?.allowed_domains ?? undefined;
+  const blockedDomains = wsTool?.blocked_domains ?? undefined;
+
+  let messages = initialMessages;
+  let webSearchRequests = 0;
+  let used = false;
+
+  // Hard ceiling on loop iterations as a safety net beyond the per-request
+  // budget — covers degenerate cases where the model never stops calling.
+  const HARD_TURN_CEILING = budget + 2;
+
+  for (let turn = 0; turn < HARD_TURN_CEILING; turn++) {
+    if (cancellationToken.isCancellationRequested) {
+      break;
+    }
+
+    const response = await client.sendRequest(
+      messages,
+      initialOptions,
+      cancellationToken,
+    );
+
+    /**
+     * For each model chunk, if it's a web_search call we capture it; otherwise
+     * we forward it to the caller. We need to collect ALL text + tool calls
+     * from this turn before deciding whether to loop, because the model can
+     * mix text with tool calls.
+     */
+    const turnTextParts: vscode.LanguageModelTextPart[] = [];
+    const turnToolCalls: vscode.LanguageModelToolCallPart[] = [];
+    let turnHadWebSearch = false;
+
+    for await (const chunk of response.stream) {
+      if (chunk instanceof vscode.LanguageModelTextPart) {
+        turnTextParts.push(chunk);
+        await onModelChunk(chunk);
+      } else if (chunk instanceof vscode.LanguageModelToolCallPart) {
+        if (chunk.name === WEB_SEARCH_TOOL_NAME) {
+          turnHadWebSearch = true;
+          turnToolCalls.push(chunk);
+          // Don't forward — we'll synthesize server_tool_use blocks instead.
+        } else {
+          turnToolCalls.push(chunk);
+          await onModelChunk(chunk);
+        }
+      }
+    }
+
+    if (!turnHadWebSearch) {
+      // Model is done with web_search for this conversation.
+      break;
+    }
+
+    // Execute every web_search call from this turn and synthesize blocks.
+    const toolResultParts: vscode.LanguageModelToolResultPart[] = [];
+
+    for (const call of turnToolCalls) {
+      if (call.name !== WEB_SEARCH_TOOL_NAME) {
+        // Non-web_search tool calls in the same turn cannot be auto-resolved
+        // here; the client must answer them. Stop the loop and let the caller
+        // surface them. (This is a corner case — typically web_search turns
+        // don't include other tool calls.)
+        logger.warn(
+          `web_search loop: encountered non-web_search tool call '${call.name}' in same turn — stopping loop and surfacing to client`,
+        );
+        return { webSearchRequests, used };
+      }
+
+      const query = String((call.input as { query?: unknown }).query ?? "");
+      const srvToolUseId = newServerToolUseId();
+
+      // Surface server_tool_use block
+      await onWebSearchBlock({
+        block: buildServerToolUseBlock(query, srvToolUseId),
+      });
+
+      let resultText: string;
+      let results: WebSearchResult[] = [];
+      let errored = false;
+
+      if (webSearchRequests >= budget) {
+        await onWebSearchBlock({
+          block: buildWebSearchErrorBlock(srvToolUseId, {
+            name: "WebSearchError",
+            message: "Per-request budget exhausted",
+            code: "max_uses_exceeded",
+          } as unknown as Error),
+        });
+        resultText = "Search quota exhausted for this request.";
+        errored = true;
+      } else {
+        webSearchRequests++;
+        used = true;
+        try {
+          results = await provider.search(query, {
+            maxResults: cfg.maxResults,
+            allowedDomains,
+            blockedDomains,
+          });
+          await onWebSearchBlock({
+            block: buildWebSearchResultBlock(srvToolUseId, results),
+          });
+          resultText = renderResultsAsToolResultText(results);
+        } catch (err) {
+          await onWebSearchBlock({
+            block: buildWebSearchErrorBlock(srvToolUseId, err),
+          });
+          resultText = renderErrorAsToolResultText(err);
+          errored = true;
+          logger.warn(
+            `web_search call failed: ${(err as Error).message ?? err}`,
+          );
+        }
+      }
+
+      toolResultParts.push(
+        new vscode.LanguageModelToolResultPart(call.callId, [
+          new vscode.LanguageModelTextPart(resultText),
+        ]),
+      );
+
+      if (errored && webSearchRequests >= budget) {
+        // No point continuing — feed back what we have and let the model wrap up.
+      }
+    }
+
+    // Build the next-turn messages: prior messages + assistant turn (text +
+    // tool_use parts) + user turn (tool_result parts).
+    const assistantParts: Array<
+      vscode.LanguageModelTextPart | vscode.LanguageModelToolCallPart
+    > = [...turnTextParts, ...turnToolCalls];
+    messages = [
+      ...messages,
+      vscode.LanguageModelChatMessage.Assistant(assistantParts),
+      vscode.LanguageModelChatMessage.User(toolResultParts),
+    ];
+  }
+
+  return { webSearchRequests, used };
+};

--- a/src/test/server/webSearchSynth.test.ts
+++ b/src/test/server/webSearchSynth.test.ts
@@ -1,0 +1,95 @@
+import * as assert from "assert";
+
+import {
+  buildServerToolUseBlock,
+  buildWebSearchErrorBlock,
+  buildWebSearchResultBlock,
+  renderErrorAsToolResultText,
+  renderResultsAsToolResultText,
+} from "../../server/utils/webSearch/synth";
+import { WebSearchError } from "../../server/utils/webSearch/types";
+
+suite("webSearch synth", () => {
+  test("buildServerToolUseBlock has correct shape", () => {
+    const block = buildServerToolUseBlock("hello world", "srvtoolu_x");
+    assert.strictEqual(block.type, "server_tool_use");
+    assert.strictEqual(block.id, "srvtoolu_x");
+    assert.strictEqual(block.name, "web_search");
+    assert.deepStrictEqual(block.input, { query: "hello world" });
+  });
+
+  test("buildWebSearchResultBlock wraps results", () => {
+    const block = buildWebSearchResultBlock("srvtoolu_y", [
+      { title: "T1", url: "https://example.com/a", snippet: "S1" },
+      {
+        title: "T2",
+        url: "https://example.com/b",
+        snippet: "S2",
+        publishedDate: "2026-01-01",
+      },
+    ]);
+    assert.strictEqual(block.type, "web_search_tool_result");
+    assert.strictEqual(block.tool_use_id, "srvtoolu_y");
+    assert.ok(Array.isArray(block.content));
+    const content = block.content as Array<{
+      type: string;
+      url: string;
+      title: string;
+      page_age: string | null;
+      encrypted_content: string;
+    }>;
+    assert.strictEqual(content.length, 2);
+    assert.strictEqual(content[0].type, "web_search_result");
+    assert.strictEqual(content[0].url, "https://example.com/a");
+    assert.strictEqual(content[0].page_age, null);
+    assert.strictEqual(content[1].page_age, "2026-01-01");
+    assert.ok(
+      content[0].encrypted_content.length > 0,
+      "encrypted_content should be populated",
+    );
+  });
+
+  test("buildWebSearchErrorBlock encodes WebSearchError code", () => {
+    const block = buildWebSearchErrorBlock(
+      "srvtoolu_z",
+      new WebSearchError("over budget", "max_uses_exceeded"),
+    );
+    assert.strictEqual(block.type, "web_search_tool_result");
+    const content = block.content as {
+      type: string;
+      error_code: string;
+    };
+    assert.strictEqual(content.type, "web_search_tool_result_error");
+    assert.strictEqual(content.error_code, "max_uses_exceeded");
+  });
+
+  test("buildWebSearchErrorBlock falls back to 'unavailable' for plain errors", () => {
+    const block = buildWebSearchErrorBlock("srvtoolu_z", new Error("oops"));
+    const content = block.content as {
+      type: string;
+      error_code: string;
+    };
+    assert.strictEqual(content.error_code, "unavailable");
+  });
+
+  test("renderResultsAsToolResultText renders empty as 'No results.'", () => {
+    assert.strictEqual(renderResultsAsToolResultText([]), "No results.");
+  });
+
+  test("renderResultsAsToolResultText numbers + includes urls", () => {
+    const text = renderResultsAsToolResultText([
+      { title: "T1", url: "https://e/a", snippet: "S1" },
+      { title: "T2", url: "https://e/b", snippet: "S2" },
+    ]);
+    assert.ok(text.includes("[1] T1"));
+    assert.ok(text.includes("[2] T2"));
+    assert.ok(text.includes("https://e/a"));
+  });
+
+  test("renderErrorAsToolResultText surfaces WebSearchError code", () => {
+    const text = renderErrorAsToolResultText(
+      new WebSearchError("ratelimit hit", "too_many_requests"),
+    );
+    assert.ok(text.includes("too_many_requests"));
+  });
+});


### PR DESCRIPTION
> **Stacked on #167** — that PR fixes the hang/400 by dropping web_search; this PR adds an opt-in path that actually makes WebSearch work. Please review #167 first; this PR's diff is most readable once #167 is merged.

## Summary

When `agent-maestro.webSearch.enabled` is true and an apiKey is configured, the proxy intercepts Anthropic's `web_search_20250305` server-side tool, runs the query against a third-party search backend (Tavily by default, Brave optional), and synthesizes the `server_tool_use` + `web_search_tool_result` content blocks Anthropic's backend would have returned. The result: WebSearch in Claude Code (or any Anthropic-compatible client) actually works through the proxy instead of being dropped.

When disabled (the default), behavior is identical to #167 — web_search tool definitions are dropped with a warning. **No new dependencies, no extra prompt overhead, no behavior change for users who don't opt in.**

## How it works

1. **Tool exposure** — when active, `convertAnthropicToolToVSCode` rewrites the client's `web_search_20250305` tool into a regular VS Code custom tool named `web_search` with input schema `{ query: string }` (no overhead unless the model decides to call it).

2. **Loop runner** (`webSearchLoop.ts`) — drives a multi-turn conversation with the VS Code LM:
   - Iterate over the model's stream chunks, forwarding text / regular-tool calls to the caller as usual.
   - When the model emits a `web_search` tool call, capture it without forwarding.
   - Execute the search via the provider, build a `web_search_tool_result` block, surface it to the caller.
   - Feed the result text back to the LM as a `tool_result`, re-issue `sendRequest`, and continue until the model stops calling web_search.

3. **Block synthesis** (`webSearch/synth.ts`) — produces the on-the-wire Anthropic shape: `server_tool_use` (with stable `srvtoolu_*` ids) and `web_search_tool_result` blocks (with `encrypted_content` as opaque base64). Errors map to `web_search_tool_result_error` with the appropriate `error_code` (`too_many_requests`, `max_uses_exceeded`, `invalid_input`, `query_too_long`, `unavailable`).

4. **Routes integration** — both streaming and non-streaming paths use the loop. SSE emits proper `content_block_start` / `content_block_stop` for the synthetic blocks. `usage.server_tool_use.web_search_requests` is reported.

## Acceptance preempts

I'm aware PR #157 was closed for scope reasons. This PR is framed to address that concern:

- **Bug-class motivation, not feature creep.** Claude Code ships WebSearch by default; without this, the proxy either crashes (#163) or makes WebSearch silently dead. PR-A (#167) restores baseline; this PR restores the actual user-visible feature.
- **Off by default, zero overhead when off.** Users who don't enable it pay nothing — no extra tool exposed to the model, no prompt augmentation, behavior identical to #167.
- **Pluggable backend.** Users pick their own search provider; the project doesn't endorse one. Adding a new provider is one file under `src/server/utils/webSearch/providers/`.
- **No new runtime deps.** Uses the global `fetch` already required by Node 22+.

## Configuration

| Setting | Default | Description |
|---|---|---|
| `agent-maestro.webSearch.enabled` | `false` | Master switch |
| `agent-maestro.webSearch.provider` | `"tavily"` | One of `tavily` / `brave` |
| `agent-maestro.webSearch.apiKey` | `""` | Or via `AGENT_MAESTRO_WEBSEARCH_API_KEY` env |
| `agent-maestro.webSearch.maxResults` | `5` | Per-query result cap |
| `agent-maestro.webSearch.maxUsesPerRequest` | `5` | Hard cap regardless of client's `max_uses` |
| `agent-maestro.webSearch.timeoutMs` | `8000` | Per-search HTTP timeout |

## Tests

- `webSearchSynth.test.ts` — unit tests for `server_tool_use` / `web_search_tool_result` shape, error code mapping, text rendering.
- Existing `anthropic.test.ts` keeps the drop-behavior tests from #167 intact (and verifies the `webSearchActive: false` path is identical to PR-A behavior).

`pnpm exec tsc --noEmit` passes; `pnpm exec eslint` clean on all changed files.

## Open questions for the maintainer

1. **Default provider.** Tavily is the lowest-friction option (1k free searches/mo, single-field signup). Open to shipping with no default and documenting both, if you'd rather not bless one.
2. **API key storage.** Currently in plain settings.json + env override. Happy to migrate to `vscode.SecretStorage` if preferred (parity with existing settings was the call here).
3. **Citations.** Not implemented in v1 — the protocol's `web_search_result_location` citation event has under-documented streaming shape. Most clients (including Claude Code) render fine without inline citations because the URL set is in the `web_search_tool_result` block. Open to adding URL-match best-effort citations in a follow-up.
4. **Multi-turn conversation history.** Prior-turn `web_search_tool_result` blocks already roundtrip cleanly because `convertContentToVSCodeParts` (existing code) handles `server_tool_use` / `web_search_tool_result` block types. Verified by inspection; would appreciate a sanity check.

## Test plan

- [ ] `pnpm test` passes
- [ ] Manual: enable in settings with a Tavily key, ask Claude Code to "search the web for X" — see `server_tool_use` and `web_search_tool_result` blocks render in the conversation, model uses results to answer.
- [ ] Manual: `max_uses` budget honored (set `maxUsesPerRequest=1`, ask a question requiring multiple searches — second call returns `max_uses_exceeded`).
- [ ] Manual: `allowed_domains` / `blocked_domains` from request honored.
- [ ] Manual: with feature disabled, behavior identical to #167 (drop + warn).

## Related

- Builds on #167 (drop unsupported server-side tools)
- Closes the user-visible part of #163 / #150 (WebSearch actually works, not just stops hanging)
