### PR TITLE
fix(anthropic): handle image blocks inside tool_result content

### DIFF
--- a/.changeset/fix-tool-result-image-blocks.md
+++ b/.changeset/fix-tool-result-image-blocks.md
@@ -1,0 +1,7 @@
+---
+"agent-maestro": patch
+---
+
+fix: convert image blocks inside Anthropic tool_result content arrays
+
+`toolResultBlockParamToVSCodePart` previously stringified non-text blocks via `JSON.stringify(c)`. When a tool result contains an image (e.g. Claude Code's Read tool returning a binary image file), the base64 payload was sent to the underlying Language Model as a JSON-serialized string instead of a `LanguageModelDataPart`, causing the model to hallucinate image content. Top-level user-message images were already handled correctly via `imageBlockParamToVSCodePart`; this PR routes tool_result images through the same converter.

--- a/scripts/test-vision.ts
+++ b/scripts/test-vision.ts
@@ -15,8 +15,13 @@ import os from "os";
 import path from "path";
 import { parse } from "smol-toml";
 
-type ApiType = "chat" | "responses" | "anthropic";
-const ALL_APIS: ApiType[] = ["chat", "responses", "anthropic"];
+type ApiType = "chat" | "responses" | "anthropic" | "anthropic-tool-result";
+const ALL_APIS: ApiType[] = [
+  "chat",
+  "responses",
+  "anthropic",
+  "anthropic-tool-result",
+];
 
 const DEFAULT_PORT = 23333;
 const DEFAULT_MODEL = "gpt-5.1";
@@ -47,11 +52,16 @@ function parseArgs(): { apis: ApiType[]; imagePath: string } {
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--api" && args[i + 1]) {
       const val = args[++i];
-      if (val === "chat" || val === "responses" || val === "anthropic") {
+      if (
+        val === "chat" ||
+        val === "responses" ||
+        val === "anthropic" ||
+        val === "anthropic-tool-result"
+      ) {
         api = val;
       } else {
         console.error(
-          `Unknown API type: ${val}. Use chat, responses, or anthropic.`,
+          `Unknown API type: ${val}. Use chat, responses, anthropic, or anthropic-tool-result.`,
         );
         process.exit(1);
       }
@@ -62,7 +72,7 @@ function parseArgs(): { apis: ApiType[]; imagePath: string } {
 
   if (!imagePath) {
     console.error(
-      "Usage: npx tsx scripts/test-vision.ts [--api chat|responses|anthropic] <image-path>",
+      "Usage: npx tsx scripts/test-vision.ts [--api chat|responses|anthropic|anthropic-tool-result] <image-path>",
     );
     process.exit(1);
   }
@@ -133,6 +143,61 @@ function buildAnthropicRequest(
   };
 }
 
+// Mimics what Claude Code's Read tool produces: an assistant turn calls a
+// tool, then the user turn delivers the tool result containing an image block.
+// Exercises the tool_result.content path in convertAnthropicMessagesToVSCode.
+function buildAnthropicToolResultRequest(
+  model: string,
+  mimeType: string,
+  base64: string,
+) {
+  return {
+    url: "/api/anthropic/v1/messages",
+    headers: { "x-api-key": "test", "anthropic-version": "2023-06-01" },
+    body: {
+      model,
+      max_tokens: 1024,
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "Read the attached image." }],
+        },
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool_use",
+              id: "toolu_test_read_image",
+              name: "Read",
+              input: { file_path: "/tmp/test.png" },
+            },
+          ],
+        },
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "toolu_test_read_image",
+              content: [
+                {
+                  type: "image",
+                  source: {
+                    type: "base64",
+                    media_type: mimeType,
+                    data: base64,
+                  },
+                },
+              ],
+            },
+            { type: "text", text: PROMPT },
+          ],
+        },
+      ],
+    },
+  };
+}
+
 async function runApi(
   api: ApiType,
   model: string,
@@ -160,6 +225,13 @@ async function runApi(
     }
     case "anthropic": {
       const req = buildAnthropicRequest(model, mimeType, base64);
+      url = req.url;
+      body = req.body;
+      extraHeaders = req.headers;
+      break;
+    }
+    case "anthropic-tool-result": {
+      const req = buildAnthropicToolResultRequest(model, mimeType, base64);
       url = req.url;
       body = req.body;
       extraHeaders = req.headers;

--- a/src/server/utils/anthropic.ts
+++ b/src/server/utils/anthropic.ts
@@ -53,7 +53,9 @@ const toolResultBlockParamToVSCodePart = (
       : param.content.map((c) =>
           c.type === "text"
             ? textBlockParamToVSCodePart(c)
-            : new vscode.LanguageModelTextPart(JSON.stringify(c)),
+            : c.type === "image"
+              ? imageBlockParamToVSCodePart(c)
+              : new vscode.LanguageModelTextPart(JSON.stringify(c)),
         );
   return new vscode.LanguageModelToolResultPart(param.tool_use_id, content);
 };


### PR DESCRIPTION
## Summary

`toolResultBlockParamToVSCodePart` in `src/server/utils/anthropic.ts` falls back to `JSON.stringify(c)` for any `tool_result.content` element that isn't a text block. When the tool result contains an image block (e.g. Claude Code's Read tool returning a binary image file), the base64 payload is delivered to the underlying Language Model as a serialized JSON string instead of a `LanguageModelDataPart`. The model receives no actual image data and hallucinates content.

This PR mirrors the routing already used for top-level user-message image blocks (line 119): when `c.type === "image"`, run it through `imageBlockParamToVSCodePart`, which produces a proper `LanguageModelDataPart`.

Reproduces in real use with `claude` (Claude Code CLI) → Maestro → backend LM: ask Claude to Read a local image file, observe completely fabricated descriptions on every retry (different hallucination each time, confirming the image bytes never reach the model).

## Test plan

- Added an `anthropic-tool-result` mode to `scripts/test-vision.ts` that constructs a request shaped like Claude Code's actual `tool_use` → `tool_result(image)` sequence, exercising the previously untested path.
  ```
  npx tsx scripts/test-vision.ts --api anthropic-tool-result <image-path>
  ```
  Without this fix the model returns a generic / hallucinated description; with the fix it describes the actual image.
- The change itself is a single ternary branch added by symmetry with the existing top-level image handling — no other paths affected.
- Includes a changeset entry.

## Related

Same category as #155 (image support in Chat Completions route), but for the Anthropic Messages route's `tool_result.content` array specifically — this path isn't exercised by the existing `--api anthropic` test, which only sends a top-level user image block.