### PR TITLE
feat(anthropic): redirect dropped web_search to a WebFetch fallback

### DIFF
--- a/.changeset/web-search-webfetch-fallback.md
+++ b/.changeset/web-search-webfetch-fallback.md
@@ -1,0 +1,11 @@
+---
+"agent-maestro": patch
+---
+
+feat(anthropic): redirect dropped `web_search` server-side tool to a `WebFetch` fallback
+
+When a client (e.g. Claude Code) sends Anthropic's `web_search` server-side tool definition, #167 began dropping it because the underlying VS Code Language Model API can't execute it. That stops the request from hanging or 400-ing, but it also leaves the model unable to search the web at all.
+
+This change adds a tiny system-prompt nudge whenever a `web_search_*` tool is dropped: the model is told to fall back to the `WebFetch` tool with `https://html.duckduckgo.com/html/?q=<URL-encoded query>` and a prompt asking it to extract the most relevant result titles, URLs, and snippets. WebFetch is a standard client-side tool in Claude Code (and similar agents), so the user gets web-search-style behavior back with zero proxy-side dependencies, no API keys, and no extra setup. DuckDuckGo's HTML endpoint is used because Google's search page blocks/degrades non-browser HTTP fetches, leaving WebFetch with nothing useful to summarize.
+
+Other dropped server-side tools (`bash`, `computer`, etc.) are unaffected.

--- a/src/server/routes/anthropicRoutes.ts
+++ b/src/server/routes/anthropicRoutes.ts
@@ -10,6 +10,8 @@ import { logger } from "../../utils/logger";
 import { AnthropicErrorResponseSchema } from "../schemas/anthropic";
 import {
   type AnthropicTokenUsage,
+  WEB_SEARCH_FALLBACK_SYSTEM_NOTE,
+  appendSystemNote,
   convertAnthropicMessagesToVSCode,
   convertAnthropicSystemToVSCode,
   convertAnthropicToolChoiceToVSCode,
@@ -353,9 +355,27 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
 
       let client = initialClient!;
 
+      // Convert tools up front. If a `web_search` server-side tool was
+      // dropped, append a fallback note to the request's `system` block
+      // *before* prepareAnthropicMessages and getFallbackUsage see the
+      // payload — otherwise the LM call would include the note while
+      // token counting wouldn't, and usage figures would diverge from
+      // what's actually sent. The note is added to `system` (not as a
+      // trailing `user` turn) so it doesn't pollute the conversation
+      // transcript that gets replayed on subsequent client turns.
+      const { tools: convertedTools, webSearchDropped } =
+        convertAnthropicToolToVSCode(tools);
+      const augmentedRequestBody: Anthropic.Messages.MessageCreateParams =
+        webSearchDropped
+          ? {
+              ...requestBody,
+              system: appendSystemNote(system, WEB_SEARCH_FALLBACK_SYSTEM_NOTE),
+            }
+          : requestBody;
+
       // 3. Map Anthropic messages to VS Code LM API messages
       const { vsCodeLmMessages } = await prepareAnthropicMessages({
-        requestBody: { ...requestBody, model: resolvedModel },
+        requestBody: { ...augmentedRequestBody, model: resolvedModel },
       });
       lmChatMessages = vsCodeLmMessages;
       cancellationTokenSource = new vscode.CancellationTokenSource();
@@ -366,12 +386,14 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
         }`,
       );
 
-      // 4. Build VS Code Language Model request options
+      // 4. Build VS Code Language Model request options. If a `web_search`
+      //    fallback note was injected above, it's already part of
+      //    `vsCodeLmMessages` via `augmentedRequestBody.system`.
       const lmRequestOptions: vscode.LanguageModelChatRequestOptions = {
         justification:
           "Anthropic-compatible /v1/messages endpoint with streaming support using VS Code Language Model API",
         modelOptions: msgCreateParams,
-        tools: convertAnthropicToolToVSCode(tools),
+        tools: convertedTools,
         toolMode: convertAnthropicToolChoiceToVSCode(tool_choice),
       };
 
@@ -386,7 +408,7 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
         accumulatedText: string,
       ): Promise<AnthropicTokenUsage> => {
         const inputTokenCount = await countAnthropicMessageTokens(
-          JSON.stringify(requestBody),
+          JSON.stringify(augmentedRequestBody),
           client,
         );
         const outputTokenCount = accumulatedText

--- a/src/server/routes/anthropicRoutes.ts
+++ b/src/server/routes/anthropicRoutes.ts
@@ -743,8 +743,23 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
       if (clientError) {
         return c.json(clientError, 404);
       }
+
+      const { webSearchDropped } = convertAnthropicToolToVSCode(
+        requestBody.tools,
+      );
+      const augmentedRequestBody: Anthropic.Messages.MessageCreateParams =
+        webSearchDropped
+          ? {
+              ...requestBody,
+              system: appendSystemNote(
+                requestBody.system,
+                WEB_SEARCH_FALLBACK_SYSTEM_NOTE,
+              ),
+            }
+          : requestBody;
+
       const inputTokenCount = await countAnthropicMessageTokens(
-        JSON.stringify(requestBody),
+        JSON.stringify(augmentedRequestBody),
         client,
       );
 

--- a/src/server/utils/anthropic.ts
+++ b/src/server/utils/anthropic.ts
@@ -240,6 +240,29 @@ export const convertAnthropicSystemToVSCode = (
 };
 
 /**
+ * Append an extra system note to an Anthropic `system` field, normalizing
+ * whichever shape the caller used (undefined / string / TextBlockParam[]).
+ * Used to inject the `web_search` → WebFetch fallback nudge without
+ * polluting the conversation transcript with a synthetic user turn.
+ */
+export const appendSystemNote = (
+  system: string | Array<Anthropic.Messages.TextBlockParam> | undefined,
+  note: string,
+): Array<Anthropic.Messages.TextBlockParam> => {
+  const noteBlock: Anthropic.Messages.TextBlockParam = {
+    type: "text",
+    text: note,
+  };
+  if (!system) {
+    return [noteBlock];
+  }
+  if (typeof system === "string") {
+    return [{ type: "text", text: system }, noteBlock];
+  }
+  return [...system, noteBlock];
+};
+
+/**
  * Anthropic server-side tools (web_search, code_execution, computer_use,
  * bash, text_editor, memory, web_fetch, etc.) are executed by Anthropic's
  * backend, not the client. They are identified by the presence of a `type`
@@ -255,16 +278,49 @@ const isUnsupportedServerSideTool = (tool: unknown): boolean => {
   return typeof t.type === "string" && t.type !== "custom" && !t.input_schema;
 };
 
+/**
+ * Detect Anthropic web_search server-side tool variants
+ * (e.g. `web_search_20250305`).
+ */
+const isWebSearchServerSideTool = (tool: unknown): boolean => {
+  const t = tool as { type?: string };
+  return typeof t.type === "string" && t.type.startsWith("web_search");
+};
+
+/**
+ * System-prompt nudge appended when a client requested `web_search` but the
+ * backend can't execute it. Tells the model to fall back to `WebFetch` (a
+ * standard Claude Code client-side tool) against a public search-engine URL,
+ * so the user still gets web-search-like behavior with zero proxy-side
+ * dependencies.
+ */
+export const WEB_SEARCH_FALLBACK_SYSTEM_NOTE =
+  "The Anthropic `web_search` server-side tool is unavailable on this proxy. " +
+  "To search the web, use the `WebFetch` tool with a URL like " +
+  "`https://html.duckduckgo.com/html/?q=<URL-encoded query>` and a prompt " +
+  "asking it to extract the most relevant result titles, URLs, and snippets. " +
+  "If WebFetch is unavailable or cannot access the search page, tell the " +
+  "user the search URL so they can open it manually.";
+
+export interface ConvertAnthropicToolResult {
+  tools: vscode.LanguageModelChatTool[] | undefined;
+  webSearchDropped: boolean;
+}
+
 export const convertAnthropicToolToVSCode = (
   tools?: Anthropic.Messages.ToolUnion[],
-): vscode.LanguageModelChatTool[] | undefined => {
+): ConvertAnthropicToolResult => {
   if (!tools) {
-    return undefined;
+    return { tools: undefined, webSearchDropped: false };
   }
 
   const filtered: vscode.LanguageModelChatTool[] = [];
+  let webSearchDropped = false;
   for (const tool of tools) {
     if (isUnsupportedServerSideTool(tool)) {
+      if (isWebSearchServerSideTool(tool)) {
+        webSearchDropped = true;
+      }
       logger.warn(
         `Dropping unsupported Anthropic server-side tool: ${
           (tool as { type?: string }).type
@@ -279,7 +335,7 @@ export const convertAnthropicToolToVSCode = (
       inputSchema: t.input_schema,
     });
   }
-  return filtered;
+  return { tools: filtered, webSearchDropped };
 };
 
 export const convertAnthropicToolChoiceToVSCode = (

--- a/src/test/server/anthropic.test.ts
+++ b/src/test/server/anthropic.test.ts
@@ -2,6 +2,8 @@ import * as assert from "assert";
 import * as vscode from "vscode";
 
 import {
+  WEB_SEARCH_FALLBACK_SYSTEM_NOTE,
+  appendSystemNote,
   convertAnthropicMessageToVSCode,
   convertAnthropicMessagesToVSCode,
   convertAnthropicSystemToVSCode,
@@ -488,10 +490,14 @@ suite("Anthropic Conversion Utils Test Suite", () => {
 
       const result = convertAnthropicToolToVSCode(tools as any);
 
-      assert.ok(result);
-      assert.strictEqual(result.length, 1);
-      assert.strictEqual(result[0].name, "get_weather");
-      assert.strictEqual(result[0].description, "Get the weather for a city");
+      assert.ok(result.tools);
+      assert.strictEqual(result.tools.length, 1);
+      assert.strictEqual(result.tools[0].name, "get_weather");
+      assert.strictEqual(
+        result.tools[0].description,
+        "Get the weather for a city",
+      );
+      assert.strictEqual(result.webSearchDropped, false);
     });
 
     test("should ignore cache_control metadata on tools", () => {
@@ -511,11 +517,18 @@ suite("Anthropic Conversion Utils Test Suite", () => {
 
       const result = convertAnthropicToolToVSCode(tools as any);
 
-      assert.ok(result);
-      assert.strictEqual(result.length, 1);
-      assert.strictEqual(result[0].name, "cached_lookup");
-      assert.strictEqual(result[0].description, "Lookup using cached context");
-      assert.deepStrictEqual(result[0].inputSchema, tools[0].input_schema);
+      assert.ok(result.tools);
+      assert.strictEqual(result.tools.length, 1);
+      assert.strictEqual(result.tools[0].name, "cached_lookup");
+      assert.strictEqual(
+        result.tools[0].description,
+        "Lookup using cached context",
+      );
+      assert.deepStrictEqual(
+        result.tools[0].inputSchema,
+        tools[0].input_schema,
+      );
+      assert.strictEqual(result.webSearchDropped, false);
     });
 
     test("should drop unsupported server-side tools without input_schema", () => {
@@ -534,14 +547,22 @@ suite("Anthropic Conversion Utils Test Suite", () => {
 
       const result = convertAnthropicToolToVSCode(tools as any);
 
-      assert.ok(result);
+      assert.ok(result.tools);
       assert.strictEqual(
-        result.length,
+        result.tools.length,
         1,
         "server-side tools without input_schema should be dropped",
       );
-      assert.strictEqual(result[0].name, "get_weather");
-      assert.deepStrictEqual(result[0].inputSchema, tools[3].input_schema);
+      assert.strictEqual(result.tools[0].name, "get_weather");
+      assert.deepStrictEqual(
+        result.tools[0].inputSchema,
+        tools[3].input_schema,
+      );
+      assert.strictEqual(
+        result.webSearchDropped,
+        true,
+        "webSearchDropped flag should be set when web_search tool is dropped",
+      );
     });
 
     test("should keep custom tools with type: 'custom'", () => {
@@ -560,16 +581,21 @@ suite("Anthropic Conversion Utils Test Suite", () => {
 
       const result = convertAnthropicToolToVSCode(tools as any);
 
-      assert.ok(result);
-      assert.strictEqual(result.length, 1);
-      assert.strictEqual(result[0].name, "lookup");
-      assert.strictEqual(result[0].description, "Look something up");
-      assert.deepStrictEqual(result[0].inputSchema, tools[0].input_schema);
+      assert.ok(result.tools);
+      assert.strictEqual(result.tools.length, 1);
+      assert.strictEqual(result.tools[0].name, "lookup");
+      assert.strictEqual(result.tools[0].description, "Look something up");
+      assert.deepStrictEqual(
+        result.tools[0].inputSchema,
+        tools[0].input_schema,
+      );
+      assert.strictEqual(result.webSearchDropped, false);
     });
 
-    test("should return undefined for undefined tools", () => {
+    test("should return undefined tools list when input is undefined", () => {
       const result = convertAnthropicToolToVSCode(undefined);
-      assert.strictEqual(result, undefined);
+      assert.strictEqual(result.tools, undefined);
+      assert.strictEqual(result.webSearchDropped, false);
     });
 
     test("should handle tool without description", () => {
@@ -582,9 +608,118 @@ suite("Anthropic Conversion Utils Test Suite", () => {
 
       const result = convertAnthropicToolToVSCode(tools as any);
 
-      assert.ok(result);
-      assert.strictEqual(result[0].name, "simple_tool");
-      assert.strictEqual(result[0].description, "");
+      assert.ok(result.tools);
+      assert.strictEqual(result.tools[0].name, "simple_tool");
+      assert.strictEqual(result.tools[0].description, "");
+    });
+
+    test("should set webSearchDropped only when a web_search tool is dropped, not for other server-side tools", () => {
+      const tools = [
+        { name: "bash", type: "bash_20250124" },
+        { name: "computer", type: "computer_20250124" },
+      ];
+
+      const result = convertAnthropicToolToVSCode(tools as any);
+
+      assert.deepStrictEqual(result.tools, []);
+      assert.strictEqual(
+        result.webSearchDropped,
+        false,
+        "non-web_search server-side tools should not flip webSearchDropped",
+      );
+    });
+  });
+
+  suite("appendSystemNote", () => {
+    test("returns a single-block array when system is undefined", () => {
+      const result = appendSystemNote(undefined, "the note");
+      assert.deepStrictEqual(result, [{ type: "text", text: "the note" }]);
+    });
+
+    test("wraps a string system into an array with the note appended", () => {
+      const result = appendSystemNote("Be helpful", "the note");
+      assert.deepStrictEqual(result, [
+        { type: "text", text: "Be helpful" },
+        { type: "text", text: "the note" },
+      ]);
+    });
+
+    test("appends the note to an existing TextBlockParam array", () => {
+      const result = appendSystemNote(
+        [
+          { type: "text", text: "A" },
+          { type: "text", text: "B" },
+        ],
+        "the note",
+      );
+      assert.deepStrictEqual(result, [
+        { type: "text", text: "A" },
+        { type: "text", text: "B" },
+        { type: "text", text: "the note" },
+      ]);
+    });
+
+    test("does not mutate the input array", () => {
+      const original = [{ type: "text" as const, text: "A" }];
+      const result = appendSystemNote(original, "the note");
+      assert.strictEqual(original.length, 1);
+      assert.strictEqual(result.length, 2);
+    });
+  });
+
+  // Mirrors the wiring inside the Anthropic /v1/messages route handler:
+  // when web_search is dropped, the route appends the fallback note to
+  // `system` (not as a trailing user turn) before token counting + LM
+  // dispatch. This test locks that contract so a future refactor can't
+  // silently regress it (which is exactly the bug Copilot caught earlier
+  // when the note was appended after token counting).
+  suite("web_search fallback wiring (system-block injection)", () => {
+    test("system block sent to LM contains the fallback note when web_search is dropped", () => {
+      const tools = [{ name: "web_search", type: "web_search_20250305" }];
+      const originalSystem = "Be helpful.";
+
+      const { webSearchDropped } = convertAnthropicToolToVSCode(tools as any);
+      assert.strictEqual(webSearchDropped, true);
+
+      const augmentedSystem = webSearchDropped
+        ? appendSystemNote(originalSystem, WEB_SEARCH_FALLBACK_SYSTEM_NOTE)
+        : originalSystem;
+
+      const lmSystemMessages = convertAnthropicSystemToVSCode(augmentedSystem);
+
+      assert.strictEqual(lmSystemMessages.length, 2);
+      const noteMessage = lmSystemMessages[lmSystemMessages.length - 1];
+      const contentText =
+        typeof noteMessage.content === "string"
+          ? noteMessage.content
+          : JSON.stringify(noteMessage.content);
+      assert.ok(
+        contentText.includes("WebFetch") &&
+          contentText.includes("html.duckduckgo.com/html"),
+        `note content should mention WebFetch + html.duckduckgo.com/html, got: ${contentText}`,
+      );
+      assert.strictEqual(
+        noteMessage.role,
+        vscode.LanguageModelChatMessageRole.User,
+        "system blocks are converted to User-role LM messages by VS Code's API",
+      );
+    });
+
+    test("system block is unchanged when only non-web_search server-side tools are dropped", () => {
+      const tools = [{ name: "bash", type: "bash_20250124" }];
+      const originalSystem = "Be helpful.";
+
+      const { webSearchDropped } = convertAnthropicToolToVSCode(tools as any);
+      assert.strictEqual(webSearchDropped, false);
+
+      const augmentedSystem = webSearchDropped
+        ? appendSystemNote(originalSystem, WEB_SEARCH_FALLBACK_SYSTEM_NOTE)
+        : originalSystem;
+
+      assert.strictEqual(augmentedSystem, originalSystem);
+
+      const lmSystemMessages = convertAnthropicSystemToVSCode(augmentedSystem);
+      assert.strictEqual(lmSystemMessages.length, 1);
     });
   });
 


### PR DESCRIPTION
## Why

PR #167 filters out Anthropic server-side tools (`web_search_*`, `bash_*`, `computer_*`) that VS Code LM API can't execute. That stops the hang, but when a Claude Code user asks something like *"search the web for X"*, the model now has no search tool at all and either gives up or hallucinates.

Most Claude Code clients already ship a client-side `WebFetch` tool. We can nudge the model toward it.

## What

When `convertAnthropicToolToVSCode` drops a `web_search_*` tool, the route appends a short note to the request's `system` block telling the model:

> The Anthropic `web_search` server-side tool is unavailable on this proxy. To search the web, use the `WebFetch` tool with a URL like `https://html.duckduckgo.com/html/?q=<URL-encoded query>` and a prompt asking it to extract the most relevant result titles, URLs, and snippets. If WebFetch is unavailable or cannot access the search page, tell the user the search URL so they can open it manually.

- Only fires when `web_search_*` was actually requested and dropped — `bash_*` / `computer_*` don't trigger it.
- Note is added to `system` (not as a trailing `user` turn) so it doesn't pollute the conversation transcript that gets replayed on subsequent client turns.
- Note is included in `getFallbackUsage`'s token counting (the path that fires when the LM stream doesn't emit a usage chunk), so client-visible `input_tokens` reflect the prompt that was actually sent.
- DuckDuckGo's HTML endpoint is used because Google's search page blocks/degrades non-browser HTTP fetches, leaving WebFetch with nothing useful to summarize. DuckDuckGo HTML returns fetch-friendly markup with extractable titles, URLs, and snippets.
- No new dependencies, no third-party search API keys.
- Builds on #167's filter — doesn't replace it.

## Changes

- `src/server/utils/anthropic.ts` — `convertAnthropicToolToVSCode` now returns `{ tools, webSearchDropped }`; added `isWebSearchServerSideTool` helper, the `WEB_SEARCH_FALLBACK_SYSTEM_NOTE` constant, and an `appendSystemNote` helper that normalizes the (`undefined` | `string` | `TextBlockParam[]`) `system` shape.
- `src/server/routes/anthropicRoutes.ts` — converts tools and augments the `system` block before `prepareAnthropicMessages`, so token counting and the LM call both see the note.
- `src/test/server/anthropic.test.ts` — updated 5 existing tests for the new return shape; added a test that the flag fires only for `web_search_*`.
- `.changeset/web-search-webfetch-fallback.md` — patch-level changeset.

## Considered alternatives

- **Server-side search proxy (Tavily / Brave / Serper).** Adds API keys, billing, a network dependency, and a config surface. Wrong tradeoff for a project whose pitch is a zero-config bridge to VS Code LM API.
- **Server-synthesized `web_search_tool_result` blocks** (have the proxy fetch the SERP itself and return it as a synthetic Anthropic tool result). Strictly better when it works (no client cooperation needed, no language drift, no `WebFetch` dependency) but a much bigger change and has its own failure modes (search-engine blocks, HTML parsing brittleness). Reasonable v2.
- **Just let it fail** (status quo after #167). Visibly broken UX for the most common Claude Code prompt.

## Known tradeoffs

- The note is English. In non-English conversations the model may answer one turn in English. Cheap to address later if it becomes a complaint. (DuckDuckGo HTML endpoint itself handles percent-encoded CJK queries fine — verified.)
- The note hard-codes `WebFetch` (Claude Code's tool name). For clients without `WebFetch` (Cline, Continue.dev, raw API users), the note's "tell the user the search URL" clause is the graceful-degradation path.
- The note hard-codes `html.duckduckgo.com/html`. Could be made configurable later.

## Test plan

- [x] `pnpm run check-types` — 0 errors
- [x] `pnpm test` — **283 passing** (includes new tests for `webSearchDropped`, `appendSystemNote`, and the route-level system-block injection wiring; rebased onto upstream/main, picks up new upstream tests)
- [x] End-to-end: loaded the patched bundle in an isolated VS Code Extension Development Host (separate user-data-dir, port 33333, no impact on the user's normal install). Verified five scenarios behave as expected:

| Tools sent | `system` before | `system` after | Notes |
|---|---|---|---|
| `web_search_20250305` only, system=`"Be helpful"` | string | `[{Be helpful}, {note}]` | string→array+note |
| `web_search_20250305` only, no system | undefined | `[{note}]` | sole block |
| `web_search_20250305` only, system=`[{A},{B}]` | 2 blocks | 3 blocks (`[A,B,note]`) | append at end |
| `WebFetch` only | string | unchanged | not dropped, not triggered |
| `bash_20250124` only | string | unchanged | dropped (per #167) but `webSearchDropped=false` so no note |

