### PR TITLE
feat(anthropic): tag 1M-capable models with [1m] suffix for Claude Code detection

### DIFF
--- a/src/commands/configuratorCommands.ts
+++ b/src/commands/configuratorCommands.ts
@@ -14,6 +14,17 @@ import { logger } from "../utils/logger";
 import { updateEnvFile } from "../utils/updateEnvFile";
 import { createCommandHandler } from "./commandHandler";
 
+/**
+ * Append `[1m]` to a model ID containing `1m` so Claude Code enables its
+ * 1M-context code path. The proxy strips this suffix before model resolution.
+ */
+function tagModelFor1mContext(modelId: string): string {
+  if (!modelId.includes("1m") || modelId.endsWith("[1m]")) {
+    return modelId;
+  }
+  return `${modelId}[1m]`;
+}
+
 export function registerConfiguratorCommands(
   proxy: ProxyServer,
   context: vscode.ExtensionContext,
@@ -149,8 +160,10 @@ export function registerConfiguratorCommands(
             ...existingSettings?.env,
             ANTHROPIC_BASE_URL: `http://localhost:${proxyPort}/api/anthropic`,
             ANTHROPIC_AUTH_TOKEN: authToken,
-            ANTHROPIC_MODEL: selectedMainModel.modelId,
-            ANTHROPIC_SMALL_FAST_MODEL: selectedFastModel.modelId,
+            ANTHROPIC_MODEL: tagModelFor1mContext(selectedMainModel.modelId),
+            ANTHROPIC_SMALL_FAST_MODEL: tagModelFor1mContext(
+              selectedFastModel.modelId,
+            ),
             // Equivalent of setting `DISABLE_AUTOUPDATER`, `DISABLE_BUG_COMMAND`, `DISABLE_ERROR_REPORTING`, and `DISABLE_TELEMETRY` to true
             CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1",
           },

--- a/src/commands/configuratorCommands.ts
+++ b/src/commands/configuratorCommands.ts
@@ -5,6 +5,7 @@ import { parse, stringify } from "smol-toml";
 import * as vscode from "vscode";
 
 import { ProxyServer } from "../server/ProxyServer";
+import { tagCc1mSuffix } from "../utils/cc1m";
 import { getChatModelsQuickPickItems } from "../utils/chatModels";
 import {
   ensureClaudeConfigExists,
@@ -13,17 +14,6 @@ import {
 import { logger } from "../utils/logger";
 import { updateEnvFile } from "../utils/updateEnvFile";
 import { createCommandHandler } from "./commandHandler";
-
-/**
- * Append `[1m]` to a model ID containing `1m` so Claude Code enables its
- * 1M-context code path. The proxy strips this suffix before model resolution.
- */
-function tagModelFor1mContext(modelId: string): string {
-  if (!modelId.includes("1m") || modelId.endsWith("[1m]")) {
-    return modelId;
-  }
-  return `${modelId}[1m]`;
-}
 
 export function registerConfiguratorCommands(
   proxy: ProxyServer,
@@ -160,8 +150,8 @@ export function registerConfiguratorCommands(
             ...existingSettings?.env,
             ANTHROPIC_BASE_URL: `http://localhost:${proxyPort}/api/anthropic`,
             ANTHROPIC_AUTH_TOKEN: authToken,
-            ANTHROPIC_MODEL: tagModelFor1mContext(selectedMainModel.modelId),
-            ANTHROPIC_SMALL_FAST_MODEL: tagModelFor1mContext(
+            ANTHROPIC_MODEL: tagCc1mSuffix(selectedMainModel.modelId),
+            ANTHROPIC_SMALL_FAST_MODEL: tagCc1mSuffix(
               selectedFastModel.modelId,
             ),
             // Equivalent of setting `DISABLE_AUTOUPDATER`, `DISABLE_BUG_COMMAND`, `DISABLE_ERROR_REPORTING`, and `DISABLE_TELEMETRY` to true

--- a/src/server/routes/anthropicRoutes.ts
+++ b/src/server/routes/anthropicRoutes.ts
@@ -179,6 +179,38 @@ const countTokensRoute = createRoute({
 });
 
 /**
+ * Suffix appended to outbound model names so Claude Code detects the 1M context
+ * variant. Claude Code looks for this exact literal — do not change it.
+ */
+const CC_1M_SUFFIX = "[1m]";
+
+/**
+ * Strip the `[1m]` suffix that Claude Code may echo back in subsequent requests.
+ * The real VS Code LM model ID never contains this suffix.
+ */
+export function stripCc1mSuffix(model: string): string {
+  return model.endsWith(CC_1M_SUFFIX)
+    ? model.slice(0, -CC_1M_SUFFIX.length)
+    : model;
+}
+
+/**
+ * Tag the outbound model name with `[1m]` when the underlying model ID contains
+ * `1m`, so Claude Code enables its 1M-context code path.
+ */
+export function tagCc1mSuffix(
+  clientModel: string,
+  effectiveModelId: string,
+): string {
+  if (!effectiveModelId.includes("1m")) {
+    return clientModel;
+  }
+  return clientModel.endsWith(CC_1M_SUFFIX)
+    ? clientModel
+    : `${clientModel}${CC_1M_SUFFIX}`;
+}
+
+/**
  * Resolve model ID by checking the anthropic-beta header for context window variants.
  *
  * Claude Code sends `model: "claude-opus-4-6"` in the body and signals the 1M context
@@ -222,13 +254,16 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
       rawRequestBody = requestBody;
 
       const {
-        model,
+        model: rawModel,
         system,
         messages,
         tools,
         tool_choice,
         ...msgCreateParams
       } = requestBody;
+
+      // Strip the Claude Code 1M-context detection suffix that the client may echo back.
+      const model = stripCc1mSuffix(rawModel);
 
       // 1. Get chat model client (handles model mapping internally)
       const resolvedModel = resolveModelId(model, c);
@@ -336,7 +371,7 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
           id: `msg_${Date.now()}`,
           type: "message",
           role: "assistant",
-          model,
+          model: tagCc1mSuffix(model, effectiveModelId),
           content,
           stop_reason:
             content.at(-1)?.type === "tool_use" ? "tool_use" : "end_turn",
@@ -380,7 +415,7 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
               id: `msg_${Date.now()}`,
               type: "message",
               role: "assistant",
-              model,
+              model: tagCc1mSuffix(model, effectiveModelId),
               content: [],
               stop_reason: null,
               stop_sequence: null,
@@ -541,11 +576,14 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
         inputTokens > maxInputTokens;
 
       if (isContextWindowExceeded) {
-        const model = rawRequestBody?.model ?? effectiveModelId;
+        const clientModel = stripCc1mSuffix(
+          rawRequestBody?.model ?? effectiveModelId,
+        );
+        const model = tagCc1mSuffix(clientModel, effectiveModelId);
         const modelLabel =
-          model === effectiveModelId
+          clientModel === effectiveModelId
             ? effectiveModelId
-            : `${model} → ${effectiveModelId}`;
+            : `${clientModel} → ${effectiveModelId}`;
 
         logger.warn(
           `⚠ /v1/messages | context window exceeded | input: ${inputTokens} > max: ${maxInputTokens} | model: ${modelLabel}`,
@@ -669,7 +707,10 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
       const requestBody =
         (await c.req.json()) as Anthropic.Messages.MessageCreateParams;
 
-      const resolvedModel = resolveModelId(requestBody.model, c);
+      const resolvedModel = resolveModelId(
+        stripCc1mSuffix(requestBody.model),
+        c,
+      );
       const { client, error: clientError } =
         await getChatModelClient(resolvedModel);
 

--- a/src/server/routes/anthropicRoutes.ts
+++ b/src/server/routes/anthropicRoutes.ts
@@ -4,6 +4,7 @@ import { Context } from "hono";
 import { streamSSE } from "hono/streaming";
 import * as vscode from "vscode";
 
+import { stripCc1mSuffix } from "../../utils/cc1m";
 import { getChatModelClient } from "../../utils/chatModels";
 import { logger } from "../../utils/logger";
 import { AnthropicErrorResponseSchema } from "../schemas/anthropic";
@@ -179,19 +180,6 @@ const countTokensRoute = createRoute({
 });
 
 /**
- * Strip the `[1m]` suffix that users add to ANTHROPIC_MODEL so Claude Code enables
- * its 1M-context code path. The real VS Code LM model ID never contains this suffix,
- * so we remove it before model resolution.
- */
-const CC_1M_SUFFIX = "[1m]";
-
-export function stripCc1mSuffix(model: string): string {
-  return model.endsWith(CC_1M_SUFFIX)
-    ? model.slice(0, -CC_1M_SUFFIX.length)
-    : model;
-}
-
-/**
  * Resolve model ID by checking the anthropic-beta header for context window variants.
  *
  * Claude Code sends `model: "claude-opus-4-6"` in the body and signals the 1M context
@@ -265,7 +253,7 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
       // 3. Map Anthropic messages to VS Code LM API messages and count input tokens
       const { vsCodeLmMessages, inputTokenCount, cancellationToken } =
         await prepareAnthropicMessages({
-          requestBody,
+          requestBody: { ...requestBody, model },
           client,
         });
       lmChatMessages = vsCodeLmMessages;
@@ -698,7 +686,7 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
       }
 
       const { inputTokenCount } = await prepareAnthropicMessages({
-        requestBody,
+        requestBody: { ...requestBody, model: resolvedModel },
         client,
       });
 

--- a/src/server/routes/anthropicRoutes.ts
+++ b/src/server/routes/anthropicRoutes.ts
@@ -179,35 +179,16 @@ const countTokensRoute = createRoute({
 });
 
 /**
- * Suffix appended to outbound model names so Claude Code detects the 1M context
- * variant. Claude Code looks for this exact literal — do not change it.
+ * Strip the `[1m]` suffix that users add to ANTHROPIC_MODEL so Claude Code enables
+ * its 1M-context code path. The real VS Code LM model ID never contains this suffix,
+ * so we remove it before model resolution.
  */
 const CC_1M_SUFFIX = "[1m]";
 
-/**
- * Strip the `[1m]` suffix that Claude Code may echo back in subsequent requests.
- * The real VS Code LM model ID never contains this suffix.
- */
 export function stripCc1mSuffix(model: string): string {
   return model.endsWith(CC_1M_SUFFIX)
     ? model.slice(0, -CC_1M_SUFFIX.length)
     : model;
-}
-
-/**
- * Tag the outbound model name with `[1m]` when the underlying model ID contains
- * `1m`, so Claude Code enables its 1M-context code path.
- */
-export function tagCc1mSuffix(
-  clientModel: string,
-  effectiveModelId: string,
-): string {
-  if (!effectiveModelId.includes("1m")) {
-    return clientModel;
-  }
-  return clientModel.endsWith(CC_1M_SUFFIX)
-    ? clientModel
-    : `${clientModel}${CC_1M_SUFFIX}`;
 }
 
 /**
@@ -371,7 +352,7 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
           id: `msg_${Date.now()}`,
           type: "message",
           role: "assistant",
-          model: tagCc1mSuffix(model, effectiveModelId),
+          model: rawModel,
           content,
           stop_reason:
             content.at(-1)?.type === "tool_use" ? "tool_use" : "end_turn",
@@ -415,7 +396,7 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
               id: `msg_${Date.now()}`,
               type: "message",
               role: "assistant",
-              model: tagCc1mSuffix(model, effectiveModelId),
+              model: rawModel,
               content: [],
               stop_reason: null,
               stop_sequence: null,
@@ -576,14 +557,12 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
         inputTokens > maxInputTokens;
 
       if (isContextWindowExceeded) {
-        const clientModel = stripCc1mSuffix(
-          rawRequestBody?.model ?? effectiveModelId,
-        );
-        const model = tagCc1mSuffix(clientModel, effectiveModelId);
+        const model = rawRequestBody?.model ?? effectiveModelId;
+        const strippedModel = stripCc1mSuffix(model);
         const modelLabel =
-          clientModel === effectiveModelId
+          strippedModel === effectiveModelId
             ? effectiveModelId
-            : `${clientModel} → ${effectiveModelId}`;
+            : `${strippedModel} → ${effectiveModelId}`;
 
         logger.warn(
           `⚠ /v1/messages | context window exceeded | input: ${inputTokens} > max: ${maxInputTokens} | model: ${modelLabel}`,

--- a/src/test/server/modelResolution.test.ts
+++ b/src/test/server/modelResolution.test.ts
@@ -97,8 +97,15 @@ suite("Model Resolution Test Suite", () => {
       );
     });
 
-    test("does not tag non -1m models even if they contain '1m'", () => {
-      assert.strictEqual(tagCc1mSuffix("claude-1m-opus"), "claude-1m-opus");
+    test("tags -1m variants with extra trailing segments", () => {
+      assert.strictEqual(
+        tagCc1mSuffix("claude-opus-4.7-1m-internal"),
+        "claude-opus-4.7-1m-internal[1m]",
+      );
+    });
+
+    test("does not tag IDs whose '1m' lacks a leading dash", () => {
+      assert.strictEqual(tagCc1mSuffix("claude1m-opus"), "claude1m-opus");
     });
 
     test("does not tag plain models", () => {

--- a/src/test/server/modelResolution.test.ts
+++ b/src/test/server/modelResolution.test.ts
@@ -2,6 +2,7 @@ import * as assert from "assert";
 import type { Context } from "hono";
 
 import { resolveModelId } from "../../server/routes/anthropicRoutes";
+import { stripCc1mSuffix, tagCc1mSuffix } from "../../utils/cc1m";
 import { jaccardSimilarity } from "../../utils/chatModels";
 
 function createMockContext(headers: Record<string, string> = {}): Context {
@@ -50,6 +51,64 @@ suite("Model Resolution Test Suite", () => {
       assert.strictEqual(
         resolveModelId("claude-opus-4-6", ctx),
         "claude-opus-4-6",
+      );
+    });
+  });
+
+  suite("stripCc1mSuffix", () => {
+    test("removes trailing [1m] suffix", () => {
+      assert.strictEqual(
+        stripCc1mSuffix("claude-opus-4-6-1m[1m]"),
+        "claude-opus-4-6-1m",
+      );
+    });
+
+    test("returns model unchanged when no suffix is present", () => {
+      assert.strictEqual(stripCc1mSuffix("claude-opus-4-6"), "claude-opus-4-6");
+    });
+
+    test("only strips a terminal suffix, not occurrences elsewhere", () => {
+      assert.strictEqual(
+        stripCc1mSuffix("claude-[1m]-opus"),
+        "claude-[1m]-opus",
+      );
+    });
+
+    test("is idempotent on repeated application", () => {
+      const once = stripCc1mSuffix("claude-opus-4-6-1m[1m]");
+      assert.strictEqual(stripCc1mSuffix(once), once);
+    });
+
+    test("handles empty string", () => {
+      assert.strictEqual(stripCc1mSuffix(""), "");
+    });
+
+    test("returns non-string input untouched without throwing", () => {
+      assert.strictEqual(stripCc1mSuffix(undefined), undefined);
+      assert.strictEqual(stripCc1mSuffix(null), null);
+    });
+  });
+
+  suite("tagCc1mSuffix", () => {
+    test("appends [1m] to a -1m variant", () => {
+      assert.strictEqual(
+        tagCc1mSuffix("claude-opus-4-6-1m"),
+        "claude-opus-4-6-1m[1m]",
+      );
+    });
+
+    test("does not tag non -1m models even if they contain '1m'", () => {
+      assert.strictEqual(tagCc1mSuffix("claude-1m-opus"), "claude-1m-opus");
+    });
+
+    test("does not tag plain models", () => {
+      assert.strictEqual(tagCc1mSuffix("claude-opus-4-6"), "claude-opus-4-6");
+    });
+
+    test("is idempotent — does not double-tag", () => {
+      assert.strictEqual(
+        tagCc1mSuffix("claude-opus-4-6-1m[1m]"),
+        "claude-opus-4-6-1m[1m]",
       );
     });
   });

--- a/src/utils/cc1m.ts
+++ b/src/utils/cc1m.ts
@@ -25,11 +25,12 @@ export function stripCc1mSuffix(model: unknown): string {
 
 /**
  * Append `[1m]` to a model ID that targets the 1M-context variant, so Claude
- * Code enables its 1M-context code path. Idempotent and only tags IDs whose
- * variant suffix is `-1m` to avoid false positives on incidental "1m" matches.
+ * Code enables its 1M-context code path. Idempotent. Detection matches the
+ * convention used elsewhere in the proxy: any `-1m` segment in the ID marks
+ * a 1M variant (e.g. `claude-opus-4.7-1m-internal`), not just a terminal one.
  */
 export function tagCc1mSuffix(modelId: string): string {
-  if (!modelId.endsWith("-1m") || modelId.endsWith(CC_1M_SUFFIX)) {
+  if (!modelId.includes("-1m") || modelId.endsWith(CC_1M_SUFFIX)) {
     return modelId;
   }
   return `${modelId}${CC_1M_SUFFIX}`;

--- a/src/utils/cc1m.ts
+++ b/src/utils/cc1m.ts
@@ -1,0 +1,36 @@
+/**
+ * Shared helpers for the Claude Code 1M-context detection suffix.
+ *
+ * Claude Code (CC) decides whether to enable its 1M-context code path by
+ * inspecting the configured model name (e.g. ANTHROPIC_MODEL). We tag
+ * 1M-capable model IDs with a `[1m]` suffix when writing settings, and strip
+ * it on inbound proxy requests before model resolution.
+ */
+
+export const CC_1M_SUFFIX = "[1m]";
+
+/**
+ * Remove the trailing `[1m]` suffix that the client may echo back.
+ * Returns the input unchanged if it is not a non-empty string, so callers in
+ * routes that skip schema validation don't crash on missing/invalid `model`.
+ */
+export function stripCc1mSuffix(model: unknown): string {
+  if (typeof model !== "string") {
+    return model as string;
+  }
+  return model.endsWith(CC_1M_SUFFIX)
+    ? model.slice(0, -CC_1M_SUFFIX.length)
+    : model;
+}
+
+/**
+ * Append `[1m]` to a model ID that targets the 1M-context variant, so Claude
+ * Code enables its 1M-context code path. Idempotent and only tags IDs whose
+ * variant suffix is `-1m` to avoid false positives on incidental "1m" matches.
+ */
+export function tagCc1mSuffix(modelId: string): string {
+  if (!modelId.endsWith("-1m") || modelId.endsWith(CC_1M_SUFFIX)) {
+    return modelId;
+  }
+  return `${modelId}${CC_1M_SUFFIX}`;
+}


### PR DESCRIPTION
Append [1m] to outbound model field when the resolved VS Code LM model ID contains "1m", so Claude Code enables its 1M-context code path. Strip the suffix from inbound requests before model resolution.


demo:
<img width="1486" height="790" alt="image" src="https://github.com/user-attachments/assets/8e523e98-8609-436d-b5f8-b3f4f121045c" />
