### PR TITLE
fix(anthropic): handle image blocks inside tool_result content

### DIFF
--- a/.changeset/fix-anthropic-tool-result-image.md
+++ b/.changeset/fix-anthropic-tool-result-image.md
@@ -1,0 +1,7 @@
+---
+"agent-maestro": patch
+---
+
+fix: handle image blocks inside Anthropic `tool_result` content arrays
+
+`toolResultBlockParamToVSCodePart` previously stringified non-text content blocks via `JSON.stringify(c)`. When a tool_result contains an image (e.g. Claude Code's `Read` tool returning a binary image file), the base64 payload reached the Language Model as serialized JSON text instead of a `LanguageModelDataPart`, causing the model to receive no image data and hallucinate. Top-level user-message images were already routed correctly via `imageBlockParamToVSCodePart`; this change uses the same converter for tool_result images.

--- a/scripts/test-vision.ts
+++ b/scripts/test-vision.ts
@@ -6,6 +6,7 @@
  *   npx tsx scripts/test-vision.ts --api chat <image-path>            # chat completions only
  *   npx tsx scripts/test-vision.ts --api responses <image-path>       # responses only
  *   npx tsx scripts/test-vision.ts --api anthropic <image-path>       # anthropic messages only
+ *   npx tsx scripts/test-vision.ts --api anthropic-tool-result <image-path>  # anthropic tool_result(image) shape
  *
  * Reads model and base_url from ~/.codex/config.toml when available.
  * Make sure Agent Maestro extension is running with the proxy server active.

--- a/scripts/test-vision.ts
+++ b/scripts/test-vision.ts
@@ -15,8 +15,13 @@ import os from "os";
 import path from "path";
 import { parse } from "smol-toml";
 
-type ApiType = "chat" | "responses" | "anthropic";
-const ALL_APIS: ApiType[] = ["chat", "responses", "anthropic"];
+type ApiType = "chat" | "responses" | "anthropic" | "anthropic-tool-result";
+const ALL_APIS: ApiType[] = [
+  "chat",
+  "responses",
+  "anthropic",
+  "anthropic-tool-result",
+];
 
 const DEFAULT_PORT = 23333;
 const DEFAULT_MODEL = "gpt-5.1";
@@ -47,11 +52,16 @@ function parseArgs(): { apis: ApiType[]; imagePath: string } {
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--api" && args[i + 1]) {
       const val = args[++i];
-      if (val === "chat" || val === "responses" || val === "anthropic") {
+      if (
+        val === "chat" ||
+        val === "responses" ||
+        val === "anthropic" ||
+        val === "anthropic-tool-result"
+      ) {
         api = val;
       } else {
         console.error(
-          `Unknown API type: ${val}. Use chat, responses, or anthropic.`,
+          `Unknown API type: ${val}. Use chat, responses, anthropic, or anthropic-tool-result.`,
         );
         process.exit(1);
       }
@@ -62,7 +72,7 @@ function parseArgs(): { apis: ApiType[]; imagePath: string } {
 
   if (!imagePath) {
     console.error(
-      "Usage: npx tsx scripts/test-vision.ts [--api chat|responses|anthropic] <image-path>",
+      "Usage: npx tsx scripts/test-vision.ts [--api chat|responses|anthropic|anthropic-tool-result] <image-path>",
     );
     process.exit(1);
   }
@@ -133,6 +143,61 @@ function buildAnthropicRequest(
   };
 }
 
+// Mimics what Claude Code's Read tool produces: an assistant turn calls a
+// tool, then the user turn delivers the tool result containing an image block.
+// Exercises the tool_result.content path in convertAnthropicMessagesToVSCode.
+function buildAnthropicToolResultRequest(
+  model: string,
+  mimeType: string,
+  base64: string,
+) {
+  return {
+    url: "/api/anthropic/v1/messages",
+    headers: { "x-api-key": "test", "anthropic-version": "2023-06-01" },
+    body: {
+      model,
+      max_tokens: 1024,
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "Read the attached image." }],
+        },
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool_use",
+              id: "toolu_test_read_image",
+              name: "Read",
+              input: { file_path: "/tmp/test.png" },
+            },
+          ],
+        },
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "toolu_test_read_image",
+              content: [
+                {
+                  type: "image",
+                  source: {
+                    type: "base64",
+                    media_type: mimeType,
+                    data: base64,
+                  },
+                },
+              ],
+            },
+            { type: "text", text: PROMPT },
+          ],
+        },
+      ],
+    },
+  };
+}
+
 async function runApi(
   api: ApiType,
   model: string,
@@ -160,6 +225,13 @@ async function runApi(
     }
     case "anthropic": {
       const req = buildAnthropicRequest(model, mimeType, base64);
+      url = req.url;
+      body = req.body;
+      extraHeaders = req.headers;
+      break;
+    }
+    case "anthropic-tool-result": {
+      const req = buildAnthropicToolResultRequest(model, mimeType, base64);
       url = req.url;
       body = req.body;
       extraHeaders = req.headers;

--- a/src/server/utils/anthropic.ts
+++ b/src/server/utils/anthropic.ts
@@ -53,7 +53,9 @@ const toolResultBlockParamToVSCodePart = (
       : param.content.map((c) =>
           c.type === "text"
             ? textBlockParamToVSCodePart(c)
-            : new vscode.LanguageModelTextPart(JSON.stringify(c)),
+            : c.type === "image"
+              ? imageBlockParamToVSCodePart(c)
+              : new vscode.LanguageModelTextPart(JSON.stringify(c)),
         );
   return new vscode.LanguageModelToolResultPart(param.tool_use_id, content);
 };

--- a/src/test/server/anthropic.test.ts
+++ b/src/test/server/anthropic.test.ts
@@ -93,6 +93,99 @@ suite("Anthropic Conversion Utils Test Suite", () => {
       assert.strictEqual(result.role, vscode.LanguageModelChatMessageRole.User);
     });
 
+    test("should convert tool_result with image content block", () => {
+      const base64Data =
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
+      const message = {
+        role: "user" as const,
+        content: [
+          {
+            type: "tool_result" as const,
+            tool_use_id: "tool-456",
+            content: [
+              {
+                type: "image" as const,
+                source: {
+                  type: "base64" as const,
+                  media_type: "image/png" as const,
+                  data: base64Data,
+                },
+              },
+            ],
+          },
+        ],
+      };
+
+      const result = convertAnthropicMessageToVSCode(message);
+
+      assert.ok(!Array.isArray(result));
+      assert.strictEqual(result.role, vscode.LanguageModelChatMessageRole.User);
+      assert.strictEqual(result.content.length, 1);
+      const toolResultPart = result
+        .content[0] as vscode.LanguageModelToolResultPart;
+      assert.ok(toolResultPart instanceof vscode.LanguageModelToolResultPart);
+      assert.strictEqual(toolResultPart.callId, "tool-456");
+      assert.strictEqual(toolResultPart.content.length, 1);
+      // LanguageModelDataPart may not be available in the test environment,
+      // so the image part could be either a DataPart or a TextPart fallback.
+      // The key regression check is that it is NOT a JSON-stringified blob:
+      // before this fix, the image block was serialized via JSON.stringify(c)
+      // and the resulting TextPart's value started with `{"type":"image"`.
+      const imagePart = toolResultPart.content[0];
+      assert.ok(imagePart);
+      if (imagePart instanceof vscode.LanguageModelTextPart) {
+        assert.ok(
+          !imagePart.value.startsWith("{\"type\":\"image\""),
+          "image block should not be delivered as a JSON-stringified text blob",
+        );
+      }
+    });
+
+    test("should convert tool_result with mixed text and image content", () => {
+      const base64Data =
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
+      const message = {
+        role: "user" as const,
+        content: [
+          {
+            type: "tool_result" as const,
+            tool_use_id: "tool-789",
+            content: [
+              { type: "text" as const, text: "Here is the screenshot:" },
+              {
+                type: "image" as const,
+                source: {
+                  type: "base64" as const,
+                  media_type: "image/png" as const,
+                  data: base64Data,
+                },
+              },
+            ],
+          },
+        ],
+      };
+
+      const result = convertAnthropicMessageToVSCode(message);
+
+      assert.ok(!Array.isArray(result));
+      const toolResultPart = result
+        .content[0] as vscode.LanguageModelToolResultPart;
+      assert.strictEqual(toolResultPart.content.length, 2);
+      assert.ok(toolResultPart.content[0] instanceof vscode.LanguageModelTextPart);
+      assert.strictEqual(
+        (toolResultPart.content[0] as vscode.LanguageModelTextPart).value,
+        "Here is the screenshot:",
+      );
+      const imagePart = toolResultPart.content[1];
+      assert.ok(imagePart);
+      if (imagePart instanceof vscode.LanguageModelTextPart) {
+        assert.ok(
+          !imagePart.value.startsWith("{\"type\":\"image\""),
+          "image block should not be delivered as a JSON-stringified text blob",
+        );
+      }
+    });
+
     test("should handle thinking block", () => {
       const message = {
         role: "assistant" as const,


### PR DESCRIPTION
## Summary

`toolResultBlockParamToVSCodePart` in `src/server/utils/anthropic.ts` falls back to `JSON.stringify(c)` for any `tool_result.content` element that isn't a text block. When the tool result contains an image (e.g. Claude Code's `Read` tool returning a binary image file), the base64 payload reaches the underlying Language Model as a serialized JSON string instead of a `LanguageModelDataPart`. The model receives no actual image data and hallucinates the response.

This change mirrors the routing already used for top-level user-message image blocks: when `c.type === "image"`, route through `imageBlockParamToVSCodePart`, which produces a proper `LanguageModelDataPart`.

## Test plan

End-to-end verification with a deterministic ground-truth image:
- Generated a 64×64 PNG at runtime with four solid-color quadrants (top-left red, top-right green, bottom-left blue, bottom-right yellow).
- Asked Claude Code (via `ANTHROPIC_BASE_URL` pointing at Maestro) to `Read` the file and report each quadrant's color. This is exactly the path this PR fixes: `assistant` → `tool_use(Read)` → `user` → `tool_result` whose `content` contains an image block.

Without the fix: model produces a different fabricated description on every retry — image bytes never reach it.

With the fix:
```
- Top-left: red
- Top-right: green
- Bottom-left: blue
- Bottom-right: yellow
```
Exactly correct, deterministic across retries — confirming both that the conversion is structurally right and that the downstream VS Code Language Model API backend genuinely consumes the `LanguageModelDataPart`.

Adds an `anthropic-tool-result` mode to `scripts/test-vision.ts` that builds the same `tool_use → tool_result(image)` shape, so this path is covered going forward:
```
npx tsx scripts/test-vision.ts --api anthropic-tool-result <image-path>
```
The existing `--api anthropic` mode only sends a top-level user image block, so this code path was previously untested.

## Related

Same category as #155 (image support in Chat Completions route), but for the Anthropic Messages route's `tool_result.content` array.