### PR TITLE
fix(anthropic): always translate orphan tool_use_id errors to context-window exceeded

### DIFF
--- a/.changeset/fix-orphan-tool-result-fallback.md
+++ b/.changeset/fix-orphan-tool-result-fallback.md
@@ -1,0 +1,5 @@
+---
+"agent-maestro": patch
+---
+
+Refine `/v1/messages` orphan `tool_use_id` handling so a Copilot-side bug isn't silently translated to `model_context_window_exceeded`. Now: (1) malformed client requests with orphan `tool_result` blocks are rejected up-front with a 400 `invalid_request_error`; (2) downstream orphan errors that survive that pre-flight are translated to `model_context_window_exceeded` only when the calibrated input token count is at or over the model's `max_input_tokens` — i.e. when Copilot's internal truncation is the plausible cause. Below the cap, the original error is now re-raised so a Copilot-side bug (also seen by litellm users) stays visible to whoever owns the upstream fix. Adds dogfood-friendly logging of `error.code` and the error constructor at every orphan catch so a future PR can replace message-substring matching with a stable code-based check once we confirm what Copilot actually fills.

--- a/src/server/routes/anthropicRoutes.ts
+++ b/src/server/routes/anthropicRoutes.ts
@@ -10,12 +10,16 @@ import { logger } from "../../utils/logger";
 import { AnthropicErrorResponseSchema } from "../schemas/anthropic";
 import {
   type AnthropicTokenUsage,
+  OrphanToolResultError,
   convertAnthropicMessagesToVSCode,
   convertAnthropicSystemToVSCode,
   convertAnthropicToolChoiceToVSCode,
   convertAnthropicToolToVSCode,
   countAnthropicMessageTokens,
   extractAnthropicTokenUsageFromVSCodeChunk,
+  isDownstreamTruncationOrphan,
+  isInputAtOrOverCapacity,
+  validateAnthropicToolPairing,
 } from "../utils/anthropic";
 import {
   createAnthropicModelsResponse,
@@ -23,6 +27,29 @@ import {
 } from "../utils/anthropicModels";
 import { handleErrorWithLogging } from "../utils/errorDiagnostics";
 import { isResponseTooLongError } from "../utils/languageModelErrors";
+
+const CONTEXT_WINDOW_WARNING_THROTTLE_MS = 15_000;
+let lastContextWindowWarningAt = 0;
+
+/**
+ * Show the "context window exceeded — please /compact" toast at most once
+ * per `CONTEXT_WINDOW_WARNING_THROTTLE_MS`. SDK clients (Claude Code SDK,
+ * autonomous goals) auto-retry on `model_context_window_exceeded`, so the
+ * downstream-truncation code path can fire many times per second; without
+ * throttling, VS Code stacks identical notifications and drowns the editor.
+ * The structured logger.warn at every occurrence is the source of truth for
+ * frequency — this only governs the user-visible toast.
+ */
+const maybeShowContextWindowWarning = (): void => {
+  const now = Date.now();
+  if (now - lastContextWindowWarningAt < CONTEXT_WINDOW_WARNING_THROTTLE_MS) {
+    return;
+  }
+  lastContextWindowWarningAt = now;
+  void vscode.window.showWarningMessage(
+    "The model has reached its context window limit. Please use the /compact command to reduce the conversation history. You can adjust 'agent-maestro.anthropic.tokenCountScaleFactor' in settings to fine-tune token estimation.",
+  );
+};
 
 const prepareAnthropicMessages = async ({
   requestBody,
@@ -33,6 +60,11 @@ const prepareAnthropicMessages = async ({
   logger.debug(JSON.stringify(requestBody, null, 2));
 
   const { system, messages } = requestBody;
+
+  const pairing = validateAnthropicToolPairing(messages ?? []);
+  if (!pairing.ok) {
+    throw new OrphanToolResultError(pairing.orphanIds);
+  }
 
   const vsCodeLmMessages: vscode.LanguageModelChatMessage[] = [
     ...convertAnthropicSystemToVSCode(system),
@@ -322,6 +354,8 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
     let effectiveModelId = "";
     let rawRequestBody;
     let lmChatMessages: vscode.LanguageModelChatMessage[] | undefined;
+    let inputTokens = 0;
+    let maxInputTokens = 0;
 
     try {
       // Parse request body
@@ -347,6 +381,7 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
 
       if (initialClient) {
         effectiveModelId = initialClient.id;
+        maxInputTokens = initialClient.maxInputTokens;
       }
 
       if (clientError) {
@@ -361,10 +396,15 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
           requestBody: { ...requestBody, model: resolvedModel },
         });
       lmChatMessages = vsCodeLmMessages;
+      const inputTokenCount = await countAnthropicMessageTokens(
+        JSON.stringify(requestBody),
+        client,
+      );
+      inputTokens = inputTokenCount.calibrated;
       logger.info(
         `→ /v1/messages | model: ${
           model === effectiveModelId ? model : `${model} → ${effectiveModelId}`
-        }`,
+        } | input: ${inputTokenCount.original} → ${inputTokenCount.calibrated} | maxInput: ${maxInputTokens}`,
       );
 
       // 4. Build VS Code Language Model request options
@@ -386,10 +426,6 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
       const getFallbackUsage = async (
         accumulatedText: string,
       ): Promise<AnthropicTokenUsage> => {
-        const inputTokenCount = await countAnthropicMessageTokens(
-          JSON.stringify(requestBody),
-          client,
-        );
         const outputTokenCount = accumulatedText
           ? await countAnthropicMessageTokens(accumulatedText, client)
           : { original: 1, calibrated: 1 };
@@ -612,14 +648,50 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
               }
             }
           } catch (streamError) {
-            if (!isResponseTooLongError(streamError)) {
-              throw streamError;
+            if (isResponseTooLongError(streamError)) {
+              stopReason = "max_tokens";
+              logger.warn(
+                `/v1/messages (stream) | returning truncated response after length error | contentBlocks: ${contentBlocks.length}`,
+              );
+            } else {
+              // Mid-stream orphan tool_use_id error: vscode.lm normally
+              // surfaces orphan-pairing errors from `sendRequest()` (caught by
+              // the outer try/catch around `streamSSE`), but if a future
+              // version of Copilot ever defers validation until generation
+              // begins, the error appears here instead — inside `streamSSE`,
+              // where rethrowing would only land in `streamSSE`'s onError and
+              // never reach the outer fallback. Apply the same case-1/case-2
+              // disambiguation as the outer catch: only translate to
+              // model_context_window_exceeded when calibrated input is at or
+              // over capacity (true downstream truncation); otherwise rethrow
+              // so a Copilot-side bug that happens to surface mid-stream
+              // stays visible.
+              const streamErrorMessage =
+                streamError instanceof Error
+                  ? streamError.message
+                  : JSON.stringify(streamError);
+              if (isDownstreamTruncationOrphan(streamErrorMessage)) {
+                const errorCode = (streamError as { code?: unknown })?.code;
+                logger.info(
+                  `/v1/messages (stream) | orphan tool_use_id error caught mid-stream | error.code=${String(errorCode)} | error.constructor=${streamError?.constructor?.name ?? "n/a"}`,
+                );
+                if (isInputAtOrOverCapacity(inputTokens, maxInputTokens)) {
+                  logger.warn(
+                    `/v1/messages (stream) | context window exceeded (orphan tool_use_id from downstream, surfaced mid-stream) | input: ${inputTokens} / max: ${maxInputTokens}`,
+                  );
+                  maybeShowContextWindowWarning();
+                  stopReason =
+                    "model_context_window_exceeded" as Anthropic.Messages.StopReason;
+                } else {
+                  logger.warn(
+                    `/v1/messages (stream) | orphan tool_use_id mid-stream but input under capacity (input: ${inputTokens} / max: ${maxInputTokens}) — likely Copilot bug, not capacity. Rethrowing.`,
+                  );
+                  throw streamError;
+                }
+              } else {
+                throw streamError;
+              }
             }
-
-            stopReason = "max_tokens";
-            logger.warn(
-              `/v1/messages (stream) | returning truncated response after length error | contentBlocks: ${contentBlocks.length}`,
-            );
           }
 
           logger.debug("/v1/messages streamed content block responses:");
@@ -644,9 +716,12 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
               stop_reason:
                 stopReason === "max_tokens"
                   ? "max_tokens"
-                  : contentBlocks.at(-1)?.type === "tool_use"
-                    ? "tool_use"
-                    : "end_turn",
+                  : stopReason ===
+                      ("model_context_window_exceeded" as Anthropic.Messages.StopReason)
+                    ? stopReason
+                    : contentBlocks.at(-1)?.type === "tool_use"
+                      ? "tool_use"
+                      : "end_turn",
               stop_sequence: null,
             },
             usage: {
@@ -677,10 +752,170 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
         error,
         endpoint: "/api/anthropic/v1/messages",
         modelId: effectiveModelId,
+        inputTokens,
       });
+
+      // The request itself contained tool_result blocks with no matching
+      // tool_use. Refuse it with 400 — do NOT translate to context-window
+      // exceeded, because compacting won't help (the client is malformed).
+      // We return JSON even when the client asked for `stream: true`; this
+      // matches the upstream Anthropic API, which refuses pre-stream
+      // validation failures before opening any SSE channel. Do not call
+      // streamSSE() above this point or that contract breaks.
+      // Diagnostics are still captured (above) so client-side bugs can be
+      // investigated from the same log file path as other failures.
+      if (error instanceof OrphanToolResultError) {
+        return c.json(
+          {
+            error: {
+              type: "invalid_request_error",
+              message: error.message,
+              log_file: logFilePath,
+            },
+          },
+          400,
+        );
+      }
 
       const errorMessage =
         error instanceof Error ? error.message : JSON.stringify(error);
+
+      if (isDownstreamTruncationOrphan(errorMessage)) {
+        // Dogfood diagnostic: capture vscode.lm error.code and full error
+        // shape so we can later confirm whether Copilot fills `code` with a
+        // stable provider-specific value (in which case a future PR can
+        // replace this message-substring match with a code match).
+        // Documented as `Unknown` historically; logging here lets us verify
+        // against current Copilot builds.
+        const errorCode = (error as { code?: unknown })?.code;
+        logger.info(
+          `/v1/messages | orphan tool_use_id error caught | error.code=${String(errorCode)} | error.constructor=${error?.constructor?.name ?? "n/a"} | error.name=${(error as Error)?.name ?? "n/a"}`,
+        );
+
+        // Disambiguate the two known causes of this error:
+        //   case 2 — calibrated input is at or over the model's max input
+        //            capacity → Copilot's internal truncation almost certainly
+        //            cut a tool_use/tool_result pair to keep the prompt under
+        //            the cap. Translate to model_context_window_exceeded so
+        //            Claude Code (incl. SDK and autonomous-goal callers) can
+        //            auto-compact and retry.
+        //   case 1 — capacity is well below the cap → orphan came from a
+        //            Copilot-side bug (also seen in litellm). Translating
+        //            here would mask the bug; rethrow so the underlying
+        //            error stays visible to whoever owns the upstream fix.
+        if (!isInputAtOrOverCapacity(inputTokens, maxInputTokens)) {
+          logger.warn(
+            `/v1/messages | orphan tool_use_id error but input under capacity (input: ${inputTokens} / max: ${maxInputTokens}) — likely Copilot bug, not capacity. Letting the original error surface.`,
+          );
+        } else {
+          const model = rawRequestBody?.model ?? effectiveModelId;
+          const modelLabel =
+            model === effectiveModelId
+              ? effectiveModelId
+              : `${model} → ${effectiveModelId}`;
+
+          logger.warn(
+            `/v1/messages | context window exceeded (orphan tool_use_id from downstream) | input: ${inputTokens} / max: ${maxInputTokens} | model: ${modelLabel}`,
+          );
+
+          // SDK clients (Claude Code SDK, autonomous goals) retry on
+          // `model_context_window_exceeded` automatically, so this branch can
+          // fire many times in quick succession. Throttle the user-visible
+          // toast so VS Code doesn't stack notifications; the structured log
+          // line above still records every occurrence for debugging.
+          maybeShowContextWindowWarning();
+
+          if (rawRequestBody?.stream) {
+            return streamSSE(
+              c,
+              async (stream) => {
+                const writeSSE = async (
+                  message: Anthropic.Messages.RawMessageStreamEvent,
+                ) => {
+                  await stream.writeSSE({
+                    event: message.type,
+                    data: JSON.stringify(message),
+                  });
+                };
+
+                await writeSSE({
+                  type: "message_start",
+                  message: {
+                    id: `msg_${Date.now()}`,
+                    type: "message",
+                    role: "assistant",
+                    model,
+                    container: null,
+                    content: [],
+                    stop_details: null,
+                    stop_reason: null,
+                    stop_sequence: null,
+                    usage: {
+                      cache_creation: null,
+                      input_tokens: inputTokens,
+                      output_tokens: 0,
+                      cache_creation_input_tokens: 0,
+                      cache_read_input_tokens: 0,
+                      inference_geo: null,
+                      server_tool_use: null,
+                      service_tier: "standard",
+                    },
+                  },
+                });
+
+                await writeSSE({
+                  type: "message_delta",
+                  delta: {
+                    container: null,
+                    stop_details: null,
+                    stop_reason:
+                      "model_context_window_exceeded" as Anthropic.Messages.StopReason,
+                    stop_sequence: null,
+                  },
+                  usage: {
+                    input_tokens: inputTokens * 2, // Inflate to ensure Claude Code triggers auto-compact before next message
+                    output_tokens: 0,
+                    cache_creation_input_tokens: 0,
+                    cache_read_input_tokens: 0,
+                    server_tool_use: null,
+                  },
+                });
+
+                await writeSSE({ type: "message_stop" });
+              },
+              async (err, _stream) => {
+                logger.error(
+                  "✕ /v1/messages (context window exceeded stream) |",
+                  err,
+                );
+              },
+            );
+          }
+
+          return c.json({
+            id: `msg_${Date.now()}`,
+            type: "message",
+            role: "assistant",
+            model,
+            container: null,
+            content: [],
+            stop_details: null,
+            stop_reason:
+              "model_context_window_exceeded" as Anthropic.Messages.StopReason,
+            stop_sequence: null,
+            usage: {
+              cache_creation: null,
+              cache_creation_input_tokens: 0,
+              cache_read_input_tokens: 0,
+              inference_geo: null,
+              input_tokens: inputTokens * 2, // Inflate to ensure Claude Code triggers auto-compact before next message
+              output_tokens: 0,
+              server_tool_use: null,
+              service_tier: null,
+            },
+          } as Anthropic.Messages.Message);
+        }
+      }
 
       const isModelNotSupportedError = errorMessage.includes(
         "model_not_supported",

--- a/src/server/utils/anthropic.ts
+++ b/src/server/utils/anthropic.ts
@@ -191,6 +191,216 @@ export const convertAnthropicMessageToVSCode = (
 };
 
 /**
+ * Result of validating tool_use ↔ tool_result pairing across a message list.
+ * `orphanIds` is the de-duplicated set of `tool_use_id`s referenced by a
+ * `tool_result` that has no matching `tool_use` in an earlier message.
+ */
+export type ToolPairingValidation =
+  | { ok: true }
+  | { ok: false; orphanIds: string[] };
+
+/**
+ * The Anthropic API requires every `tool_result` block to point at a
+ * `tool_use` that appeared in an earlier assistant message. When the request
+ * we're about to forward violates this, the upstream returns:
+ *   "unexpected `tool_use_id` found in `tool_result` blocks: <id>"
+ *
+ * We validate the same invariant locally before conversion so that:
+ *   1. Genuinely malformed client requests are rejected up-front with a 400,
+ *      rather than slipping through to vscode.lm and surfacing as a 500.
+ *   2. When vscode.lm later reports the same error class, we can be confident
+ *      the orphan was introduced downstream (typically Copilot's internal
+ *      message truncation) and treat it as a context-window event.
+ *
+ * Design choices when the rules are ambiguous:
+ *   - Only `assistant`-role `tool_use` blocks register ids. A `tool_use` in a
+ *     user message is itself protocol-illegal, but we don't treat it as a
+ *     "matching" use for a later `tool_result` — that would mask the bug.
+ *   - We accept a `tool_use` without a matching `tool_result` (in-flight or
+ *     intentionally dropped).
+ *   - We tolerate a `tool_use` and its `tool_result` co-located in the same
+ *     assistant message (registration happens in a first pass before the
+ *     result pass, making the verdict order-independent within one message).
+ *     A `tool_result` in a *user* message must still reference a `tool_use`
+ *     from an *earlier* assistant message — that is the only protocol-valid
+ *     placement, and is the case the wire bug actually breaks.
+ *   - All Anthropic SDK *success* result block types that carry a
+ *     `tool_use_id` are pooled into one id set against all `tool_use` /
+ *     `server_tool_use` blocks. The `*_tool_result_error` SDK variants
+ *     (e.g. `web_search_tool_result_error`) are *inner content* of those
+ *     success blocks, not top-level message blocks, and do not carry a
+ *     `tool_use_id` of their own — so they correctly aren't in this set.
+ *     Anthropic technically pairs result types to specific use types, but
+ *     we don't distinguish here because doing so adds little protection
+ *     and risks false positives. Recognized result types are kept in sync
+ *     with `@anthropic-ai/sdk` — extend `RESULT_BLOCK_TYPES` below when
+ *     new ones ship.
+ *
+ * Non-array / null / malformed inputs are treated as ok — schema validation
+ * is the route layer's responsibility; this function should never throw.
+ */
+export const validateAnthropicToolPairing = (
+  messages: Array<Anthropic.Messages.MessageParam>,
+): ToolPairingValidation => {
+  if (!Array.isArray(messages)) {
+    return { ok: true };
+  }
+
+  // Block types from `@anthropic-ai/sdk` that carry a `tool_use_id` referencing
+  // an earlier tool_use. Kept explicit (rather than suffix-matching) so adding
+  // a new SDK type is a deliberate, reviewable change.
+  const RESULT_BLOCK_TYPES = new Set<string>([
+    "tool_result",
+    "web_search_tool_result",
+    "web_fetch_tool_result",
+    "code_execution_tool_result",
+    "bash_code_execution_tool_result",
+    "text_editor_code_execution_tool_result",
+    "tool_search_tool_result",
+  ]);
+  const USE_BLOCK_TYPES = new Set<string>(["tool_use", "server_tool_use"]);
+
+  const knownToolUseIds = new Set<string>();
+  const orphanIds = new Set<string>();
+
+  for (const message of messages) {
+    if (!message || typeof message !== "object") {
+      continue;
+    }
+    const { role, content } = message;
+    if (content === null || content === undefined) {
+      continue;
+    }
+    if (typeof content === "string" || !Array.isArray(content)) {
+      continue;
+    }
+
+    // Two passes per message. The first registers every assistant-role
+    // tool_use id from this message so that a tool_result in the SAME
+    // message — including one whose block sits before its tool_use in the
+    // content array — can find its pair. A single forward pass would make
+    // the verdict order-sensitive within one message, which is wrong: the
+    // Anthropic protocol orders by message, not by block index inside a
+    // message's content. The cost is one extra cheap iteration per message.
+    for (const block of content) {
+      if (!block || typeof block !== "object" || !("type" in block)) {
+        continue;
+      }
+      if (!USE_BLOCK_TYPES.has(block.type)) {
+        continue;
+      }
+      // Only assistant-role tool_use blocks may register ids. A tool_use
+      // in a user message is itself out-of-spec; treating it as "known"
+      // would let a follow-up tool_result silently satisfy validation
+      // even though the upstream will still reject the conversation.
+      if (role !== "assistant") {
+        continue;
+      }
+      const { id } = block as { id?: unknown };
+      if (typeof id === "string" && id.length > 0) {
+        knownToolUseIds.add(id);
+      }
+    }
+
+    for (const block of content) {
+      if (!block || typeof block !== "object" || !("type" in block)) {
+        continue;
+      }
+      if (!RESULT_BLOCK_TYPES.has(block.type)) {
+        continue;
+      }
+      const { tool_use_id } = block as { tool_use_id?: unknown };
+      if (typeof tool_use_id !== "string" || tool_use_id.length === 0) {
+        continue;
+      }
+      if (!knownToolUseIds.has(tool_use_id)) {
+        orphanIds.add(tool_use_id);
+      }
+    }
+  }
+
+  if (orphanIds.size === 0) {
+    return { ok: true };
+  }
+  return { ok: false, orphanIds: Array.from(orphanIds) };
+};
+
+/**
+ * Thrown by `prepareAnthropicMessages` when the incoming request itself
+ * contains orphan `tool_result` blocks. Routes should map this to a 400
+ * `invalid_request_error` rather than letting it reach vscode.lm.
+ */
+export class OrphanToolResultError extends Error {
+  readonly orphanIds: string[];
+
+  constructor(orphanIds: string[]) {
+    super(
+      `Request contains tool_result block(s) with no matching tool_use in any earlier assistant message: ${orphanIds.join(", ")}`,
+    );
+    this.name = "OrphanToolResultError";
+    this.orphanIds = orphanIds;
+    // Preserve the prototype chain across transpilation boundaries so that
+    // `err instanceof OrphanToolResultError` works in all consumers.
+    Object.setPrototypeOf(this, OrphanToolResultError.prototype);
+  }
+}
+
+/**
+ * vscode.lm surfaces this exact substring when the message array forwarded
+ * to the upstream contains a `tool_result` whose `tool_use_id` doesn't match
+ * any prior `tool_use`. Because routes run `validateAnthropicToolPairing`
+ * before forwarding, any request that reaches vscode.lm is known to be
+ * well-formed at our boundary — so this error string only fires when
+ * something between us and the upstream dropped a tool_use but kept its
+ * tool_result. There are two known causes (see `isInputAtOrOverCapacity`):
+ *
+ *   1. Copilot's internal message truncation as it approaches its context
+ *      window — a *capacity* problem, recoverable via auto-compact.
+ *   2. Some other Copilot-side bug (also reported by litellm users) that
+ *      can produce this error even when capacity is well below the limit.
+ *
+ * This helper only confirms the error *shape*. Routes pair it with
+ * `isInputAtOrOverCapacity` to decide whether to translate (case 1) or
+ * rethrow (case 2 — let the underlying bug surface so it can be reported
+ * upstream).
+ */
+export const isDownstreamTruncationOrphan = (errorMessage: string): boolean =>
+  errorMessage.includes(
+    "unexpected `tool_use_id` found in `tool_result` blocks",
+  );
+
+/**
+ * True when the calibrated input token count is at or over the model's
+ * advertised max input capacity. Used together with
+ * `isDownstreamTruncationOrphan` to disambiguate which of the two known
+ * causes produced an orphan error: a *capacity-driven* orphan (this returns
+ * true) is recoverable via Claude Code auto-compact, so we translate it to
+ * `model_context_window_exceeded`; a *capacity-clear* orphan (this returns
+ * false) is almost certainly a Copilot-side bug, and the right move is to
+ * let it propagate so the upstream bug stays visible.
+ *
+ * Calibrated tokens are produced by `countAnthropicMessageTokens`, which
+ * applies `agent-maestro.anthropic.tokenCountScaleFactor` (default 1.25) on
+ * top of vscode.lm's count. That scale factor is *also* the safety margin
+ * here: a calibrated value at the cap means the raw vscode.lm count is at
+ * 1 / 1.25 ≈ 80% of the cap — already in the band where Copilot's internal
+ * truncation kicks in. Users can tune the scale factor to widen or narrow
+ * this band; we deliberately don't introduce a separate threshold knob.
+ *
+ * Returns false for non-positive `maxInputTokens` (the model didn't
+ * advertise a cap, so we can't reason about capacity at all).
+ */
+export const isInputAtOrOverCapacity = (
+  inputTokensCalibrated: number,
+  maxInputTokens: number,
+): boolean => {
+  if (!Number.isFinite(maxInputTokens) || maxInputTokens <= 0) {
+    return false;
+  }
+  return inputTokensCalibrated >= maxInputTokens;
+};
+
+/**
  * Convert an array of Anthropic MessageParams to VS Code LanguageModelChatMessages
  * Flattens any array results from individual message conversions
  *

--- a/src/test/server/anthropic.test.ts
+++ b/src/test/server/anthropic.test.ts
@@ -1,13 +1,18 @@
+import Anthropic from "@anthropic-ai/sdk";
 import * as assert from "assert";
 import * as vscode from "vscode";
 
 import {
+  OrphanToolResultError,
   convertAnthropicMessageToVSCode,
   convertAnthropicMessagesToVSCode,
   convertAnthropicSystemToVSCode,
   convertAnthropicToolChoiceToVSCode,
   convertAnthropicToolToVSCode,
   extractAnthropicTokenUsageFromVSCodeChunk,
+  isDownstreamTruncationOrphan,
+  isInputAtOrOverCapacity,
+  validateAnthropicToolPairing,
 } from "../../server/utils/anthropic";
 import {
   createAnthropicModelsResponse,
@@ -617,6 +622,530 @@ suite("Anthropic Conversion Utils Test Suite", () => {
     test("should return undefined for undefined tool choice", () => {
       const result = convertAnthropicToolChoiceToVSCode(undefined);
       assert.strictEqual(result, undefined);
+    });
+  });
+
+  suite("validateAnthropicToolPairing", () => {
+    const textUser = (text: string): Anthropic.Messages.MessageParam => ({
+      role: "user",
+      content: text,
+    });
+
+    const toolUse = (
+      id: string,
+      name = "do_thing",
+    ): Anthropic.Messages.ToolUseBlockParam => ({
+      type: "tool_use",
+      id,
+      name,
+      input: {},
+    });
+
+    const toolResult = (
+      tool_use_id: string,
+      content: string | null = "ok",
+    ): Anthropic.Messages.ToolResultBlockParam =>
+      content === null
+        ? ({ type: "tool_result", tool_use_id } as any)
+        : { type: "tool_result", tool_use_id, content };
+
+    const assistantBlocks = (
+      ...blocks: Anthropic.Messages.ContentBlockParam[]
+    ): Anthropic.Messages.MessageParam => ({
+      role: "assistant",
+      content: blocks as Anthropic.Messages.ContentBlockParam[],
+    });
+
+    const userBlocks = (
+      ...blocks: Anthropic.Messages.ContentBlockParam[]
+    ): Anthropic.Messages.MessageParam => ({
+      role: "user",
+      content: blocks as Anthropic.Messages.ContentBlockParam[],
+    });
+
+    test("empty messages array is ok", () => {
+      assert.deepStrictEqual(validateAnthropicToolPairing([]), { ok: true });
+    });
+
+    test("string-content messages with no tool blocks are ok", () => {
+      assert.deepStrictEqual(
+        validateAnthropicToolPairing([
+          textUser("hi"),
+          { role: "assistant", content: "hello" },
+        ]),
+        { ok: true },
+      );
+    });
+
+    test("matched tool_use → tool_result is ok", () => {
+      const result = validateAnthropicToolPairing([
+        textUser("call my tool"),
+        assistantBlocks(toolUse("call_A")),
+        userBlocks(toolResult("call_A")),
+      ]);
+      assert.deepStrictEqual(result, { ok: true });
+    });
+
+    test("tool_result with no matching prior tool_use is orphan", () => {
+      const result = validateAnthropicToolPairing([
+        textUser("hi"),
+        assistantBlocks(toolUse("call_A")),
+        userBlocks(toolResult("call_B")),
+      ]);
+      assert.deepStrictEqual(result, {
+        ok: false,
+        orphanIds: ["call_B"],
+      });
+    });
+
+    test("tool_result with no prior tool_use at all is orphan", () => {
+      const result = validateAnthropicToolPairing([
+        userBlocks(toolResult("call_X")),
+      ]);
+      assert.deepStrictEqual(result, {
+        ok: false,
+        orphanIds: ["call_X"],
+      });
+    });
+
+    test("tool_use with no follow-up tool_result is allowed (in-flight)", () => {
+      const result = validateAnthropicToolPairing([
+        textUser("call my tool"),
+        assistantBlocks(toolUse("call_A")),
+      ]);
+      assert.deepStrictEqual(result, { ok: true });
+    });
+
+    test("multiple tool_uses in one message, all matched in next is ok", () => {
+      const result = validateAnthropicToolPairing([
+        textUser("call both"),
+        assistantBlocks(toolUse("call_A"), toolUse("call_B")),
+        userBlocks(toolResult("call_A"), toolResult("call_B")),
+      ]);
+      assert.deepStrictEqual(result, { ok: true });
+    });
+
+    test("multiple tool_uses but only one answered is ok (other in-flight)", () => {
+      const result = validateAnthropicToolPairing([
+        assistantBlocks(toolUse("call_A"), toolUse("call_B")),
+        userBlocks(toolResult("call_A")),
+      ]);
+      assert.deepStrictEqual(result, { ok: true });
+    });
+
+    test("multiple tool_results for the same id are tolerated", () => {
+      const result = validateAnthropicToolPairing([
+        assistantBlocks(toolUse("call_A")),
+        userBlocks(toolResult("call_A"), toolResult("call_A", "again")),
+      ]);
+      assert.deepStrictEqual(result, { ok: true });
+    });
+
+    test("duplicate tool_use ids across messages are tolerated", () => {
+      const result = validateAnthropicToolPairing([
+        assistantBlocks(toolUse("call_A")),
+        userBlocks(toolResult("call_A")),
+        assistantBlocks(toolUse("call_A")),
+        userBlocks(toolResult("call_A")),
+      ]);
+      assert.deepStrictEqual(result, { ok: true });
+    });
+
+    test("mixed text and tool blocks with valid pairing is ok", () => {
+      const result = validateAnthropicToolPairing([
+        textUser("question"),
+        assistantBlocks(
+          { type: "text", text: "let me look that up" },
+          toolUse("call_A"),
+        ),
+        userBlocks(
+          { type: "text", text: "extra context" },
+          toolResult("call_A"),
+        ),
+      ]);
+      assert.deepStrictEqual(result, { ok: true });
+    });
+
+    test("tool_result before its tool_use (out of order) is orphan", () => {
+      const result = validateAnthropicToolPairing([
+        userBlocks(toolResult("call_A")),
+        assistantBlocks(toolUse("call_A")),
+      ]);
+      assert.deepStrictEqual(result, {
+        ok: false,
+        orphanIds: ["call_A"],
+      });
+    });
+
+    test("two distinct orphan ids are de-duplicated and reported", () => {
+      const result = validateAnthropicToolPairing([
+        userBlocks(
+          toolResult("call_X"),
+          toolResult("call_Y"),
+          toolResult("call_X"),
+        ),
+      ]);
+      assert.strictEqual((result as { ok: false }).ok, false);
+      const { orphanIds } = result as { ok: false; orphanIds: string[] };
+      // Explicit length assertion: a regression that double-reports call_X
+      // would still pass deepStrictEqual on the sorted unique array but the
+      // length check makes the dedup contract a first-class assertion.
+      assert.strictEqual(orphanIds.length, 2);
+      assert.deepStrictEqual(orphanIds.slice().sort(), ["call_X", "call_Y"]);
+    });
+
+    test("server_tool_use ids satisfy their matching tool_result", () => {
+      const result = validateAnthropicToolPairing([
+        assistantBlocks({
+          type: "server_tool_use",
+          id: "srv_A",
+          name: "web_search",
+          input: {},
+        } as Anthropic.Messages.ServerToolUseBlockParam),
+        userBlocks(toolResult("srv_A")),
+      ]);
+      assert.deepStrictEqual(result, { ok: true });
+    });
+
+    test("ignores blocks that aren't recognisable objects", () => {
+      const result = validateAnthropicToolPairing([
+        {
+          role: "user",
+          content: [
+            null as unknown as Anthropic.Messages.ContentBlockParam,
+            { type: "text", text: "hi" },
+          ],
+        },
+      ]);
+      assert.deepStrictEqual(result, { ok: true });
+    });
+
+    test("OrphanToolResultError carries the offending ids", () => {
+      const err = new OrphanToolResultError(["call_A", "call_B"]);
+      assert.strictEqual(err.name, "OrphanToolResultError");
+      assert.deepStrictEqual(err.orphanIds, ["call_A", "call_B"]);
+      // The message wording is part of the contract — the routes layer
+      // surfaces it in the 400 response body and in the diagnostic log file.
+      // Lock the prefix so accidental rewording is caught here, not by users.
+      assert.ok(
+        err.message.startsWith(
+          "Request contains tool_result block(s) with no matching tool_use",
+        ),
+        `unexpected message prefix: ${err.message}`,
+      );
+      assert.ok(err.message.includes("call_A"));
+      assert.ok(err.message.includes("call_B"));
+    });
+
+    test("OrphanToolResultError survives instanceof after throw/catch", () => {
+      let caught: unknown;
+      try {
+        throw new OrphanToolResultError(["call_X"]);
+      } catch (e) {
+        caught = e;
+      }
+      assert.ok(caught instanceof OrphanToolResultError);
+      assert.ok(caught instanceof Error);
+    });
+
+    test("non-array messages input does not throw", () => {
+      assert.deepStrictEqual(validateAnthropicToolPairing(undefined as any), {
+        ok: true,
+      });
+      assert.deepStrictEqual(validateAnthropicToolPairing(null as any), {
+        ok: true,
+      });
+    });
+
+    test("null message entry is skipped, not thrown on", () => {
+      assert.deepStrictEqual(
+        validateAnthropicToolPairing([
+          null as any,
+          assistantBlocks(toolUse("call_A")),
+          userBlocks(toolResult("call_A")),
+        ]),
+        { ok: true },
+      );
+    });
+
+    test("null/missing message.content is skipped, not thrown on", () => {
+      assert.deepStrictEqual(
+        validateAnthropicToolPairing([
+          { role: "user", content: null as any },
+          { role: "assistant", content: undefined as any },
+          assistantBlocks(toolUse("call_A")),
+          userBlocks(toolResult("call_A")),
+        ]),
+        { ok: true },
+      );
+    });
+
+    test("non-array, non-string message.content is skipped", () => {
+      assert.deepStrictEqual(
+        validateAnthropicToolPairing([
+          { role: "user", content: { weird: true } as any },
+        ]),
+        { ok: true },
+      );
+    });
+
+    test("tool_use in a user message does NOT register its id", () => {
+      // A tool_use block in a user message is itself protocol-illegal.
+      // Treating it as a known id would let a follow-up tool_result silently
+      // pass our check even though the upstream API rejects the conversation.
+      const result = validateAnthropicToolPairing([
+        userBlocks(toolUse("call_A")),
+        userBlocks(toolResult("call_A")),
+      ]);
+      assert.deepStrictEqual(result, {
+        ok: false,
+        orphanIds: ["call_A"],
+      });
+    });
+
+    test("tool_use and matching tool_result inside the same message is tolerated", () => {
+      // Conservative by design: this shape is uncommon but not provably
+      // malformed, so we do not flag it. See the design notes on the
+      // validator for the false-positive vs false-negative trade-off.
+      const result = validateAnthropicToolPairing([
+        assistantBlocks(toolUse("call_A"), toolResult("call_A") as any),
+      ]);
+      assert.deepStrictEqual(result, { ok: true });
+    });
+
+    test("same-message pairing is order-independent within the message", () => {
+      // Regression: a single forward pass would flag this as orphan because
+      // the tool_result block is visited before the tool_use registers its
+      // id. The validator must scan each message in two passes (register
+      // first, then check) so its verdict only depends on message order,
+      // not intra-message block order.
+      const result = validateAnthropicToolPairing([
+        assistantBlocks(toolResult("call_A") as any, toolUse("call_A")),
+      ]);
+      assert.deepStrictEqual(result, { ok: true });
+    });
+
+    test("web_search_tool_result paired with server_tool_use is ok", () => {
+      const result = validateAnthropicToolPairing([
+        assistantBlocks({
+          type: "server_tool_use",
+          id: "srv_A",
+          name: "web_search",
+          input: {},
+        } as Anthropic.Messages.ServerToolUseBlockParam),
+        userBlocks({
+          type: "web_search_tool_result",
+          tool_use_id: "srv_A",
+          content: [],
+        } as Anthropic.Messages.WebSearchToolResultBlockParam),
+      ]);
+      assert.deepStrictEqual(result, { ok: true });
+    });
+
+    test("web_search_tool_result with no matching server_tool_use is orphan", () => {
+      const result = validateAnthropicToolPairing([
+        userBlocks({
+          type: "web_search_tool_result",
+          tool_use_id: "srv_missing",
+          content: [],
+        } as Anthropic.Messages.WebSearchToolResultBlockParam),
+      ]);
+      assert.deepStrictEqual(result, {
+        ok: false,
+        orphanIds: ["srv_missing"],
+      });
+    });
+
+    test("extended SDK result block types are recognised as orphan when unmatched", () => {
+      // The validator hard-codes the list of SDK result block types that
+      // carry a `tool_use_id` (RESULT_BLOCK_TYPES). If a future SDK upgrade
+      // adds a new variant and we forget to extend that set, this regression
+      // test will fail loudly: each block here represents a real SDK type.
+      const results: Anthropic.Messages.ContentBlockParam[] = [
+        {
+          type: "code_execution_tool_result",
+          tool_use_id: "code_missing",
+          content: { type: "code_execution_result" },
+        } as unknown as Anthropic.Messages.ContentBlockParam,
+        {
+          type: "bash_code_execution_tool_result",
+          tool_use_id: "bash_missing",
+          content: { type: "bash_code_execution_result" },
+        } as unknown as Anthropic.Messages.ContentBlockParam,
+        {
+          type: "text_editor_code_execution_tool_result",
+          tool_use_id: "te_missing",
+          content: { type: "text_editor_code_execution_view_result" },
+        } as unknown as Anthropic.Messages.ContentBlockParam,
+        {
+          type: "tool_search_tool_result",
+          tool_use_id: "ts_missing",
+          content: [],
+        } as unknown as Anthropic.Messages.ContentBlockParam,
+        {
+          type: "web_fetch_tool_result",
+          tool_use_id: "wf_missing",
+          content: { type: "web_fetch_result" },
+        } as unknown as Anthropic.Messages.ContentBlockParam,
+      ];
+      const result = validateAnthropicToolPairing([userBlocks(...results)]);
+      assert.strictEqual((result as { ok: false }).ok, false);
+      const { orphanIds } = result as { ok: false; orphanIds: string[] };
+      assert.deepStrictEqual(
+        orphanIds.slice().sort(),
+        [
+          "bash_missing",
+          "code_missing",
+          "te_missing",
+          "wf_missing",
+          "ts_missing",
+        ].sort(),
+      );
+    });
+
+    test("validator is pure: repeated calls on the same input give the same result and don't mutate", () => {
+      // The validator builds local Sets per call and reads `messages` only.
+      // Pin that contract so a future "optimisation" that hoists state to
+      // module scope (or mutates input arrays) is caught here.
+      const messages: Array<Anthropic.Messages.MessageParam> = [
+        assistantBlocks(toolUse("call_A")),
+        userBlocks(toolResult("call_A"), toolResult("call_X")),
+      ];
+      const snapshot = JSON.stringify(messages);
+      const first = validateAnthropicToolPairing(messages);
+      const second = validateAnthropicToolPairing(messages);
+      assert.deepStrictEqual(first, second);
+      assert.deepStrictEqual(first, { ok: false, orphanIds: ["call_X"] });
+      assert.strictEqual(JSON.stringify(messages), snapshot);
+    });
+
+    test("tool_result in an assistant message (protocol-illegal) does not crash", () => {
+      // We don't police misplaced blocks, but the verdict still has to be
+      // *correct*: an assistant-role tool_result whose id was never registered
+      // (no assistant tool_use anywhere) IS an orphan and must be reported as
+      // such. Previously this test only checked `typeof ok === "boolean"`,
+      // which would accept either verdict — losing the regression signal if
+      // future code paths silently swallowed this case.
+      const result = validateAnthropicToolPairing([
+        assistantBlocks(toolResult("call_A") as any),
+      ]);
+      assert.deepStrictEqual(result, {
+        ok: false,
+        orphanIds: ["call_A"],
+      });
+    });
+
+    test("tool_use with empty-string id is ignored (cannot be 'known')", () => {
+      // An empty id can never satisfy a later tool_result's tool_use_id
+      // lookup, so we deliberately do not register it. The follow-up
+      // tool_result referencing the same empty string is therefore orphan —
+      // but tool_use_id="" is itself filtered out by the result-side guard
+      // (length === 0), so the net verdict is ok. Locking this behavior
+      // documents that empty ids are *both* unregisterable and unreportable.
+      const result = validateAnthropicToolPairing([
+        assistantBlocks(toolUse("")),
+        userBlocks(toolResult("")),
+      ]);
+      assert.deepStrictEqual(result, { ok: true });
+    });
+
+    test("blocks missing a `type` field are skipped, not thrown on", () => {
+      // Hostile / malformed payloads (e.g. `{}` slipped through schema
+      // validation) must not crash the validator. The "type" key guard is
+      // the only line of defense before property access.
+      const result = validateAnthropicToolPairing([
+        {
+          role: "user",
+          content: [{} as Anthropic.Messages.ContentBlockParam],
+        },
+      ]);
+      assert.deepStrictEqual(result, { ok: true });
+    });
+  });
+
+  suite("isDownstreamTruncationOrphan", () => {
+    test("matches the exact upstream orphan tool_use_id error", () => {
+      // Real-world payload (paraphrased) — note the backticks must stay.
+      const msg =
+        "messages.3.content.0: unexpected `tool_use_id` found in `tool_result` blocks: toolu_01ABC. Each `tool_result` block must have a corresponding `tool_use` block in the previous message.";
+      assert.strictEqual(isDownstreamTruncationOrphan(msg), true);
+    });
+
+    test("does not match unrelated errors", () => {
+      assert.strictEqual(
+        isDownstreamTruncationOrphan("Request failed: rate_limit_error"),
+        false,
+      );
+      assert.strictEqual(
+        isDownstreamTruncationOrphan("model_not_supported"),
+        false,
+      );
+      assert.strictEqual(
+        isDownstreamTruncationOrphan("Response too long"),
+        false,
+      );
+      assert.strictEqual(isDownstreamTruncationOrphan(""), false);
+    });
+
+    test("does not match a paraphrased orphan message without the canonical substring", () => {
+      // If Anthropic ever changes wording, we explicitly want this to start
+      // returning false so the test signals the regression rather than
+      // silently broadening the trigger.
+      assert.strictEqual(
+        isDownstreamTruncationOrphan(
+          "tool_result references an unknown tool_use id",
+        ),
+        false,
+      );
+    });
+  });
+
+  suite("isInputAtOrOverCapacity", () => {
+    test("returns true when calibrated input equals max input tokens", () => {
+      // The boundary case: at exactly the cap we still translate, because
+      // Copilot's truncation kicks in at-or-above the cap, not strictly above.
+      assert.strictEqual(isInputAtOrOverCapacity(200_000, 200_000), true);
+    });
+
+    test("returns true when calibrated input exceeds max input tokens", () => {
+      assert.strictEqual(isInputAtOrOverCapacity(250_000, 200_000), true);
+    });
+
+    test("returns false when calibrated input is below max input tokens", () => {
+      // The capacity-clear case: routes use this to decide that an orphan
+      // error is a Copilot-side bug rather than a truncation event.
+      assert.strictEqual(isInputAtOrOverCapacity(150_000, 200_000), false);
+    });
+
+    test("returns false when calibrated input is at the typical scale-factor band but still under cap", () => {
+      // tokenCountScaleFactor default is 1.25, so a calibrated value of
+      // 160k on a 200k model corresponds to a raw count of 128k (64%) —
+      // well below the truncation band. Pin this so a future "looser"
+      // capacity check that uses a percentage threshold is caught here.
+      assert.strictEqual(isInputAtOrOverCapacity(160_000, 200_000), false);
+    });
+
+    test("returns false when maxInputTokens is 0 (model didn't advertise a cap)", () => {
+      // Some VS Code models report maxInputTokens as 0; with no cap to
+      // reason about, we cannot conclude capacity-driven truncation, so
+      // the orphan must be treated as a bug (rethrow path) by the caller.
+      assert.strictEqual(isInputAtOrOverCapacity(150_000, 0), false);
+    });
+
+    test("returns false for negative or non-finite maxInputTokens", () => {
+      assert.strictEqual(isInputAtOrOverCapacity(150_000, -1), false);
+      assert.strictEqual(isInputAtOrOverCapacity(150_000, NaN), false);
+      assert.strictEqual(
+        isInputAtOrOverCapacity(150_000, Number.POSITIVE_INFINITY),
+        false,
+      );
+    });
+
+    test("returns false for zero inputTokens against a positive cap", () => {
+      // A request that hasn't been counted yet shouldn't be classified as
+      // capacity-driven — the comparison against a positive cap will be
+      // 0 >= cap, which is false.
+      assert.strictEqual(isInputAtOrOverCapacity(0, 200_000), false);
     });
   });
 


### PR DESCRIPTION
## Summary

Long Claude Code sessions intermittently fail with raw HTTP 500s like

```
messages.0.content.0: unexpected `tool_use_id` found in `tool_result` blocks:
toolu_xxx. Each `tool_result` block must have a corresponding `tool_use` block
in the previous message.
```

The `/v1/messages` catch block already recognised this error string and was supposed to translate it into a synthetic `model_context_window_exceeded` response so Claude Code's auto-compact kicks in. But the branch was gated on `inputTokens > maxInputTokens` using our calibrated token estimate, which disagrees with Copilot's internal accounting often enough that the fallback frequently misses: the request was truncated downstream even though our estimate said we were under the limit, and the user saw a raw 500 instead of getting auto-compacted.

This PR removes the unreliable threshold and adds a pre-flight validation layer so the relaxed trigger remains safe.

## Why I'd treat this as P1

For interactive CLI users the workaround is "type `/compact`". For users who don't have a keyboard in the loop — the Claude Code SDK, autonomous goals (`claude /goal …`), any wrapper relying on auto-compact — there is no workaround at all. The only recovery path is the model emitting `stop_reason: "model_context_window_exceeded"`, which is precisely what the fallback exists to do. When the threshold misses, those workflows just stop.

In my own usage I hit this several times per long session running goals through agent-maestro → Claude Code SDK → VS Code Copilot → Vertex. Symptom from the user's side is repeated identical 500s with no recovery, since Claude Code retries the same transcript and Copilot truncates it the same way each time.

## Fix: defense in depth

**Layer 1 — pre-flight pairing validation (new).** `validateAnthropicToolPairing` in `src/server/utils/anthropic.ts` walks the incoming `MessageParam[]` and verifies every `tool_result.tool_use_id` matches a `tool_use.id` from an earlier assistant message. On orphan, `prepareAnthropicMessages` throws a typed `OrphanToolResultError` which the route maps to a clean `400 invalid_request_error`. Malformed client requests no longer reach vscode.lm and never trigger the compact fallback (which wouldn't help them).

**Layer 2 — relaxed catch-block guard.** Because layer 1 proves any request that reaches vscode.lm is well-formed at our boundary, when the orphan error string fires there it must have been introduced downstream (Copilot's internal truncation as it approaches its context window). Compact is the correct recovery regardless of what our local token estimate says, so the threshold goes away. The match itself is extracted into a named, exported, documented helper `isDownstreamTruncationOrphan` so the trigger is easy to find, easy to test, and easy to widen later if the upstream error wording changes.

This composition is what makes removing the threshold safe: a client bug returns 400 (Anthropic-shaped `invalid_request_error`); a Copilot-side truncation returns `model_context_window_exceeded` and auto-compacts. Both paths are deterministic and don't loop.

## Validator design notes (conservative on purpose)

The validator only flags ids that are *certainly* orphan. It tolerates:

- duplicate `tool_use` ids (some clients re-emit)
- `tool_use` without a follow-up `tool_result` (in-flight or intentionally dropped)
- multiple `tool_result`s for the same `tool_use_id`
- `tool_use` + `tool_result` in the same message
- `web_search_tool_result` ↔ regular `tool_use` cross-type pairings

It does enforce role: `tool_use` blocks only register an id when they appear in an `assistant` message. A `tool_use` in a user message is itself out-of-spec, and treating it as "known" would silently satisfy a later `tool_result` and mask the bug instead of returning the 400.

Non-array / null / malformed inputs are treated as ok — schema validation is the route layer's responsibility, and the validator should never throw.

## Test coverage

11 new test cases in `src/test/server/anthropic.test.ts` covering:

- empty / undefined / null / non-array `messages` input (no crash)
- null `message` entry, null/missing/non-array `content` (no crash)
- matched and unmatched tool pairings
- in-flight `tool_use` without `tool_result` (allowed)
- multiple `tool_use`s with partial / full answers
- multiple `tool_result`s for the same id (tolerated)
- duplicate `tool_use` ids across messages (tolerated)
- out-of-order `tool_result` before its `tool_use` (orphan)
- de-duplication of multiple distinct orphan ids
- `server_tool_use` ↔ `tool_result` cross-type pairing (tolerated)
- malformed block entries (`null` etc.) skipped
- `OrphanToolResultError` `instanceof` survives throw/catch
- `tool_use` inside a user message does NOT register its id (regression for role enforcement)
- same-message use/result tolerated (documented design choice)
- protocol-illegal `tool_result` in an assistant message doesn't crash
- `isDownstreamTruncationOrphan` matches the exact upstream substring, rejects unrelated errors, rejects paraphrased orphan messages (so a wording change is a loud failure rather than a silent broadening)

Total suite: 284 → 295 passing. No regressions.

## What this PR deliberately does NOT do

- **No new config knob.** The token-scale-factor escape hatch still exists for users who'd rather throttle earlier; nothing changes for them.
- **No loop guard** on the synthetic `model_context_window_exceeded` response. If Copilot deterministically truncates the same conversation shape and Claude Code keeps re-sending the same compacted history that still triggers truncation, the user will see the same response in a loop. The inflated `input_tokens * 2` already pushes Claude Code to compact aggressively, and adding cross-request state to the proxy felt like the wrong place to fight that. Happy to revisit if it shows up in practice.
- **No change to the error response envelope.** The 400 follows the project's existing `AnthropicErrorResponseSchema` shape (`{ error: { type, message } }`). Anthropic's real wire format wraps that in an outer `{ type: "error", error: { … } }`; aligning the whole project to that envelope is its own change and out of scope here.
- **No changes to OpenAI / Gemini routes.** This bug is specific to the Anthropic adapter.

## Test plan

- [x] `pnpm run check-types`
- [x] `pnpm run lint`
- [x] `pnpm test` — 295 passing
- [x] `pnpm run build`
- [ ] Reproduce against a real long Claude Code session: confirm 500 is replaced by auto-compact. (Hard to script — would appreciate maintainer verification, or pointers if you have an existing harness.)