### PR TITLE
chore(release): v2.9.0 with agent guidance and IPv4 loopback fix

### DIFF
--- a/.changeset/bumpy-radios-tell.md
+++ b/.changeset/bumpy-radios-tell.md
@@ -1,0 +1,5 @@
+---
+"agent-maestro": patch
+---
+
+Use the IPv4 loopback address for generated Claude Code, Codex, and Gemini CLI proxy URLs to avoid localhost resolution issues.

--- a/.changeset/bumpy-radios-tell.md
+++ b/.changeset/bumpy-radios-tell.md
@@ -1,5 +1,0 @@
----
-"agent-maestro": patch
----
-
-Use the IPv4 loopback address for generated Claude Code, Codex, and Gemini CLI proxy URLs to avoid localhost resolution issues.

--- a/.changeset/cached-token-compat.md
+++ b/.changeset/cached-token-compat.md
@@ -1,5 +1,0 @@
----
-"agent-maestro": patch
----
-
-Report numeric zero cache-token usage fields across Anthropic, OpenAI, and Gemini-compatible routes and strip unsupported OpenAI prompt cache hints before forwarding model options.

--- a/.changeset/pink-dodos-rhyme.md
+++ b/.changeset/pink-dodos-rhyme.md
@@ -1,5 +1,0 @@
----
-"agent-maestro": minor
----
-
-Add Anthropic-compatible model listing and retrieval endpoints, including model context limits and known capability metadata from VS Code language models.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Guidance for AI coding agents working in this repository. Human contributors sho
 Agent Maestro is a VS Code extension that:
 
 - Orchestrates third-party AI coding extensions (Cline, Roo Code, Kilo Code, etc.) via internal adapters.
-- Exposes a local proxy server (default port `23333`) presenting OpenAI- and Anthropic-compatible APIs backed by the VS Code Language Model API (GitHub Copilot models, Claude Code, Codex).
+- Exposes a local proxy server (default port `23333`) presenting OpenAI-, Anthropic-, and Gemini-compatible APIs backed by the VS Code Language Model API (GitHub Copilot models), used by clients such as Claude Code, Codex, and Gemini.
 - Runs an MCP server (default port `23334`) for Model Context Protocol clients.
 
 Primary language: **TypeScript** (ESM, Node ≥ 22, VS Code ≥ 1.100). Package manager: **pnpm 10**.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,98 @@
+# AGENTS.md
+
+Guidance for AI coding agents working in this repository. Human contributors should read `README.md` first.
+
+## Project overview
+
+Agent Maestro is a VS Code extension that:
+
+- Orchestrates third-party AI coding extensions (Cline, Roo Code, Kilo Code, etc.) via internal adapters.
+- Exposes a local proxy server (default port `23333`) presenting OpenAI- and Anthropic-compatible APIs backed by the VS Code Language Model API (GitHub Copilot models, Claude Code, Codex).
+- Runs an MCP server (default port `23334`) for Model Context Protocol clients.
+
+Primary language: **TypeScript** (ESM, Node ≥ 22, VS Code ≥ 1.100). Package manager: **pnpm 10**.
+
+## Repository layout
+
+- `src/extension.ts` — extension entry point.
+- `src/commands/` — VS Code command handlers registered in `package.json`.
+- `src/core/` — adapters for third-party extensions (`ClineAdapter`, `RooCodeAdapter`, etc.) and the central `controller`.
+- `src/server/` — proxy + MCP servers.
+  - `routes/anthropicRoutes.ts`, `routes/openai/` — API-compatible endpoints.
+  - `schemas/` — Zod request/response schemas (also drive OpenAPI).
+  - `utils/` — request conversion helpers between Anthropic/OpenAI and the VS Code LM API.
+- `src/utils/` — shared utilities (logger, config, chat-model resolution, Claude Code helpers).
+- `src/test/` — Mocha tests run via `@vscode/test-electron`.
+- `docs/`, `website/` — user-facing documentation.
+- `.changeset/` — pending release notes (Changesets).
+
+## Commands
+
+Run via pnpm. Do not use npm or yarn.
+
+| Task                | Command            |
+| ------------------- | ------------------ |
+| Install deps        | `pnpm install`     |
+| Type-check          | `pnpm check-types` |
+| Lint                | `pnpm lint`        |
+| Build (dev)         | `pnpm build`       |
+| Build (prod)        | `pnpm build:prod`  |
+| Run tests           | `pnpm test`        |
+| Watch (build + tsc) | `pnpm watch`       |
+| Add a changeset     | `pnpm changeset`   |
+
+`pnpm test` boots a VS Code test host and is slow; prefer `pnpm check-types` + `pnpm lint` for fast feedback during edits, and only run the full test suite when behavior changes.
+
+Default validation checklist before opening a PR:
+
+- `pnpm check-types`
+- `pnpm lint`
+- `pnpm test` (when behavior changes)
+
+Pre-commit runs ESLint and Prettier via Husky + lint-staged. Do not bypass with `--no-verify`.
+
+## Code style
+
+- Prettier (`.prettierrc`) and ESLint (`eslint.config.mjs`) are authoritative — let them format. Imports are sorted by `@trivago/prettier-plugin-sort-imports`.
+- TypeScript strict mode. Prefer explicit types on exported APIs; let inference handle locals.
+- ESM only (`"type": "module"`). Use `import`/`export`, never `require` in source.
+- Logging goes through `src/utils/logger.ts` (`logger.info` / `logger.warn` / `logger.debug` / `logger.error`). Do not use `console.*` in `src/`.
+- Avoid emojis in source, logs, and commit messages unless the user requests them.
+
+## Editing conventions
+
+- Prefer editing existing files over creating new ones.
+- For behavior changes, review and update existing user-facing docs first (especially `README.md`) instead of creating new docs unless clearly needed.
+- Don't add comments that restate the code. Reserve comments for non-obvious _why_ (constraint, workaround, surprising invariant).
+- Don't add backwards-compatibility shims, dead exports, or "// removed" markers when deleting code — just remove it.
+- Don't introduce new abstractions or refactors outside the scope of the requested task.
+- Validate at system boundaries (request handlers, external APIs). Trust internal calls.
+
+## Tests
+
+- Tests live under `src/test/` and use Mocha + Node `assert`. Match the existing `suite` / `test` style.
+- Add tests for new request-conversion logic, new route behavior, and any bug fix with a reproducible case.
+- UI/extension-host behavior cannot be covered by unit tests alone — if the change affects VS Code commands or UI, say so explicitly rather than claiming verification.
+
+## Commits, changesets, and releases
+
+- Commit message style follows Conventional Commits (`fix(scope): …`, `feat(scope): …`, `refactor: …`). See `git log` for examples.
+- **Every user-visible change needs a changeset.** User-visible includes anything users can see or feel (UI text/behavior, API behavior, bug fixes, performance improvements). Developer-only internal changes (e.g., tests-only updates or refactors/tooling changes with no user-facing effect) generally do not need a changeset. Run `pnpm changeset`, pick `patch` / `minor` / `major`, and commit the generated file in `.changeset/`.
+- Release flow: a maintainer runs `pnpm changeset:version` (bumps `package.json`, regenerates `CHANGELOG.md`, deletes consumed changesets) and opens a release PR. Agents should not bump versions or edit `CHANGELOG.md` directly unless explicitly asked to cut a release.
+- Never force-push, never push directly to `main`, and confirm before pushing any branch.
+
+## Risky actions — confirm first
+
+Ask before doing any of these, even if a prior similar action was approved:
+
+- `git push`, force-push, branch deletion, tag creation.
+- Editing CI workflows in `.github/`.
+- Publishing to VS Code Marketplace / Open VSX (`publish:vs-marketplace`, `publish:open-vsx`).
+- Deleting or rewriting `.changeset/` entries, `CHANGELOG.md`, or version fields.
+- Adding, removing, or bumping dependencies, or changing package/runtime versions.
+
+## Pull requests
+
+- Keep PRs scoped to one logical change. Split release-prep commits from feature/fix commits.
+- PR title mirrors the primary commit (`fix(anthropic): …`).
+- PR body: short summary + test plan checklist. Reference the changeset.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v2.9.0 - 2026.05.16
+
+- Add Anthropic-compatible model listing and retrieval endpoints to support Claude Desktop 3P gateway compatibility, including model context limits and known capability metadata from VS Code language models.
+- Use the IPv4 loopback address for generated Claude Code, Codex, and Gemini CLI proxy URLs to avoid localhost resolution issues.
+- Report numeric zero cache-token usage fields across Anthropic, OpenAI, and Gemini-compatible routes and strip unsupported OpenAI prompt cache hints before forwarding model options.
+
 ## v2.8.7 - 2026.05.12
 
 - Fix Anthropic `/v1/messages` length-truncated responses from VS Code/Copilot so partial content can be returned successfully with `stop_reason: "max_tokens"` instead of a 500 error.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "agent-maestro",
   "displayName": "Agent Maestro",
   "description": "Turn VS Code into your compliant AI playground! With Agent Maestro, spin up Cline or Roo on demand and plug Claude Code or Codex straight in through an OpenAI/Anthropic-compatible API.",
-  "version": "2.8.7",
+  "version": "2.9.0",
   "icon": "assets/icons/icon.png",
   "publisher": "Joouis",
   "repository": "https://github.com/Joouis/agent-maestro",

--- a/src/commands/configuratorCommands.ts
+++ b/src/commands/configuratorCommands.ts
@@ -15,6 +15,8 @@ import { logger } from "../utils/logger";
 import { updateEnvFile } from "../utils/updateEnvFile";
 import { createCommandHandler } from "./commandHandler";
 
+const LOOPBACK_HOST = "127.0.0.1";
+
 export function registerConfiguratorCommands(
   proxy: ProxyServer,
   context: vscode.ExtensionContext,
@@ -139,7 +141,7 @@ export function registerConfiguratorCommands(
           ...existingSettings,
           env: {
             ...existingEnv,
-            ANTHROPIC_BASE_URL: `http://localhost:${proxyPort}/api/anthropic`,
+            ANTHROPIC_BASE_URL: `http://${LOOPBACK_HOST}:${proxyPort}/api/anthropic`,
             ANTHROPIC_AUTH_TOKEN: authToken,
             ANTHROPIC_MODEL: withClaudeCode1mSuffix(
               selectedDefaultModel.modelId,
@@ -290,7 +292,7 @@ export function registerConfiguratorCommands(
             ...existingConfig.model_providers,
             "agent-maestro": {
               name: "Agent Maestro",
-              base_url: `http://localhost:${proxyPort}/api/openai/v1`,
+              base_url: `http://${LOOPBACK_HOST}:${proxyPort}/api/openai/v1`,
               wire_api: "responses",
             },
           },
@@ -438,7 +440,7 @@ export function registerConfiguratorCommands(
         await updateEnvFile(
           envFilePath,
           {
-            GOOGLE_GEMINI_BASE_URL: `http://localhost:${proxyPort}/api/gemini`,
+            GOOGLE_GEMINI_BASE_URL: `http://${LOOPBACK_HOST}:${proxyPort}/api/gemini`,
             GEMINI_API_KEY: '"Powered by Agent Maestro"',
             GEMINI_MODEL: selectedModel.modelId,
             GEMINI_TELEMETRY_ENABLED: "false",


### PR DESCRIPTION
## Summary
- add AGENTS.md guidance for coding agents working in this repository
- switch generated Claude/Codex/Gemini proxy URLs to IPv4 loopback (`127.0.0.1`)
- prepare release `v2.9.0` by consuming changesets, updating `CHANGELOG.md`, and bumping `package.json` version

## Test plan
- [x] `pnpm lint` (via pre-commit hook)
- [x] `pnpm check-types`
- [x] `pnpm test` (if behavior changes need full extension-host verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)