### PR TITLE
Release v2.8.6

### DIFF
--- a/.changeset/drop-unsupported-server-side-tools.md
+++ b/.changeset/drop-unsupported-server-side-tools.md
@@ -1,5 +1,0 @@
----
-"agent-maestro": patch
----
-
-Fix `/v1/messages` failing or hanging when Claude Code (or any client) sends Anthropic server-side tool definitions such as `web_search_20250305`, `computer_20250124`, `bash_20250124`, etc. The previous tool converter stuffed the entire tool object into `inputSchema`, producing invalid JSON Schema (`tools.0.custom.input_schema.type: Input should be 'object'`) and, when no upstream error surfaced, leaving the client waiting forever for a `tool_result` that VS Code's Language Model API cannot produce. These tools are now dropped with a logged warning so the model never sees them and the request proceeds normally. Fixes #163, addresses #150.

--- a/.changeset/explicit-claude-1m-models.md
+++ b/.changeset/explicit-claude-1m-models.md
@@ -1,5 +1,0 @@
----
-"agent-maestro": patch
----
-
-Route Claude Code 1M context requests through its 1M model signal and remove automatic oversized-prompt upgrades. For exact 1M model selection, run `Configure Claude Code Settings` and choose the desired 1M model explicitly.

--- a/.changeset/fix-anthropic-tool-result-image.md
+++ b/.changeset/fix-anthropic-tool-result-image.md
@@ -1,7 +1,0 @@
----
-"agent-maestro": patch
----
-
-fix: handle image blocks inside Anthropic `tool_result` content arrays
-
-`toolResultBlockParamToVSCodePart` previously stringified non-text content blocks via `JSON.stringify(c)`. When a tool_result contains an image (e.g. Claude Code's `Read` tool returning a binary image file), the base64 payload reached the Language Model as serialized JSON text instead of a `LanguageModelDataPart`, causing the model to receive no image data and hallucinate. Top-level user-message images were already routed correctly via `imageBlockParamToVSCodePart`; this change uses the same converter for tool_result images.

--- a/.changeset/fix-gemini-functionresponse-pairing.md
+++ b/.changeset/fix-gemini-functionresponse-pairing.md
@@ -1,5 +1,0 @@
----
-"agent-maestro": patch
----
-
-Fix multi-turn Gemini tool calls failing with `the number of function response parts is equal to the number of function call parts of the function call turn`. `langchain-google-genai` 4.x emits `functionResponse` parts with only `name` (no `id`), relying on Gemini's positional pairing rules; the previous strict id check dropped those parts entirely. The converter now walks all parts in document order, assigns a stable `callId` to every `functionCall`, and uses a per-name FIFO queue to recover the matching `callId` when a `functionResponse` arrives without one.

--- a/.changeset/fix-openai-system-content-array.md
+++ b/.changeset/fix-openai-system-content-array.md
@@ -1,5 +1,0 @@
----
-"agent-maestro": patch
----
-
-Fix `/v1/chat/completions` failing with `Unexpected chat message content type llm 2` when the OpenAI client sends a `system` or `developer` message whose content is an array of text blocks (deepagents, langchain-openai, etc. do this when splitting long system prompts). The converter previously mapped each block to a bare `{ value: text }` object, which Copilot Chat's `_convertMessages` does not accept. Each block is now wrapped in `LanguageModelTextPart`, mirroring the user-role branch.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v2.8.6 - 2026.05.03
+
+- Route Claude Code 1M context requests through its 1M model signal and remove automatic oversized-prompt upgrades. For exact 1M model selection, run `Configure Claude Code Settings` and choose the desired 1M model explicitly.
+- Fix `/v1/messages` failing or hanging when Claude Code (or any client) sends Anthropic server-side tool definitions such as `web_search_20250305`, `computer_20250124`, `bash_20250124`, etc. The previous tool converter stuffed the entire tool object into `inputSchema`, producing invalid JSON Schema (`tools.0.custom.input_schema.type: Input should be 'object'`) and, when no upstream error surfaced, leaving the client waiting forever for a `tool_result` that VS Code's Language Model API cannot produce. These tools are now dropped with a logged warning so the model never sees them and the request proceeds normally. Fixes #163, addresses #150.
+- Fix Anthropic `tool_result` image blocks by routing image content through `LanguageModelDataPart` instead of serialized JSON text, matching top-level user-message image handling.
+- Fix multi-turn Gemini tool calls failing with `the number of function response parts is equal to the number of function call parts of the function call turn`. `langchain-google-genai` 4.x emits `functionResponse` parts with only `name` (no `id`), relying on Gemini's positional pairing rules; the previous strict id check dropped those parts entirely. The converter now walks all parts in document order, assigns a stable `callId` to every `functionCall`, and uses a per-name FIFO queue to recover the matching `callId` when a `functionResponse` arrives without one.
+- Fix `/v1/chat/completions` failing with `Unexpected chat message content type llm 2` when the OpenAI client sends a `system` or `developer` message whose content is an array of text blocks (deepagents, langchain-openai, etc. do this when splitting long system prompts). The converter previously mapped each block to a bare `{ value: text }` object, which Copilot Chat's `_convertMessages` does not accept. Each block is now wrapped in `LanguageModelTextPart`, mirroring the user-role branch.
+
 ## v2.8.5 - 2026.03.28
 
 - Change default `codex.contextWindowScaleFactor` from 1.3 to 1 to better align with model context limits.
@@ -203,19 +211,17 @@
 - Support get Roo task with id
 - Fix 'message "number" is required' issue when requesting /roo/tasks
 
-## v0.3.0 - 2025-06-17
+## v0.3.0 - 2025.06.17
 
 - Support fetch Roo task history
 - Support `newTab` argument for new Roo task creation
 
-## v0.2.5 - 2025-06-17
+## v0.2.5 - 2025.06.17
 
 - Fix logo missing issue and reduce package size by removing unnecessary files
 - Do not show output panel at extension activation
 
-## v0.2.4 - 2025-06-16
-
-### Features
+## v0.2.4 - 2025.06.16
 
 - Added file system read API for project file access
 - Added configuration support when creating new Roo tasks
@@ -223,9 +229,7 @@
 - Added Server-Sent Events (SSE) documentation for Roo API
 - Proxy server skips start if another one is already running, otherwise find an available port if default one has been used
 
-## v0.1.0 - 2025-06-14
-
-### Features
+## v0.1.0 - 2025.06.14
 
 - Multi-agent support for RooCode and Cline extensions
 - RESTful API server with OpenAPI documentation

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "agent-maestro",
   "displayName": "Agent Maestro",
   "description": "Turn VS Code into your compliant AI playground! With Agent Maestro, spin up Cline or Roo on demand and plug Claude Code or Codex straight in through an OpenAI/Anthropic-compatible API.",
-  "version": "2.8.5",
+  "version": "2.8.6",
   "icon": "assets/icons/icon.png",
   "publisher": "Joouis",
   "repository": "https://github.com/Joouis/agent-maestro",

--- a/src/server/routes/anthropicRoutes.ts
+++ b/src/server/routes/anthropicRoutes.ts
@@ -24,8 +24,9 @@ const prepareAnthropicMessages = async ({
   requestBody: Anthropic.Messages.MessageCreateParams;
   client: vscode.LanguageModelChat;
 }) => {
-  const requestBodyStr = JSON.stringify(requestBody);
-  logger.debug("/v1/messages payload: ", requestBodyStr);
+  const requestBodyStr = JSON.stringify(requestBody, null, 2);
+  logger.debug("/v1/messages payload:");
+  logger.debug(requestBodyStr);
 
   const { system, messages } = requestBody;
 
@@ -304,7 +305,8 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
           // container: null,
         };
 
-        logger.debug("/v1/messages response: ", JSON.stringify(resp, null, 2));
+        logger.debug("/v1/messages response:");
+        logger.debug(JSON.stringify(resp, null, 2));
         logger.info(
           `← /v1/messages | input: ${inputTokenCount.original} → ${inputTokenCount.calibrated} | output: ${outputTokenCount.original} → ${outputTokenCount.calibrated}`,
         );
@@ -425,10 +427,8 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
             }
           }
 
-          logger.debug(
-            "/v1/messages streamed content block responses: ",
-            JSON.stringify(contentBlocks, null, 2),
-          );
+          logger.debug("/v1/messages streamed content block responses: ");
+          logger.debug(JSON.stringify(contentBlocks, null, 2));
 
           // Finalize last content block if it exists
           await writeSSE({

--- a/src/server/routes/anthropicRoutes.ts
+++ b/src/server/routes/anthropicRoutes.ts
@@ -24,9 +24,8 @@ const prepareAnthropicMessages = async ({
   requestBody: Anthropic.Messages.MessageCreateParams;
   client: vscode.LanguageModelChat;
 }) => {
-  const requestBodyStr = JSON.stringify(requestBody, null, 2);
   logger.debug("/v1/messages payload:");
-  logger.debug(requestBodyStr);
+  logger.debug(JSON.stringify(requestBody, null, 2));
 
   const { system, messages } = requestBody;
 
@@ -37,7 +36,7 @@ const prepareAnthropicMessages = async ({
 
   const cancellationToken = new vscode.CancellationTokenSource().token;
   const inputTokenCount = await countAnthropicMessageTokens(
-    requestBodyStr,
+    JSON.stringify(requestBody),
     client,
   );
 
@@ -427,7 +426,7 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
             }
           }
 
-          logger.debug("/v1/messages streamed content block responses: ");
+          logger.debug("/v1/messages streamed content block responses:");
           logger.debug(JSON.stringify(contentBlocks, null, 2));
 
           // Finalize last content block if it exists

--- a/src/server/routes/geminiRoutes.ts
+++ b/src/server/routes/geminiRoutes.ts
@@ -34,9 +34,8 @@ const prepareGeminiRequest = async ({
   requestBody: GenerateContentRequest;
   client: vscode.LanguageModelChat;
 }) => {
-  const requestBodyStr = JSON.stringify(requestBody, null, 2);
   logger.debug("Gemini request payload:");
-  logger.debug(requestBodyStr);
+  logger.debug(JSON.stringify(requestBody, null, 2));
 
   const { systemInstruction, contents, tools, generationConfig, toolConfig } =
     requestBody;
@@ -53,7 +52,7 @@ const prepareGeminiRequest = async ({
   // do this to leverage the official tokenizer instead of building our own wheel.
   const cancellationToken = new vscode.CancellationTokenSource().token;
   const inputTokenCount = await client.countTokens(
-    requestBodyStr,
+    JSON.stringify(requestBody),
     cancellationToken,
   );
 

--- a/src/server/routes/geminiRoutes.ts
+++ b/src/server/routes/geminiRoutes.ts
@@ -34,8 +34,9 @@ const prepareGeminiRequest = async ({
   requestBody: GenerateContentRequest;
   client: vscode.LanguageModelChat;
 }) => {
-  const requestBodyStr = JSON.stringify(requestBody);
-  logger.debug("Gemini request payload: ", requestBodyStr);
+  const requestBodyStr = JSON.stringify(requestBody, null, 2);
+  logger.debug("Gemini request payload:");
+  logger.debug(requestBodyStr);
 
   const { systemInstruction, contents, tools, generationConfig, toolConfig } =
     requestBody;
@@ -387,10 +388,8 @@ export function registerGeminiRoutes(app: OpenAPIHono) {
         modelVersion: modelId,
       };
 
-      logger.debug(
-        "generateContent response:",
-        JSON.stringify(geminiResponse, null, 2),
-      );
+      logger.debug("generateContent response:");
+      logger.debug(JSON.stringify(geminiResponse, null, 2));
       logger.info(
         `← /v1beta/models/${modelWithMethod} | input: ${inputTokenCount} | output: ${outputTokenCount}`,
       );

--- a/src/server/routes/openai/openaiChatRoutes.ts
+++ b/src/server/routes/openai/openaiChatRoutes.ts
@@ -120,12 +120,11 @@ export function registerOpenaiChatRoutes(app: OpenAPIHono) {
       // We pass the stringified request body to VSCode's countTokens() API, which is technically
       // a misuse since it's designed for LanguageModelChatMessage objects. However, we intentionally
       // do this to leverage the official tokenizer instead of building our own wheel.
-      const requestBodyStr = JSON.stringify(requestBody, null, 2);
       logger.debug("/v1/chat/completions payload:");
-      logger.debug(requestBodyStr);
+      logger.debug(JSON.stringify(requestBody, null, 2));
       const cancellationToken = new vscode.CancellationTokenSource().token;
       const inputTokenCount = await client.countTokens(
-        requestBodyStr,
+        JSON.stringify(requestBody),
         cancellationToken,
       );
       inputTokens = inputTokenCount;

--- a/src/server/routes/openai/openaiChatRoutes.ts
+++ b/src/server/routes/openai/openaiChatRoutes.ts
@@ -120,8 +120,9 @@ export function registerOpenaiChatRoutes(app: OpenAPIHono) {
       // We pass the stringified request body to VSCode's countTokens() API, which is technically
       // a misuse since it's designed for LanguageModelChatMessage objects. However, we intentionally
       // do this to leverage the official tokenizer instead of building our own wheel.
-      const requestBodyStr = JSON.stringify(requestBody);
-      logger.debug("/v1/chat/completions payload: ", requestBodyStr);
+      const requestBodyStr = JSON.stringify(requestBody, null, 2);
+      logger.debug("/v1/chat/completions payload:");
+      logger.debug(requestBodyStr);
       const cancellationToken = new vscode.CancellationTokenSource().token;
       const inputTokenCount = await client.countTokens(
         requestBodyStr,
@@ -210,10 +211,8 @@ export function registerOpenaiChatRoutes(app: OpenAPIHono) {
           },
         };
 
-        logger.debug(
-          "/v1/chat/completions response: ",
-          JSON.stringify(openaiResponse, null, 2),
-        );
+        logger.debug("/v1/chat/completions response:");
+        logger.debug(JSON.stringify(openaiResponse, null, 2));
         logger.info(
           `← /v1/chat/completions | input: ${inputTokenCount} | output: ${completionTokens}`,
         );

--- a/src/server/routes/openai/openaiResponsesRoutes.ts
+++ b/src/server/routes/openai/openaiResponsesRoutes.ts
@@ -223,8 +223,9 @@ export function registerOpenaiResponsesRoutes(app: OpenAPIHono) {
       }
 
       // 5. Count input tokens
-      const requestBodyStr = JSON.stringify(requestBody);
-      logger.debug("/v1/responses payload:", requestBodyStr);
+      const requestBodyStr = JSON.stringify(requestBody, null, 2);
+      logger.debug("/v1/responses payload:");
+      logger.debug(requestBodyStr);
       const cancellationTokenSource = new vscode.CancellationTokenSource();
       const cancellationToken = cancellationTokenSource.token;
       inputTokens = await client.countTokens(requestBodyStr, cancellationToken);
@@ -309,10 +310,8 @@ export function registerOpenaiResponsesRoutes(app: OpenAPIHono) {
           metadata,
         };
 
-        logger.debug(
-          "/v1/responses response:",
-          JSON.stringify(responseObj, null, 2),
-        );
+        logger.debug("/v1/responses response:");
+        logger.debug(JSON.stringify(responseObj, null, 2));
         logger.info(
           `← /v1/responses | input: ${inputTokens} | output: ${outputTokens}`,
         );

--- a/src/server/routes/openai/openaiResponsesRoutes.ts
+++ b/src/server/routes/openai/openaiResponsesRoutes.ts
@@ -223,12 +223,14 @@ export function registerOpenaiResponsesRoutes(app: OpenAPIHono) {
       }
 
       // 5. Count input tokens
-      const requestBodyStr = JSON.stringify(requestBody, null, 2);
       logger.debug("/v1/responses payload:");
-      logger.debug(requestBodyStr);
+      logger.debug(JSON.stringify(requestBody, null, 2));
       const cancellationTokenSource = new vscode.CancellationTokenSource();
       const cancellationToken = cancellationTokenSource.token;
-      inputTokens = await client.countTokens(requestBodyStr, cancellationToken);
+      inputTokens = await client.countTokens(
+        JSON.stringify(requestBody),
+        cancellationToken,
+      );
 
       logger.info(
         `→ /v1/responses | model: ${


### PR DESCRIPTION
## Summary

- release Agent Maestro v2.8.6
- consume pending patch changesets into CHANGELOG.md
- bump package version from 2.8.5 to 2.8.6
- include debug payload logging polish

## Verification

- pre-commit checks passed during commits
