### PR TITLE
Disable CCH header to preserve prompt caching

### DIFF
--- a/.changeset/disable-cch-header.md
+++ b/.changeset/disable-cch-header.md
@@ -1,0 +1,5 @@
+---
+"@fake-scope/fake-pkg": patch
+---
+
+Set `CLAUDE_CODE_ATTRIBUTION_HEADER=0` in generated Claude Code `settings.json` to disable the `x-anthropic-billing-header` (CCH), which can break prompt caching on non-Anthropic LLM gateways. See https://code.claude.com/docs/en/llm-gateway.

--- a/.changeset/disable-cch-header.md
+++ b/.changeset/disable-cch-header.md
@@ -1,5 +1,5 @@
 ---
-"@fake-scope/fake-pkg": patch
+"agent-maestro": patch
 ---
 
 Set `CLAUDE_CODE_ATTRIBUTION_HEADER=0` in generated Claude Code `settings.json` to disable the `x-anthropic-billing-header` (CCH), which can break prompt caching on non-Anthropic LLM gateways. See https://code.claude.com/docs/en/llm-gateway.

--- a/src/commands/configuratorCommands.ts
+++ b/src/commands/configuratorCommands.ts
@@ -148,6 +148,8 @@ export function registerConfiguratorCommands(
             ),
             // Equivalent of setting `DISABLE_AUTOUPDATER`, `DISABLE_BUG_COMMAND`, `DISABLE_ERROR_REPORTING`, and `DISABLE_TELEMETRY` to true
             CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1",
+            // Disable the x-anthropic-billing-header (CCH) which can break prompt caching on non-Anthropic LLM gateways
+            CLAUDE_CODE_ATTRIBUTION_HEADER: "0",
           },
         };
 


### PR DESCRIPTION
Set CLAUDE_CODE_ATTRIBUTION_HEADER=0 in generated settings.json to disable the x-anthropic-billing-header, which can break prompt caching on non-Anthropic LLM gateways.

Reference: https://code.claude.com/docs/en/llm-gateway

<img width="1538" height="420" alt="image" src="https://github.com/user-attachments/assets/ba156c10-5220-42f4-a922-0df597a86bdf" />

## Before
<img width="1623" height="616" alt="image" src="https://github.com/user-attachments/assets/b461a78a-1e01-427d-b631-ae669700d0b3" />

## After
<img width="1176" height="377" alt="image" src="https://github.com/user-attachments/assets/c3b4bcf2-c849-4550-9e49-0a41934f08aa" />
