### PR TITLE
fix(lm): pair Gemini tool calls without id and unwrap OpenAI system content

### DIFF
--- a/.changeset/fix-gemini-functionresponse-pairing.md
+++ b/.changeset/fix-gemini-functionresponse-pairing.md
@@ -1,0 +1,5 @@
+---
+"agent-maestro": patch
+---
+
+Fix multi-turn Gemini tool calls failing with `the number of function response parts is equal to the number of function call parts of the function call turn`. `langchain-google-genai` 4.x emits `functionResponse` parts with only `name` (no `id`), relying on Gemini's positional pairing rules; the previous strict id check dropped those parts entirely. The converter now walks all parts in document order, assigns a stable `callId` to every `functionCall`, and uses a per-name FIFO queue to recover the matching `callId` when a `functionResponse` arrives without one.

--- a/.changeset/fix-openai-system-content-array.md
+++ b/.changeset/fix-openai-system-content-array.md
@@ -1,0 +1,5 @@
+---
+"agent-maestro": patch
+---
+
+Fix `/v1/chat/completions` failing with `Unexpected chat message content type llm 2` when the OpenAI client sends a `system` or `developer` message whose content is an array of text blocks (deepagents, langchain-openai, etc. do this when splitting long system prompts). The converter previously mapped each block to a bare `{ value: text }` object, which Copilot Chat's `_convertMessages` does not accept. Each block is now wrapped in `LanguageModelTextPart`, mirroring the user-role branch.

--- a/src/server/utils/gemini.ts
+++ b/src/server/utils/gemini.ts
@@ -274,14 +274,24 @@ export const convertGeminiContentsToVSCode = (
           );
         }
       }
-      // For functionResponse without an explicit id: drain the FIFO queue for
-      // the matching name and pass that callId into the part converter so it
-      // produces a properly-paired LanguageModelToolResultPart.
+      // For functionResponse: keep the per-name pending queue in sync.
+      // If an explicit id is present, remove that matched callId so it cannot
+      // later be reused by an id-less response for the same function name.
+      // Otherwise, drain the FIFO queue for the matching name and pass that
+      // callId into the part converter so it produces a properly-paired
+      // LanguageModelToolResultPart.
       let resolvedCallId: string | undefined;
-      if (part.functionResponse?.name && !part.functionResponse.id) {
+      if (part.functionResponse?.name) {
         const queue = pendingByName.get(part.functionResponse.name);
         if (queue && queue.length > 0) {
-          resolvedCallId = queue.shift();
+          if (part.functionResponse.id) {
+            const matchedIndex = queue.indexOf(part.functionResponse.id);
+            if (matchedIndex !== -1) {
+              queue.splice(matchedIndex, 1);
+            }
+          } else {
+            resolvedCallId = queue.shift();
+          }
         }
       }
       return convertGeminiPartToVSCodePart(part, resolvedCallId);

--- a/src/server/utils/gemini.ts
+++ b/src/server/utils/gemini.ts
@@ -112,6 +112,7 @@ export const normalizeSchemaTypes = (
  */
 const convertGeminiPartToVSCodePart = (
   part: Part,
+  resolvedCallId?: string,
 ):
   | vscode.LanguageModelTextPart
   | vscode.LanguageModelToolCallPart
@@ -131,14 +132,29 @@ const convertGeminiPartToVSCodePart = (
     );
   }
 
-  // Function response (tool result)
-  if (part.functionResponse?.id) {
-    const responseText = part.functionResponse.response
-      ? JSON.stringify(part.functionResponse.response)
-      : "";
-    return new vscode.LanguageModelToolResultPart(part.functionResponse.id, [
-      new vscode.LanguageModelTextPart(responseText),
-    ]);
+  // Function response (tool result).
+  // Some Gemini clients (e.g. langchain-google-genai) only send `name` on
+  // functionResponse parts and rely on Gemini's positional pairing rules,
+  // omitting `id`. The original strict `if (part.functionResponse?.id)` check
+  // dropped those parts entirely, leading the upstream LM API to reject the
+  // turn with "function response parts != function call parts". Fall back to
+  // a callId resolved by the caller (positional FIFO match against the
+  // preceding functionCall) and finally to a synthetic name-based id.
+  if (part.functionResponse) {
+    const callId =
+      part.functionResponse.id ||
+      resolvedCallId ||
+      (part.functionResponse.name
+        ? `function_call_${part.functionResponse.name}`
+        : undefined);
+    if (callId) {
+      const responseText = part.functionResponse.response
+        ? JSON.stringify(part.functionResponse.response)
+        : "";
+      return new vscode.LanguageModelToolResultPart(callId, [
+        new vscode.LanguageModelTextPart(responseText),
+      ]);
+    }
   }
 
   // Inline data (images, etc.) - try to use LanguageModelDataPart if available
@@ -172,7 +188,9 @@ const convertGeminiPartToVSCodePart = (
 export const convertGeminiContentToVSCode = (
   content: Content,
 ): vscode.LanguageModelChatMessage => {
-  const parts = (content.parts || []).map(convertGeminiPartToVSCodePart);
+  const parts = (content.parts || []).map((part) =>
+    convertGeminiPartToVSCodePart(part),
+  );
 
   // Default to empty text if no valid parts
   if (parts.length === 0) {
@@ -201,12 +219,96 @@ export const convertGeminiContentToVSCode = (
 };
 
 /**
- * Convert Gemini Contents array to VSCode LanguageModelChatMessages
+ * Convert Gemini Contents array to VSCode LanguageModelChatMessages.
+ *
+ * Why this isn't just `contents.map(convertGeminiContentToVSCode)`: Gemini's
+ * API allows clients to send `functionCall`/`functionResponse` parts WITHOUT
+ * an explicit `id`, relying on positional pairing within the `contents` array
+ * (langchain-google-genai 4.x does this). VSCode's LanguageModel API on the
+ * other hand REQUIRES a callId on every tool result and matches it against
+ * the preceding tool-call. Without pairing here, every tool-using Gemini
+ * conversation through this proxy fails with
+ *   "Please ensure that the number of function response parts is equal to
+ *    the number of function call parts of the function call turn."
+ *
+ * Strategy: walk all parts in document order, assigning a stable callId to
+ * each functionCall (using its `id` when present, else a synthetic id), and
+ * push that callId onto a per-name FIFO queue. When we then encounter a
+ * functionResponse without an `id`, we drain the queue for that name to
+ * recover the matching callId.
  */
 export const convertGeminiContentsToVSCode = (
   contents: Content[],
 ): vscode.LanguageModelChatMessage[] => {
-  return contents.map(convertGeminiContentToVSCode);
+  // Pre-walk: assign a callId to every functionCall and remember it on the
+  // part itself (via WeakMap), and build a per-name FIFO queue we'll drain
+  // during the conversion pass.
+  const callIdByPart = new WeakMap<object, string>();
+  const pendingByName = new Map<string, string[]>();
+  let synthCounter = 0;
+  for (const content of contents) {
+    for (const part of content.parts || []) {
+      if (part.functionCall?.name) {
+        const callId =
+          part.functionCall.id ||
+          `function_call_synth_${synthCounter++}_${part.functionCall.name}`;
+        callIdByPart.set(part as unknown as object, callId);
+        const queue = pendingByName.get(part.functionCall.name) || [];
+        queue.push(callId);
+        pendingByName.set(part.functionCall.name, queue);
+      }
+    }
+  }
+
+  return contents.map((content) => {
+    const parts = (content.parts || []).map((part) => {
+      // For functionCall: use the pre-assigned callId so the tool-result side
+      // has something to match against.
+      if (part.functionCall?.name) {
+        const callId = callIdByPart.get(part as unknown as object);
+        if (callId) {
+          return new vscode.LanguageModelToolCallPart(
+            callId,
+            part.functionCall.name,
+            (part.functionCall.args || {}) as object,
+          );
+        }
+      }
+      // For functionResponse without an explicit id: drain the FIFO queue for
+      // the matching name and pass that callId into the part converter so it
+      // produces a properly-paired LanguageModelToolResultPart.
+      let resolvedCallId: string | undefined;
+      if (part.functionResponse?.name && !part.functionResponse.id) {
+        const queue = pendingByName.get(part.functionResponse.name);
+        if (queue && queue.length > 0) {
+          resolvedCallId = queue.shift();
+        }
+      }
+      return convertGeminiPartToVSCodePart(part, resolvedCallId);
+    });
+
+    if (parts.length === 0) {
+      parts.push(new vscode.LanguageModelTextPart(""));
+    }
+
+    const role = content.role || "user";
+    if (role === "model") {
+      return vscode.LanguageModelChatMessage.Assistant(
+        parts.filter(
+          (p) => !(p instanceof vscode.LanguageModelToolResultPart),
+        ) as Array<
+          vscode.LanguageModelTextPart | vscode.LanguageModelToolCallPart
+        >,
+      );
+    }
+    return vscode.LanguageModelChatMessage.User(
+      parts.filter(
+        (p) => !(p instanceof vscode.LanguageModelToolCallPart),
+      ) as Array<
+        vscode.LanguageModelTextPart | vscode.LanguageModelToolResultPart
+      >,
+    );
+  });
 };
 
 /**
@@ -217,7 +319,7 @@ export const convertGeminiSystemInstructionToVSCode = (
   instruction?: Content,
 ): vscode.LanguageModelChatMessage[] => {
   const parts = (instruction?.parts || [])
-    .map(convertGeminiPartToVSCodePart)
+    .map((part) => convertGeminiPartToVSCodePart(part))
     .filter((p) => !(p instanceof vscode.LanguageModelToolCallPart)) as Array<
     vscode.LanguageModelTextPart | vscode.LanguageModelToolResultPart
   >;

--- a/src/server/utils/openaiChat.ts
+++ b/src/server/utils/openaiChat.ts
@@ -52,15 +52,18 @@ export const convertOpenAIMessagesToVSCode = (
     switch (msg.role) {
       case "developer": // ChatCompletionDeveloperMessageParam
       case "system": // ChatCompletionSystemMessageParam
-        content =
-          typeof msg.content === "string"
-            ? msg.content
-            : msg.content.map((m) => ({
-                value: m.text,
-              }));
+        // Copilot Chat's _convertMessages rejects bare {value} objects with
+        // "Unexpected chat message content type llm 2". Always wrap text in
+        // LanguageModelTextPart, mirroring the user-role branch below.
+        if (typeof msg.content === "string") {
+          return new vscode.LanguageModelChatMessage(
+            vscode.LanguageModelChatMessageRole.User,
+            msg.content,
+          );
+        }
         return new vscode.LanguageModelChatMessage(
           vscode.LanguageModelChatMessageRole.User,
-          content,
+          msg.content.map((m) => new vscode.LanguageModelTextPart(m.text)),
         );
 
       case "user": // ChatCompletionUserMessageParam

--- a/src/test/server/gemini.test.ts
+++ b/src/test/server/gemini.test.ts
@@ -154,6 +154,88 @@ suite("Gemini Conversion Utils Test Suite", () => {
       const result = convertGeminiContentsToVSCode([]);
       assert.strictEqual(result.length, 0);
     });
+
+    test("should pair functionResponse without id via FIFO queue", () => {
+      // langchain-google-genai 4.x emits functionResponse with only `name`
+      // (no `id`). The pre-walk must assign a callId to the functionCall and
+      // the second pass must drain the per-name FIFO queue to recover it.
+      const contents = [
+        {
+          role: "model",
+          parts: [
+            { functionCall: { name: "fund_search", args: { q: "tech" } } },
+          ],
+        },
+        {
+          role: "user",
+          parts: [
+            {
+              functionResponse: {
+                name: "fund_search",
+                response: { result: "Found 026211" },
+              },
+            },
+          ],
+        },
+      ];
+
+      const result = convertGeminiContentsToVSCode(contents);
+
+      assert.strictEqual(result.length, 2);
+      const callPart = result[0].content[0] as vscode.LanguageModelToolCallPart;
+      const resultPart = result[1]
+        .content[0] as vscode.LanguageModelToolResultPart;
+      assert.ok(callPart instanceof vscode.LanguageModelToolCallPart);
+      assert.ok(resultPart instanceof vscode.LanguageModelToolResultPart);
+      assert.strictEqual(
+        resultPart.callId,
+        callPart.callId,
+        "functionResponse should inherit the callId of its paired functionCall",
+      );
+    });
+
+    test("should not reuse an id-matched callId for a later id-less response", () => {
+      // Two functionCalls for the same name. First response matches by id,
+      // second response omits id. The second one must pair with the SECOND
+      // call, not the first — i.e. the id-matched callId must be removed
+      // from the FIFO queue when the explicit id consumes it.
+      const contents = [
+        {
+          role: "model",
+          parts: [
+            { functionCall: { id: "call_A", name: "f", args: {} } },
+            { functionCall: { id: "call_B", name: "f", args: {} } },
+          ],
+        },
+        {
+          role: "user",
+          parts: [
+            {
+              functionResponse: {
+                id: "call_A",
+                name: "f",
+                response: { ok: 1 },
+              },
+            },
+            {
+              functionResponse: { name: "f", response: { ok: 2 } },
+            },
+          ],
+        },
+      ];
+
+      const result = convertGeminiContentsToVSCode(contents);
+
+      const responses = result[1]
+        .content as vscode.LanguageModelToolResultPart[];
+      assert.strictEqual(responses.length, 2);
+      assert.strictEqual(responses[0].callId, "call_A");
+      assert.strictEqual(
+        responses[1].callId,
+        "call_B",
+        "id-less response must drain to call_B, not stale call_A",
+      );
+    });
   });
 
   suite("convertGeminiSystemInstructionToVSCode", () => {

--- a/src/test/server/openaiChat.test.ts
+++ b/src/test/server/openaiChat.test.ts
@@ -36,6 +36,62 @@ suite("OpenAI Conversion Utils Test Suite", () => {
       );
     });
 
+    test("should wrap array-shaped system content blocks in LanguageModelTextPart", () => {
+      // deepagents / langchain-openai split long system prompts into multiple
+      // text blocks. Without LanguageModelTextPart wrapping, Copilot Chat's
+      // _convertMessages throws "Unexpected chat message content type llm 2".
+      const messages = [
+        {
+          role: "system" as const,
+          content: [
+            { type: "text" as const, text: "Block one" },
+            { type: "text" as const, text: "Block two" },
+            { type: "text" as const, text: "Block three" },
+          ],
+        },
+      ];
+
+      const result = convertOpenAIMessagesToVSCode(messages);
+
+      assert.strictEqual(result.length, 1);
+      assert.strictEqual(
+        result[0].role,
+        vscode.LanguageModelChatMessageRole.User,
+      );
+      const parts = result[0].content as vscode.LanguageModelTextPart[];
+      assert.strictEqual(parts.length, 3);
+      for (const part of parts) {
+        assert.ok(
+          part instanceof vscode.LanguageModelTextPart,
+          "every system content block must be a LanguageModelTextPart",
+        );
+      }
+      assert.strictEqual(parts[0].value, "Block one");
+      assert.strictEqual(parts[1].value, "Block two");
+      assert.strictEqual(parts[2].value, "Block three");
+    });
+
+    test("should wrap array-shaped developer content blocks in LanguageModelTextPart", () => {
+      const messages = [
+        {
+          role: "developer" as const,
+          content: [
+            { type: "text" as const, text: "Dev instruction A" },
+            { type: "text" as const, text: "Dev instruction B" },
+          ],
+        },
+      ];
+
+      const result = convertOpenAIMessagesToVSCode(messages);
+
+      const parts = result[0].content as vscode.LanguageModelTextPart[];
+      assert.strictEqual(parts.length, 2);
+      assert.ok(parts[0] instanceof vscode.LanguageModelTextPart);
+      assert.ok(parts[1] instanceof vscode.LanguageModelTextPart);
+      assert.strictEqual(parts[0].value, "Dev instruction A");
+      assert.strictEqual(parts[1].value, "Dev instruction B");
+    });
+
     test("should convert user message with string content", () => {
       const messages = [{ role: "user" as const, content: "Hello!" }];
 


### PR DESCRIPTION
 Two independent fixes in the LM message conversion layer that together
  unblock multi-vendor multi-turn tool calls through the proxy.

  ## 1. `gemini.ts` — pair functionResponse without explicit id

  `langchain-google-genai` 4.x emits `functionResponse` parts with only
  `name` (no `id`), relying on Gemini's positional pairing rules. The
  previous strict id check dropped those parts entirely, so the upstream
  LM API rejected the turn with:

  > the number of function response parts is equal to the number of
  > function call parts of the function call turn

  Fix: walk all parts in document order, assign a stable callId to every
  `functionCall` and push it onto a per-name FIFO queue. When a
  `functionResponse` arrives without an id, drain the queue for its name
  to recover the matching callId. Falls back to a synthetic name-based id
  as a last resort so we never silently drop a response part.

  ## 2. `openaiChat.ts` — wrap system text blocks in `LanguageModelTextPart`

  When an OpenAI client sends a system/developer message with array-shaped
  content (multiple text blocks), the converter mapped each block to a bare
  `{ value: text }` object. Copilot Chat's `_convertMessages` does not
  recognize that shape and throws:

  > Unexpected chat message content type llm 2

  Fix: wrap each text block in `new vscode.LanguageModelTextPart(...)`,
  mirroring how the user-role branch already handles array content. String
  content keeps its existing fast path. This unblocks any client
  (deepagents, langchain-openai, etc.) that splits the system prompt into
  multiple text parts.

  ## Validation

  Verified end-to-end through a deepagents-based pipeline that fans out
  to Claude (Anthropic), Gemini 3.1 Pro, and GPT-5.4 with multi-turn tool
  calls — all three completed without the errors above.