### PR TITLE
feat(anthropic): add /v1/models and /v1/models/{model_id}

### DIFF
--- a/.changeset/pink-dodos-rhyme.md
+++ b/.changeset/pink-dodos-rhyme.md
@@ -1,0 +1,5 @@
+---
+"agent-maestro": minor
+---
+
+Add Anthropic-compatible model listing and retrieval endpoints, including model context limits and known capability metadata from VS Code language models.

--- a/package.json
+++ b/package.json
@@ -182,7 +182,7 @@
     "onStartupFinished"
   ],
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.71.0",
+    "@anthropic-ai/sdk": "^0.96.0",
     "@google/genai": "^1.29.1",
     "@hono/node-server": "^1.17.1",
     "@hono/zod-openapi": "^1.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,8 +10,8 @@ importers:
   .:
     dependencies:
       "@anthropic-ai/sdk":
-        specifier: ^0.71.0
-        version: 0.71.0(zod@4.0.10)
+        specifier: ^0.96.0
+        version: 0.96.0(zod@4.0.10)
       "@google/genai":
         specifier: ^1.29.1
         version: 1.29.1
@@ -108,10 +108,10 @@ importers:
         version: 5.8.3
 
 packages:
-  "@anthropic-ai/sdk@0.71.0":
+  "@anthropic-ai/sdk@0.96.0":
     resolution:
       {
-        integrity: sha512-go1XeWXmpxuiTkosSXpb8tokLk2ZLkIRcXpbWVwJM6gH5OBtHOVsfPfGuqI1oW7RRt4qc59EmYbrXRZ0Ng06Jw==,
+        integrity: sha512-KlCsODtTyb17bLUVCSDC2HtSvAbJf60sEiPEax9dInF+aDF92vS4TZJ5XD7YCQXNb1/5icYaw8Y7wMjPlIV9Zg==,
       }
     hasBin: true
     peerDependencies:
@@ -918,6 +918,7 @@ packages:
     engines: { node: ">= 10" }
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   "@node-rs/crc32-linux-arm64-musl@1.10.6":
     resolution:
@@ -927,6 +928,7 @@ packages:
     engines: { node: ">= 10" }
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   "@node-rs/crc32-linux-x64-gnu@1.10.6":
     resolution:
@@ -936,6 +938,7 @@ packages:
     engines: { node: ">= 10" }
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   "@node-rs/crc32-linux-x64-musl@1.10.6":
     resolution:
@@ -945,6 +948,7 @@ packages:
     engines: { node: ">= 10" }
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   "@node-rs/crc32-wasm32-wasi@1.10.6":
     resolution:
@@ -1122,6 +1126,12 @@ packages:
         integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==,
       }
     engines: { node: ">=18" }
+
+  "@stablelib/base64@1.0.1":
+    resolution:
+      {
+        integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==,
+      }
 
   "@standard-schema/spec@1.0.0":
     resolution:
@@ -2590,6 +2600,12 @@ packages:
     resolution:
       {
         integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==,
+      }
+
+  fast-sha256@1.3.0:
+    resolution:
+      {
+        integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==,
       }
 
   fast-uri@3.0.6:
@@ -5214,6 +5230,12 @@ packages:
         integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==,
       }
 
+  standardwebhooks@1.0.0:
+    resolution:
+      {
+        integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==,
+      }
+
   statuses@2.0.1:
     resolution:
       {
@@ -6022,9 +6044,10 @@ packages:
       }
 
 snapshots:
-  "@anthropic-ai/sdk@0.71.0(zod@4.0.10)":
+  "@anthropic-ai/sdk@0.96.0(zod@4.0.10)":
     dependencies:
       json-schema-to-ts: 3.1.1
+      standardwebhooks: 1.0.0
     optionalDependencies:
       zod: 4.0.10
 
@@ -6717,6 +6740,8 @@ snapshots:
   "@sindresorhus/merge-streams@2.3.0": {}
 
   "@sindresorhus/merge-streams@4.0.0": {}
+
+  "@stablelib/base64@1.0.1": {}
 
   "@standard-schema/spec@1.0.0": {}
 
@@ -7783,6 +7808,8 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fast-sha256@1.3.0: {}
 
   fast-uri@3.0.6: {}
 
@@ -9391,6 +9418,11 @@ snapshots:
   spdx-license-ids@3.0.21: {}
 
   sprintf-js@1.0.3: {}
+
+  standardwebhooks@1.0.0:
+    dependencies:
+      "@stablelib/base64": 1.0.1
+      fast-sha256: 1.3.0
 
   statuses@2.0.1: {}
 

--- a/src/server/routes/anthropicRoutes.ts
+++ b/src/server/routes/anthropicRoutes.ts
@@ -15,7 +15,10 @@ import {
   convertAnthropicToolToVSCode,
   countAnthropicMessageTokens,
 } from "../utils/anthropic";
-import { createAnthropicModelsResponse } from "../utils/anthropicModels";
+import {
+  createAnthropicModelsResponse,
+  findAnthropicModelById,
+} from "../utils/anthropicModels";
 import { handleErrorWithLogging } from "../utils/errorDiagnostics";
 import { isResponseTooLongError } from "../utils/languageModelErrors";
 
@@ -213,6 +216,51 @@ const modelsRoute = createRoute({
   },
 });
 
+const modelRoute = createRoute({
+  method: "get",
+  path: "/v1/models/{model_id}",
+  tags: ["Anthropic API"],
+  summary: "Retrieve an Anthropic-compatible model",
+  description:
+    "Retrieve one Claude model available through VS Code Language Models using an Anthropic-compatible response shape.",
+  request: {
+    params: z.object({
+      model_id: z.string().describe("Model identifier"),
+    }),
+  },
+  responses: {
+    200: {
+      content: {
+        "application/json": {
+          // Skip schema validation to support API schema changes without requiring immediate updates.
+          schema: z
+            .object()
+            .describe(
+              "Anthropic Models API response body. See https://docs.anthropic.com/en/api/models-retrieve for schema details.",
+            ),
+        },
+      },
+      description: "Successfully retrieved model",
+    },
+    404: {
+      content: {
+        "application/json": {
+          schema: AnthropicErrorResponseSchema,
+        },
+      },
+      description: "Model not found",
+    },
+    500: {
+      content: {
+        "application/json": {
+          schema: AnthropicErrorResponseSchema,
+        },
+      },
+      description: "Internal server error",
+    },
+  },
+});
+
 export function registerAnthropicRoutes(app: OpenAPIHono) {
   // GET /v1/models - Anthropic-compatible models endpoint
   app.openapi(modelsRoute, async (c) => {
@@ -229,6 +277,43 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
           error: {
             message:
               error instanceof Error ? error.message : "Failed to fetch models",
+            type: "api_error",
+          },
+        },
+        500,
+      );
+    }
+  });
+
+  // GET /v1/models/{model_id} - Anthropic-compatible model retrieval endpoint
+  app.openapi(modelRoute, async (c) => {
+    const { model_id: modelId } = c.req.valid("param");
+
+    try {
+      logger.info(`Fetching Anthropic-compatible model: ${modelId}`);
+      const models = await chatModelsCache.getChatModels();
+      const model = findAnthropicModelById(models, modelId);
+
+      if (!model) {
+        return c.json(
+          {
+            error: {
+              message: `Model '${modelId}' not found`,
+              type: "not_found_error",
+            },
+          },
+          404,
+        );
+      }
+
+      return c.json(model, 200);
+    } catch (error) {
+      logger.error("Error fetching Anthropic-compatible model:", error);
+      return c.json(
+        {
+          error: {
+            message:
+              error instanceof Error ? error.message : "Failed to fetch model",
             type: "api_error",
           },
         },

--- a/src/server/routes/anthropicRoutes.ts
+++ b/src/server/routes/anthropicRoutes.ts
@@ -272,6 +272,7 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
               content.push({
                 type: "tool_use",
                 id: chunk.callId,
+                caller: { type: "direct" },
                 name: chunk.name,
                 input: chunk.input,
               });
@@ -301,7 +302,9 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
           type: "message",
           role: "assistant",
           model,
+          container: null,
           content,
+          stop_details: null,
           stop_reason:
             stopReason === "max_tokens"
               ? "max_tokens"
@@ -313,6 +316,7 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
             cache_creation: null,
             cache_creation_input_tokens: 0,
             cache_read_input_tokens: 0,
+            inference_geo: null,
             input_tokens: inputTokenCount.calibrated,
             output_tokens: outputTokenCount.calibrated,
             server_tool_use: null,
@@ -350,7 +354,9 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
               type: "message",
               role: "assistant",
               model,
+              container: null,
               content: [],
+              stop_details: null,
               stop_reason: null,
               stop_sequence: null,
               usage: {
@@ -359,6 +365,7 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
                 output_tokens: 1,
                 cache_creation_input_tokens: 0,
                 cache_read_input_tokens: 0,
+                inference_geo: null,
                 server_tool_use: null,
                 service_tier: "standard",
               },
@@ -417,6 +424,7 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
                 contentBlocks.push({
                   type: "tool_use",
                   id: chunk.callId,
+                  caller: { type: "direct" },
                   name: chunk.name,
                   input: chunk.input,
                 });
@@ -427,6 +435,7 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
                   content_block: {
                     type: "tool_use",
                     id: chunk.callId,
+                    caller: { type: "direct" },
                     name: chunk.name,
                     input: {},
                   },
@@ -474,6 +483,8 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
           await writeSSE({
             type: "message_delta",
             delta: {
+              container: null,
+              stop_details: null,
               stop_reason:
                 stopReason === "max_tokens"
                   ? "max_tokens"
@@ -558,7 +569,9 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
                   type: "message",
                   role: "assistant",
                   model,
+                  container: null,
                   content: [],
+                  stop_details: null,
                   stop_reason: null,
                   stop_sequence: null,
                   usage: {
@@ -567,6 +580,7 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
                     output_tokens: 0,
                     cache_creation_input_tokens: 0,
                     cache_read_input_tokens: 0,
+                    inference_geo: null,
                     server_tool_use: null,
                     service_tier: "standard",
                   },
@@ -576,6 +590,8 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
               await writeSSE({
                 type: "message_delta",
                 delta: {
+                  container: null,
+                  stop_details: null,
                   stop_reason:
                     "model_context_window_exceeded" as Anthropic.Messages.StopReason,
                   stop_sequence: null,
@@ -605,7 +621,9 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
           type: "message",
           role: "assistant",
           model,
+          container: null,
           content: [],
+          stop_details: null,
           stop_reason:
             "model_context_window_exceeded" as Anthropic.Messages.StopReason,
           stop_sequence: null,
@@ -613,6 +631,7 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
             cache_creation: null,
             cache_creation_input_tokens: 0,
             cache_read_input_tokens: 0,
+            inference_geo: null,
             input_tokens: inputTokens * 2, // Inflate to ensure Claude Code triggers auto-compact before next message
             output_tokens: 0,
             server_tool_use: null,

--- a/src/server/routes/anthropicRoutes.ts
+++ b/src/server/routes/anthropicRoutes.ts
@@ -4,7 +4,7 @@ import { Context } from "hono";
 import { streamSSE } from "hono/streaming";
 import * as vscode from "vscode";
 
-import { getChatModelClient } from "../../utils/chatModels";
+import { chatModelsCache, getChatModelClient } from "../../utils/chatModels";
 import { resolveClaudeCodeModelId } from "../../utils/claude";
 import { logger } from "../../utils/logger";
 import { AnthropicErrorResponseSchema } from "../schemas/anthropic";
@@ -15,6 +15,7 @@ import {
   convertAnthropicToolToVSCode,
   countAnthropicMessageTokens,
 } from "../utils/anthropic";
+import { createAnthropicModelsResponse } from "../utils/anthropicModels";
 import { handleErrorWithLogging } from "../utils/errorDiagnostics";
 import { isResponseTooLongError } from "../utils/languageModelErrors";
 
@@ -180,7 +181,62 @@ const countTokensRoute = createRoute({
   },
 });
 
+const modelsRoute = createRoute({
+  method: "get",
+  path: "/v1/models",
+  tags: ["Anthropic API"],
+  summary: "List Anthropic-compatible models",
+  description:
+    "List Claude models available through VS Code Language Models using an Anthropic-compatible response shape.",
+  responses: {
+    200: {
+      content: {
+        "application/json": {
+          // Skip schema validation to support API schema changes without requiring immediate updates.
+          schema: z
+            .object()
+            .describe(
+              "Anthropic Models API response body. See https://docs.anthropic.com/en/api/models-list for schema details.",
+            ),
+        },
+      },
+      description: "Successfully listed models",
+    },
+    500: {
+      content: {
+        "application/json": {
+          schema: AnthropicErrorResponseSchema,
+        },
+      },
+      description: "Internal server error",
+    },
+  },
+});
+
 export function registerAnthropicRoutes(app: OpenAPIHono) {
+  // GET /v1/models - Anthropic-compatible models endpoint
+  app.openapi(modelsRoute, async (c) => {
+    try {
+      logger.info("Fetching Anthropic-compatible models from VS Code LM API");
+      const models = await chatModelsCache.getChatModels();
+      const response = createAnthropicModelsResponse(models);
+      logger.info(`Retrieved ${response.data.length} Anthropic models`);
+      return c.json(response, 200);
+    } catch (error) {
+      logger.error("Error fetching Anthropic-compatible models:", error);
+      return c.json(
+        {
+          error: {
+            message:
+              error instanceof Error ? error.message : "Failed to fetch models",
+            type: "api_error",
+          },
+        },
+        500,
+      );
+    }
+  });
+
   // POST /v1/messages - Anthropic-compatible messages endpoint
   app.openapi(messagesRoute, async (c: Context): Promise<Response> => {
     let effectiveModelId = "";

--- a/src/server/utils/anthropicModels.ts
+++ b/src/server/utils/anthropicModels.ts
@@ -11,7 +11,7 @@ export interface AnthropicModelsResponse {
   last_id: string | null;
 }
 
-const UNKNOWN_MODEL_CREATED_AT = "2025-06-01T12:09:17Z";
+const UNKNOWN_MODEL_CREATED_AT = "1970-01-01T00:00:00Z";
 const supported = { supported: true };
 const unsupported = { supported: false };
 
@@ -80,7 +80,7 @@ export function convertVSCodeModelToAnthropicModel(
     created_at: UNKNOWN_MODEL_CREATED_AT,
     display_name: model.name,
     max_input_tokens: model.maxInputTokens,
-    max_tokens: 0,
+    max_tokens: null,
     type: "model",
   };
 }

--- a/src/server/utils/anthropicModels.ts
+++ b/src/server/utils/anthropicModels.ts
@@ -99,3 +99,11 @@ export function createAnthropicModelsResponse(
     last_id: data.at(-1)?.id ?? null,
   };
 }
+
+export function findAnthropicModelById(
+  models: vscode.LanguageModelChat[],
+  modelId: string,
+): ModelInfo | null {
+  const model = models.find((m) => isClaudeModel(m) && m.id === modelId);
+  return model ? convertVSCodeModelToAnthropicModel(model) : null;
+}

--- a/src/server/utils/anthropicModels.ts
+++ b/src/server/utils/anthropicModels.ts
@@ -1,0 +1,101 @@
+import {
+  ModelCapabilities,
+  ModelInfo,
+} from "@anthropic-ai/sdk/resources/models";
+import * as vscode from "vscode";
+
+export interface AnthropicModelsResponse {
+  data: ModelInfo[];
+  first_id: string | null;
+  has_more: boolean;
+  last_id: string | null;
+}
+
+const UNKNOWN_MODEL_CREATED_AT = "1970-01-01T00:00:00Z";
+const supported = { supported: true };
+const unsupported = { supported: false };
+
+interface VSCodeModelCapabilities {
+  supportsImageToText?: boolean;
+  supportsToolCalling?: boolean;
+}
+
+function getCapabilities(
+  model: vscode.LanguageModelChat,
+): VSCodeModelCapabilities {
+  return (
+    (model as { capabilities?: VSCodeModelCapabilities }).capabilities ?? {}
+  );
+}
+
+function convertVSCodeCapabilitiesToAnthropic(
+  model: vscode.LanguageModelChat,
+): ModelCapabilities {
+  const capabilities = getCapabilities(model);
+  const supportsImageInput = capabilities.supportsImageToText === true;
+  const supportsToolCalling = capabilities.supportsToolCalling === true;
+
+  return {
+    batch: unsupported,
+    citations: unsupported,
+    code_execution: unsupported,
+    context_management: {
+      clear_thinking_20251015: unsupported,
+      clear_tool_uses_20250919: unsupported,
+      compact_20260112: unsupported,
+      supported: false,
+    },
+    effort: {
+      high: unsupported,
+      low: unsupported,
+      max: unsupported,
+      medium: unsupported,
+      supported: false,
+      xhigh: unsupported,
+    },
+    image_input: supportsImageInput ? supported : unsupported,
+    pdf_input: unsupported,
+    structured_outputs: supportsToolCalling ? supported : unsupported,
+    thinking: {
+      supported: false,
+      types: {
+        adaptive: unsupported,
+        enabled: unsupported,
+      },
+    },
+  };
+}
+
+function isClaudeModel(model: vscode.LanguageModelChat): boolean {
+  const searchable = `${model.id} ${model.name} ${model.family}`.toLowerCase();
+  return searchable.includes("claude");
+}
+
+export function convertVSCodeModelToAnthropicModel(
+  model: vscode.LanguageModelChat,
+): ModelInfo {
+  return {
+    id: model.id,
+    capabilities: convertVSCodeCapabilitiesToAnthropic(model),
+    created_at: UNKNOWN_MODEL_CREATED_AT,
+    display_name: model.name,
+    max_input_tokens: model.maxInputTokens,
+    max_tokens: 0,
+    type: "model",
+  };
+}
+
+export function createAnthropicModelsResponse(
+  models: vscode.LanguageModelChat[],
+): AnthropicModelsResponse {
+  const data = models
+    .filter(isClaudeModel)
+    .map(convertVSCodeModelToAnthropicModel);
+
+  return {
+    data,
+    first_id: data[0]?.id ?? null,
+    has_more: false,
+    last_id: data.at(-1)?.id ?? null,
+  };
+}

--- a/src/server/utils/anthropicModels.ts
+++ b/src/server/utils/anthropicModels.ts
@@ -11,7 +11,7 @@ export interface AnthropicModelsResponse {
   last_id: string | null;
 }
 
-const UNKNOWN_MODEL_CREATED_AT = "1970-01-01T00:00:00Z";
+const UNKNOWN_MODEL_CREATED_AT = "2025-06-01T12:09:17Z";
 const supported = { supported: true };
 const unsupported = { supported: false };
 

--- a/src/test/server/anthropic.test.ts
+++ b/src/test/server/anthropic.test.ts
@@ -8,9 +8,116 @@ import {
   convertAnthropicToolChoiceToVSCode,
   convertAnthropicToolToVSCode,
 } from "../../server/utils/anthropic";
+import { createAnthropicModelsResponse } from "../../server/utils/anthropicModels";
 import { isResponseTooLongError } from "../../server/utils/languageModelErrors";
 
+function createMockModel(
+  overrides: Partial<vscode.LanguageModelChat> & {
+    capabilities?: {
+      supportsImageToText?: boolean;
+      supportsToolCalling?: boolean;
+    };
+  },
+): vscode.LanguageModelChat {
+  return {
+    id: "claude-sonnet-4.6",
+    name: "Claude Sonnet 4.6",
+    family: "claude",
+    version: "4.6",
+    vendor: "copilot",
+    maxInputTokens: 200000,
+    capabilities: {
+      supportsImageToText: false,
+      supportsToolCalling: true,
+    },
+    sendRequest: async () => {
+      throw new Error("not implemented");
+    },
+    countTokens: async () => 0,
+    ...overrides,
+  } as vscode.LanguageModelChat;
+}
+
 suite("Anthropic Conversion Utils Test Suite", () => {
+  suite("createAnthropicModelsResponse", () => {
+    test("should expose max_input_tokens from Claude models", () => {
+      const result = createAnthropicModelsResponse([
+        createMockModel({
+          id: "claude-opus-4.7",
+          name: "Claude Opus 4.7",
+          maxInputTokens: 1000000,
+        }),
+      ]);
+
+      assert.strictEqual(result.data.length, 1);
+      assert.strictEqual(result.data[0].id, "claude-opus-4.7");
+      assert.strictEqual(result.data[0].display_name, "Claude Opus 4.7");
+      assert.strictEqual(result.data[0].max_input_tokens, 1000000);
+      assert.strictEqual(
+        result.data[0].capabilities?.image_input.supported,
+        false,
+      );
+      assert.strictEqual(
+        result.data[0].capabilities?.structured_outputs.supported,
+        true,
+      );
+      assert.strictEqual(result.data[0].type, "model");
+      assert.strictEqual(result.first_id, "claude-opus-4.7");
+      assert.strictEqual(result.last_id, "claude-opus-4.7");
+      assert.strictEqual(result.has_more, false);
+    });
+
+    test("should preserve zero max_input_tokens", () => {
+      const result = createAnthropicModelsResponse([
+        createMockModel({ maxInputTokens: 0 }),
+      ]);
+
+      assert.strictEqual(result.data[0].max_input_tokens, 0);
+    });
+
+    test("should translate known VS Code capabilities", () => {
+      const result = createAnthropicModelsResponse([
+        createMockModel({
+          capabilities: {
+            supportsImageToText: true,
+            supportsToolCalling: false,
+          },
+        }),
+      ]);
+
+      assert.strictEqual(
+        result.data[0].capabilities?.image_input.supported,
+        true,
+      );
+      assert.strictEqual(
+        result.data[0].capabilities?.structured_outputs.supported,
+        false,
+      );
+      assert.strictEqual(
+        result.data[0].capabilities?.code_execution.supported,
+        false,
+      );
+      assert.strictEqual(
+        result.data[0].capabilities?.thinking.supported,
+        false,
+      );
+    });
+
+    test("should omit non-Claude models", () => {
+      const result = createAnthropicModelsResponse([
+        createMockModel({
+          id: "gpt-5.1",
+          name: "GPT-5.1",
+          family: "gpt",
+        }),
+      ]);
+
+      assert.deepStrictEqual(result.data, []);
+      assert.strictEqual(result.first_id, null);
+      assert.strictEqual(result.last_id, null);
+    });
+  });
+
   suite("convertAnthropicMessageToVSCode", () => {
     test("should convert user message with string content", () => {
       const message = {

--- a/src/test/server/anthropic.test.ts
+++ b/src/test/server/anthropic.test.ts
@@ -65,6 +65,7 @@ suite("Anthropic Conversion Utils Test Suite", () => {
         true,
       );
       assert.strictEqual(result.data[0].type, "model");
+      assert.strictEqual(result.data[0].max_tokens, null);
       assert.strictEqual(result.first_id, "claude-opus-4.7");
       assert.strictEqual(result.last_id, "claude-opus-4.7");
       assert.strictEqual(result.has_more, false);

--- a/src/test/server/anthropic.test.ts
+++ b/src/test/server/anthropic.test.ts
@@ -8,7 +8,10 @@ import {
   convertAnthropicToolChoiceToVSCode,
   convertAnthropicToolToVSCode,
 } from "../../server/utils/anthropic";
-import { createAnthropicModelsResponse } from "../../server/utils/anthropicModels";
+import {
+  createAnthropicModelsResponse,
+  findAnthropicModelById,
+} from "../../server/utils/anthropicModels";
 import { isResponseTooLongError } from "../../server/utils/languageModelErrors";
 
 function createMockModel(
@@ -115,6 +118,39 @@ suite("Anthropic Conversion Utils Test Suite", () => {
       assert.deepStrictEqual(result.data, []);
       assert.strictEqual(result.first_id, null);
       assert.strictEqual(result.last_id, null);
+    });
+
+    test("should find one Claude model by exact id", () => {
+      const result = findAnthropicModelById(
+        [
+          createMockModel({ id: "claude-sonnet-4.6" }),
+          createMockModel({
+            id: "claude-opus-4.7",
+            name: "Claude Opus 4.7",
+            maxInputTokens: 1000000,
+          }),
+        ],
+        "claude-opus-4.7",
+      );
+
+      assert.ok(result);
+      assert.strictEqual(result.id, "claude-opus-4.7");
+      assert.strictEqual(result.max_input_tokens, 1000000);
+    });
+
+    test("should not find non-Claude or unknown model ids", () => {
+      const result = findAnthropicModelById(
+        [
+          createMockModel({
+            id: "gpt-5.1",
+            name: "GPT-5.1",
+            family: "gpt",
+          }),
+        ],
+        "gpt-5.1",
+      );
+
+      assert.strictEqual(result, null);
     });
   });
 


### PR DESCRIPTION
## Summary
- Bump @anthropic-ai/sdk to 0.96.0 and align synthesized Anthropic response fields with the newer SDK types
- Add Anthropic-compatible GET /v1/models and GET /v1/models/{model_id}
- Map VS Code Claude model metadata into Anthropic ModelInfo, including max_input_tokens and known capability flags
- Keep the model list intentionally non-paginated in this compatibility layer (`has_more: false`)

## Test plan
- pnpm check-types
- pnpm lint
- pnpm run build-tests
- pnpm build