### PR TITLE
fix(anthropic): return truncated response with max_tokens stop reason on length errors

### DIFF
--- a/.changeset/silly-stars-work.md
+++ b/.changeset/silly-stars-work.md
@@ -1,0 +1,5 @@
+---
+"agent-maestro": patch
+---
+
+Fix Anthropic `/v1/messages` length-truncated responses from VS Code/Copilot so partial content can be returned successfully with `stop_reason: "max_tokens"` instead of a 500 error.

--- a/.changeset/silly-stars-work.md
+++ b/.changeset/silly-stars-work.md
@@ -1,5 +1,0 @@
----
-"agent-maestro": patch
----
-
-Fix Anthropic `/v1/messages` length-truncated responses from VS Code/Copilot so partial content can be returned successfully with `stop_reason: "max_tokens"` instead of a 500 error.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.8.7 - 2026.05.12
+
+- Fix Anthropic `/v1/messages` length-truncated responses from VS Code/Copilot so partial content can be returned successfully with `stop_reason: "max_tokens"` instead of a 500 error.
+
 ## v2.8.6 - 2026.05.03
 
 - Route Claude Code 1M context requests through its 1M model signal and remove automatic oversized-prompt upgrades. For exact 1M model selection, run `Configure Claude Code Settings` and choose the desired 1M model explicitly.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "agent-maestro",
   "displayName": "Agent Maestro",
   "description": "Turn VS Code into your compliant AI playground! With Agent Maestro, spin up Cline or Roo on demand and plug Claude Code or Codex straight in through an OpenAI/Anthropic-compatible API.",
-  "version": "2.8.6",
+  "version": "2.8.7",
   "icon": "assets/icons/icon.png",
   "publisher": "Joouis",
   "repository": "https://github.com/Joouis/agent-maestro",

--- a/src/server/routes/anthropicRoutes.ts
+++ b/src/server/routes/anthropicRoutes.ts
@@ -16,7 +16,7 @@ import {
   countAnthropicMessageTokens,
 } from "../utils/anthropic";
 import { handleErrorWithLogging } from "../utils/errorDiagnostics";
-import { isTokenLengthErrorLike } from "../utils/languageModelErrors";
+import { isResponseTooLongError } from "../utils/languageModelErrors";
 
 const prepareAnthropicMessages = async ({
   requestBody,
@@ -280,13 +280,13 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
             }
           }
         } catch (streamError) {
-          if (!isTokenLengthErrorLike(streamError)) {
+          if (!isResponseTooLongError(streamError)) {
             throw streamError;
           }
 
           stopReason = "max_tokens";
           logger.warn(
-            `⚠ /v1/messages | returning truncated response after length error | contentBlocks: ${content.length}`,
+            `/v1/messages | returning truncated response after length error | contentBlocks: ${content.length}`,
           );
         }
 
@@ -445,13 +445,13 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
               }
             }
           } catch (streamError) {
-            if (!isTokenLengthErrorLike(streamError)) {
+            if (!isResponseTooLongError(streamError)) {
               throw streamError;
             }
 
             stopReason = "max_tokens";
             logger.warn(
-              `⚠ /v1/messages (stream) | returning truncated response after length error | contentBlocks: ${contentBlocks.length}`,
+              `/v1/messages (stream) | returning truncated response after length error | contentBlocks: ${contentBlocks.length}`,
             );
           }
 
@@ -531,7 +531,7 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
             : `${model} → ${effectiveModelId}`;
 
         logger.warn(
-          `⚠ /v1/messages | context window exceeded | input: ${inputTokens} > max: ${maxInputTokens} | model: ${modelLabel}`,
+          `/v1/messages | context window exceeded | input: ${inputTokens} > max: ${maxInputTokens} | model: ${modelLabel}`,
         );
 
         vscode.window.showWarningMessage(

--- a/src/server/routes/anthropicRoutes.ts
+++ b/src/server/routes/anthropicRoutes.ts
@@ -16,6 +16,7 @@ import {
   countAnthropicMessageTokens,
 } from "../utils/anthropic";
 import { handleErrorWithLogging } from "../utils/errorDiagnostics";
+import { isTokenLengthErrorLike } from "../utils/languageModelErrors";
 
 const prepareAnthropicMessages = async ({
   requestBody,
@@ -255,26 +256,38 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
       if (!msgCreateParams.stream) {
         const content: Anthropic.Messages.ContentBlock[] = [];
         let accumulatedText = "";
+        let stopReason: Anthropic.Messages.StopReason = "end_turn";
 
-        for await (const chunk of response.stream) {
-          if (chunk instanceof vscode.LanguageModelTextPart) {
-            let lastBlock = content.at(-1);
-            if (!lastBlock || lastBlock.type !== "text") {
-              lastBlock = { type: "text", text: "", citations: null };
-              content.push(lastBlock);
+        try {
+          for await (const chunk of response.stream) {
+            if (chunk instanceof vscode.LanguageModelTextPart) {
+              let lastBlock = content.at(-1);
+              if (!lastBlock || lastBlock.type !== "text") {
+                lastBlock = { type: "text", text: "", citations: null };
+                content.push(lastBlock);
+              }
+              lastBlock.text += chunk.value;
+              accumulatedText += chunk.value;
+            } else if (chunk instanceof vscode.LanguageModelToolCallPart) {
+              content.push({
+                type: "tool_use",
+                id: chunk.callId,
+                name: chunk.name,
+                input: chunk.input,
+              });
+
+              accumulatedText += JSON.stringify(chunk);
             }
-            lastBlock.text += chunk.value;
-            accumulatedText += chunk.value;
-          } else if (chunk instanceof vscode.LanguageModelToolCallPart) {
-            content.push({
-              type: "tool_use",
-              id: chunk.callId,
-              name: chunk.name,
-              input: chunk.input,
-            });
-
-            accumulatedText += JSON.stringify(chunk);
           }
+        } catch (streamError) {
+          if (!isTokenLengthErrorLike(streamError)) {
+            throw streamError;
+          }
+
+          stopReason = "max_tokens";
+          logger.warn(
+            `⚠ /v1/messages | returning truncated response after length error | contentBlocks: ${content.length}`,
+          );
         }
 
         // Count output tokens
@@ -290,7 +303,11 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
           model,
           content,
           stop_reason:
-            content.at(-1)?.type === "tool_use" ? "tool_use" : "end_turn",
+            stopReason === "max_tokens"
+              ? "max_tokens"
+              : content.at(-1)?.type === "tool_use"
+                ? "tool_use"
+                : "end_turn",
           stop_sequence: null,
           usage: {
             cache_creation: null,
@@ -350,90 +367,104 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
 
           const contentBlocks: Anthropic.Messages.ContentBlock[] = [];
           let accumulatedText = "";
+          let stopReason: Anthropic.Messages.StopReason = "end_turn";
 
-          for await (const chunk of response.stream) {
-            const lastBlock = contentBlocks.at(-1);
-            if (chunk instanceof vscode.LanguageModelTextPart) {
-              // Stop last non-text block if it exists
-              if (lastBlock && lastBlock.type !== "text") {
+          try {
+            for await (const chunk of response.stream) {
+              const lastBlock = contentBlocks.at(-1);
+              if (chunk instanceof vscode.LanguageModelTextPart) {
+                // Stop last non-text block if it exists
+                if (lastBlock && lastBlock.type !== "text") {
+                  await writeSSE({
+                    type: "content_block_stop",
+                    index: contentBlocks.length - 1,
+                  });
+                }
+
+                // Start a new text block
+                if (!lastBlock || lastBlock.type !== "text") {
+                  contentBlocks.push({
+                    type: "text",
+                    text: "",
+                    citations: null,
+                  });
+                  await writeSSE({
+                    type: "content_block_start",
+                    index: contentBlocks.length - 1,
+                    content_block: { type: "text", text: "", citations: null },
+                  });
+                }
+
+                // Append text to the current text block
+                (contentBlocks.at(-1) as Anthropic.Messages.TextBlock).text +=
+                  chunk.value;
                 await writeSSE({
-                  type: "content_block_stop",
+                  type: "content_block_delta",
                   index: contentBlocks.length - 1,
+                  delta: { type: "text_delta", text: chunk.value },
                 });
-              }
 
-              // Start a new text block
-              if (!lastBlock || lastBlock.type !== "text") {
+                accumulatedText += chunk.value;
+              } else if (chunk instanceof vscode.LanguageModelToolCallPart) {
+                // Every tool call is a new content block
+                if (lastBlock) {
+                  await writeSSE({
+                    type: "content_block_stop",
+                    index: contentBlocks.length - 1,
+                  });
+                }
+
                 contentBlocks.push({
-                  type: "text",
-                  text: "",
-                  citations: null,
-                });
-                await writeSSE({
-                  type: "content_block_start",
-                  index: contentBlocks.length - 1,
-                  content_block: { type: "text", text: "", citations: null },
-                });
-              }
-
-              // Append text to the current text block
-              (contentBlocks.at(-1) as Anthropic.Messages.TextBlock).text +=
-                chunk.value;
-              await writeSSE({
-                type: "content_block_delta",
-                index: contentBlocks.length - 1,
-                delta: { type: "text_delta", text: chunk.value },
-              });
-
-              accumulatedText += chunk.value;
-            } else if (chunk instanceof vscode.LanguageModelToolCallPart) {
-              // Every tool call is a new content block
-              if (lastBlock) {
-                await writeSSE({
-                  type: "content_block_stop",
-                  index: contentBlocks.length - 1,
-                });
-              }
-
-              contentBlocks.push({
-                type: "tool_use",
-                id: chunk.callId,
-                name: chunk.name,
-                input: chunk.input,
-              });
-
-              await writeSSE({
-                type: "content_block_start",
-                index: contentBlocks.length - 1,
-                content_block: {
                   type: "tool_use",
                   id: chunk.callId,
                   name: chunk.name,
-                  input: {},
-                },
-              });
+                  input: chunk.input,
+                });
 
-              await writeSSE({
-                type: "content_block_delta",
-                index: contentBlocks.length - 1,
-                delta: {
-                  type: "input_json_delta",
-                  partial_json: JSON.stringify(chunk.input),
-                },
-              });
+                await writeSSE({
+                  type: "content_block_start",
+                  index: contentBlocks.length - 1,
+                  content_block: {
+                    type: "tool_use",
+                    id: chunk.callId,
+                    name: chunk.name,
+                    input: {},
+                  },
+                });
 
-              accumulatedText += JSON.stringify(chunk);
+                await writeSSE({
+                  type: "content_block_delta",
+                  index: contentBlocks.length - 1,
+                  delta: {
+                    type: "input_json_delta",
+                    partial_json: JSON.stringify(chunk.input),
+                  },
+                });
+
+                accumulatedText += JSON.stringify(chunk);
+              }
             }
+          } catch (streamError) {
+            if (!isTokenLengthErrorLike(streamError)) {
+              throw streamError;
+            }
+
+            stopReason = "max_tokens";
+            logger.warn(
+              `⚠ /v1/messages (stream) | returning truncated response after length error | contentBlocks: ${contentBlocks.length}`,
+            );
           }
 
           logger.debug("/v1/messages streamed content block responses:");
           logger.debug(JSON.stringify(contentBlocks, null, 2));
 
           // Finalize last content block if it exists
-          await writeSSE({
-            type: "content_block_stop",
-            index: contentBlocks.length - 1,
-          });
+          if (contentBlocks.length > 0) {
+            await writeSSE({
+              type: "content_block_stop",
+              index: contentBlocks.length - 1,
+            });
+          }
 
           // Count output tokens for the complete response
           const outputTokenCount = accumulatedText
@@ -444,9 +475,11 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
             type: "message_delta",
             delta: {
               stop_reason:
-                contentBlocks.at(-1)?.type === "tool_use"
-                  ? "tool_use"
-                  : "end_turn",
+                stopReason === "max_tokens"
+                  ? "max_tokens"
+                  : contentBlocks.at(-1)?.type === "tool_use"
+                    ? "tool_use"
+                    : "end_turn",
               stop_sequence: null,
             },
             usage: {

--- a/src/server/utils/languageModelErrors.ts
+++ b/src/server/utils/languageModelErrors.ts
@@ -1,2 +1,2 @@
-export const isTokenLengthErrorLike = (error: unknown): boolean =>
+export const isResponseTooLongError = (error: unknown): boolean =>
   error instanceof Error && error.message.includes("Response too long");

--- a/src/server/utils/languageModelErrors.ts
+++ b/src/server/utils/languageModelErrors.ts
@@ -1,0 +1,2 @@
+export const isTokenLengthErrorLike = (error: unknown): boolean =>
+  error instanceof Error && error.message.includes("Response too long");

--- a/src/test/server/anthropic.test.ts
+++ b/src/test/server/anthropic.test.ts
@@ -8,7 +8,7 @@ import {
   convertAnthropicToolChoiceToVSCode,
   convertAnthropicToolToVSCode,
 } from "../../server/utils/anthropic";
-import { isTokenLengthErrorLike } from "../../server/utils/languageModelErrors";
+import { isResponseTooLongError } from "../../server/utils/languageModelErrors";
 
 suite("Anthropic Conversion Utils Test Suite", () => {
   suite("convertAnthropicMessageToVSCode", () => {
@@ -408,20 +408,20 @@ suite("Anthropic Conversion Utils Test Suite", () => {
     test("should detect Copilot response-too-long errors", () => {
       const error = new Error("Response too long.");
 
-      assert.strictEqual(isTokenLengthErrorLike(error), true);
+      assert.strictEqual(isResponseTooLongError(error), true);
     });
 
     test("should return false for non-length errors", () => {
       assert.strictEqual(
-        isTokenLengthErrorLike(new Error("network failure")),
+        isResponseTooLongError(new Error("network failure")),
         false,
       );
     });
 
     test("should return false for non-Error values", () => {
-      assert.strictEqual(isTokenLengthErrorLike("Response too long"), false);
-      assert.strictEqual(isTokenLengthErrorLike(null), false);
-      assert.strictEqual(isTokenLengthErrorLike(undefined), false);
+      assert.strictEqual(isResponseTooLongError("Response too long"), false);
+      assert.strictEqual(isResponseTooLongError(null), false);
+      assert.strictEqual(isResponseTooLongError(undefined), false);
     });
   });
 });

--- a/src/test/server/anthropic.test.ts
+++ b/src/test/server/anthropic.test.ts
@@ -8,6 +8,7 @@ import {
   convertAnthropicToolChoiceToVSCode,
   convertAnthropicToolToVSCode,
 } from "../../server/utils/anthropic";
+import { isTokenLengthErrorLike } from "../../server/utils/languageModelErrors";
 
 suite("Anthropic Conversion Utils Test Suite", () => {
   suite("convertAnthropicMessageToVSCode", () => {
@@ -135,7 +136,7 @@ suite("Anthropic Conversion Utils Test Suite", () => {
       assert.ok(imagePart);
       if (imagePart instanceof vscode.LanguageModelTextPart) {
         assert.ok(
-          !imagePart.value.startsWith("{\"type\":\"image\""),
+          !imagePart.value.startsWith('{"type":"image"'),
           "image block should not be delivered as a JSON-stringified text blob",
         );
       }
@@ -171,7 +172,9 @@ suite("Anthropic Conversion Utils Test Suite", () => {
       const toolResultPart = result
         .content[0] as vscode.LanguageModelToolResultPart;
       assert.strictEqual(toolResultPart.content.length, 2);
-      assert.ok(toolResultPart.content[0] instanceof vscode.LanguageModelTextPart);
+      assert.ok(
+        toolResultPart.content[0] instanceof vscode.LanguageModelTextPart,
+      );
       assert.strictEqual(
         (toolResultPart.content[0] as vscode.LanguageModelTextPart).value,
         "Here is the screenshot:",
@@ -180,7 +183,7 @@ suite("Anthropic Conversion Utils Test Suite", () => {
       assert.ok(imagePart);
       if (imagePart instanceof vscode.LanguageModelTextPart) {
         assert.ok(
-          !imagePart.value.startsWith("{\"type\":\"image\""),
+          !imagePart.value.startsWith('{"type":"image"'),
           "image block should not be delivered as a JSON-stringified text blob",
         );
       }
@@ -398,6 +401,27 @@ suite("Anthropic Conversion Utils Test Suite", () => {
     test("should return undefined for undefined tool choice", () => {
       const result = convertAnthropicToolChoiceToVSCode(undefined);
       assert.strictEqual(result, undefined);
+    });
+  });
+
+  suite("Anthropic max_tokens length stop handling", () => {
+    test("should detect Copilot response-too-long errors", () => {
+      const error = new Error("Response too long.");
+
+      assert.strictEqual(isTokenLengthErrorLike(error), true);
+    });
+
+    test("should return false for non-length errors", () => {
+      assert.strictEqual(
+        isTokenLengthErrorLike(new Error("network failure")),
+        false,
+      );
+    });
+
+    test("should return false for non-Error values", () => {
+      assert.strictEqual(isTokenLengthErrorLike("Response too long"), false);
+      assert.strictEqual(isTokenLengthErrorLike(null), false);
+      assert.strictEqual(isTokenLengthErrorLike(undefined), false);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Wrap stream iteration in `/v1/messages` (both streaming and non-streaming paths) so VS Code/Copilot "Response too long" errors produce a partial response with `stop_reason: "max_tokens"` instead of a 500.
- Add `isTokenLengthErrorLike` helper in `src/server/utils/languageModelErrors.ts` to detect the length-truncation error.
- Guard the final `content_block_stop` SSE so no event is emitted when the error fires before any block starts.

## Test plan
- [x] Unit tests for `isTokenLengthErrorLike` (positive, non-length error, non-Error values)
- [x] Manual: trigger a long Copilot response and confirm client receives partial content with `stop_reason: "max_tokens"` (non-stream + stream)

🤖 Generated with [Claude Code](https://claude.com/claude-code)