### PR TITLE
feat(anthropic): report Copilot usage metadata for /v1/messages

### DIFF
--- a/.changeset/crazy-cloths-decide.md
+++ b/.changeset/crazy-cloths-decide.md
@@ -1,0 +1,5 @@
+---
+"agent-maestro": patch
+---
+
+Use Copilot usage metadata from VS Code language model responses to report Anthropic-compatible input, output, and prompt cache token counts.

--- a/.changeset/crazy-cloths-decide.md
+++ b/.changeset/crazy-cloths-decide.md
@@ -2,4 +2,4 @@
 "agent-maestro": patch
 ---
 
-Use Copilot usage metadata from VS Code language model responses to report Anthropic-compatible input, output, and prompt cache token counts.
+Use Copilot usage metadata from VS Code language model responses to report Anthropic-compatible input, output, and prompt cache token counts, with the previous token estimation path retained for count_tokens and fallback usage. Also raise the minimum VS Code engine to `^1.120.0`.

--- a/.changeset/crazy-cloths-decide.md
+++ b/.changeset/crazy-cloths-decide.md
@@ -1,5 +1,0 @@
----
-"agent-maestro": patch
----
-
-Use Copilot usage metadata from VS Code language model responses to report Anthropic-compatible input, output, and prompt cache token counts, with the previous token estimation path retained for count_tokens and fallback usage. Also raise the minimum VS Code engine to `^1.120.0`.

--- a/.changeset/disable-cch-header.md
+++ b/.changeset/disable-cch-header.md
@@ -1,5 +1,0 @@
----
-"agent-maestro": patch
----
-
-Set `CLAUDE_CODE_ATTRIBUTION_HEADER=0` in generated Claude Code `settings.json` to disable the `x-anthropic-billing-header` (CCH), which can break prompt caching on non-Anthropic LLM gateways. See https://code.claude.com/docs/en/llm-gateway.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.9.1 - 2026.05.21
+
+- Use Copilot usage metadata from VS Code language model responses to report Anthropic-compatible input, output, and prompt cache token counts, with the previous token estimation path retained for count_tokens and fallback usage. Also raise the minimum VS Code engine to `^1.120.0`.
+- Set `CLAUDE_CODE_ATTRIBUTION_HEADER=0` in generated Claude Code `settings.json` to disable the `x-anthropic-billing-header` (CCH), which can break prompt caching on non-Anthropic LLM gateways.
+
 ## v2.9.0 - 2026.05.16
 
 - Add Anthropic-compatible model listing and retrieval endpoints to support Claude Desktop 3P gateway compatibility, including model context limits and known capability metadata from VS Code language models.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Turn VS Code into your compliant AI playground! With Agent Maestro, spin up Clin
 Turn VS Code into your compliant AI playground with powerful API compatibility and one-click setup:
 
 - **Universal API Compatibility**: Anthropic (`/messages`), OpenAI (`/chat/completions`, `/responses`), and Gemini compatible endpoints - use Claude Code, Codex, Gemini CLI or any LLM client seamlessly
-  - **Context Window Management**: Configurable scale factors to prevent context window exceeded errors caused by tokenizer differences between VS Code's API and model providers
+  - **Token Usage Reporting**: Reports Copilot-provided Anthropic token usage when available, including prompt cache reads and writes, with estimated token counts as a fallback
 - **One-Click Setup**: Automated configuration commands for instant Claude Code, Codex, and Gemini CLI integration
 - **Headless AI Agent Control**: Create and manage tasks through REST APIs for Roo Code and Cline extensions
   - **Comprehensive APIs**: Complete task lifecycle management with OpenAPI documentation at `/openapi.json`
@@ -221,7 +221,7 @@ You can configure Agent Maestro settings per workspace by adding them to your pr
 | `agent-maestro.defaultRooIdentifier`            | Default Roo extension to use                                       | `"rooveterinaryinc.roo-cline"` |
 | `agent-maestro.proxyServerPort`                 | Proxy server port                                                  | `23333`                        |
 | `agent-maestro.mcpServerPort`                   | MCP server port                                                    | `23334`                        |
-| `agent-maestro.anthropic.tokenCountScaleFactor` | Scale factor for Anthropic token count estimation (range: 1.0–2.0) | `1.25`                         |
+| `agent-maestro.anthropic.tokenCountScaleFactor` | Scale factor for Anthropic token count estimation (range: 0.1–2.0) | `1.25`                         |
 | `agent-maestro.codex.contextWindowScaleFactor`  | Scale factor for Codex context window calculation (range: 0.1–2.0) | `1`                            |
 
 This allows different projects to use different configurations without affecting your global VS Code settings.
@@ -230,15 +230,15 @@ This allows different projects to use different configurations without affecting
 
 Agent Maestro proxies requests through VS Code's Language Model API, which uses a different tokenizer (OpenAI's tiktoken / O200K) than the actual model providers. This mismatch means the token counts reported locally can be lower than the real usage, potentially causing requests to exceed the model's context window and fail unexpectedly.
 
-To prevent this, Agent Maestro provides configurable scale factors that inflate the local token counts to better approximate the actual usage. Different coding agent clients require different approaches:
+Agent Maestro reports real Copilot usage metadata for Anthropic responses when VS Code provides it. When that metadata is unavailable, Agent Maestro falls back to local token counting, and configurable scale factors can inflate those fallback counts to better approximate provider-side usage. Different coding agent clients require different approaches:
 
-- **`anthropic.tokenCountScaleFactor`** (for Claude Code and other Anthropic API clients): Applied to every token count reported in API responses. The proxy multiplies the raw VS Code token count by this factor (e.g., 10,000 tokens × 1.25 = 12,500 reported). This helps the client detect when it's approaching the context limit and trigger actions like auto-compaction before hitting the wall. Increase this value if you still encounter context window errors; decrease it if you want to use more of the available context.
+- **`anthropic.tokenCountScaleFactor`** (for Claude Code and other Anthropic API clients): Applied to fallback token estimates and `/messages/count_tokens` responses. The proxy multiplies the raw VS Code token count by this factor (e.g., 10,000 tokens × 1.25 = 12,500 reported). Real Copilot usage metadata, when available, is reported directly instead of being scaled.
 
 - **`codex.contextWindowScaleFactor`** (for Codex): Used only when generating Codex's `config.toml` to set the `model_context_window` value (calculated as `maxInputTokens × scaleFactor`). This tells Codex the effective context window size upfront so it manages its own conversation history accordingly.
 
 ### Prompt Cache Compatibility
 
-Agent Maestro accepts common prompt cache hints such as Anthropic `cache_control`, OpenAI `prompt_cache_key`, and Gemini `cachedContent` without forwarding unsupported cache controls to VS Code's Language Model API. Because VS Code does not expose provider-side prompt cache reads or writes, cache usage fields are reported as `0` rather than synthetic savings.
+Agent Maestro accepts common prompt cache hints such as Anthropic `cache_control`, OpenAI `prompt_cache_key`, and Gemini `cachedContent` without forwarding unsupported cache controls to VS Code's Language Model API. For Anthropic-compatible responses, Copilot-provided usage metadata is used when available to report `cache_read_input_tokens` and `cache_creation_input_tokens`; fallback estimates report cache usage as `0` rather than synthetic savings.
 
 ## API Overview
 

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
           "default": 1.25,
           "minimum": 0.1,
           "maximum": 2,
-          "description": "Scale factor applied to token counts from VS Code's API to approximate Anthropic's actual token usage. Higher values provide more buffer against context window limits but reduce usable context. Default 1.25 means VS Code token counts are multiplied by 1.25.",
+          "description": "Scale factor applied to fallback Anthropic token estimates and count_tokens responses when real Copilot usage metadata is unavailable. Default 1.25 means VS Code token counts are multiplied by 1.25.",
           "scope": "application"
         }
       }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "publisher": "Joouis",
   "repository": "https://github.com/Joouis/agent-maestro",
   "engines": {
-    "vscode": "^1.100.0",
+    "vscode": "^1.120.0",
     "node": ">=22"
   },
   "packageManager": "pnpm@10.28.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "agent-maestro",
   "displayName": "Agent Maestro",
   "description": "Turn VS Code into your compliant AI playground! With Agent Maestro, spin up Cline or Roo on demand and plug Claude Code or Codex straight in through an OpenAI/Anthropic-compatible API.",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "icon": "assets/icons/icon.png",
   "publisher": "Joouis",
   "repository": "https://github.com/Joouis/agent-maestro",

--- a/src/server/routes/anthropicRoutes.ts
+++ b/src/server/routes/anthropicRoutes.ts
@@ -9,11 +9,13 @@ import { resolveClaudeCodeModelId } from "../../utils/claude";
 import { logger } from "../../utils/logger";
 import { AnthropicErrorResponseSchema } from "../schemas/anthropic";
 import {
+  type AnthropicTokenUsage,
   convertAnthropicMessagesToVSCode,
   convertAnthropicSystemToVSCode,
   convertAnthropicToolChoiceToVSCode,
   convertAnthropicToolToVSCode,
   countAnthropicMessageTokens,
+  extractAnthropicTokenUsageFromVSCodeChunk,
 } from "../utils/anthropic";
 import {
   createAnthropicModelsResponse,
@@ -397,6 +399,7 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
       if (!msgCreateParams.stream) {
         const content: Anthropic.Messages.ContentBlock[] = [];
         let accumulatedText = "";
+        let responseUsage: AnthropicTokenUsage | undefined;
         let stopReason: Anthropic.Messages.StopReason = "end_turn";
 
         try {
@@ -419,6 +422,10 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
               });
 
               accumulatedText += JSON.stringify(chunk);
+            } else {
+              responseUsage =
+                extractAnthropicTokenUsageFromVSCodeChunk(chunk) ??
+                responseUsage;
             }
           }
         } catch (streamError) {
@@ -436,6 +443,12 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
         const outputTokenCount = accumulatedText
           ? await countAnthropicMessageTokens(accumulatedText, client)
           : { original: 1, calibrated: 1 };
+        const usage = responseUsage ?? {
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+          input_tokens: inputTokenCount.calibrated,
+          output_tokens: outputTokenCount.calibrated,
+        };
 
         // https://docs.anthropic.com/en/api/messages#response-id
         const resp: Anthropic.Messages.Message = {
@@ -455,11 +468,11 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
           stop_sequence: null,
           usage: {
             cache_creation: null,
-            cache_creation_input_tokens: 0,
-            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: usage.cache_creation_input_tokens,
+            cache_read_input_tokens: usage.cache_read_input_tokens,
             inference_geo: null,
-            input_tokens: inputTokenCount.calibrated,
-            output_tokens: outputTokenCount.calibrated,
+            input_tokens: usage.input_tokens,
+            output_tokens: usage.output_tokens,
             server_tool_use: null,
             service_tier: null,
           },
@@ -469,7 +482,7 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
         logger.debug("/v1/messages response:");
         logger.debug(JSON.stringify(resp, null, 2));
         logger.info(
-          `← /v1/messages | input: ${inputTokenCount.original} → ${inputTokenCount.calibrated} | output: ${outputTokenCount.original} → ${outputTokenCount.calibrated}`,
+          `← /v1/messages | input: ${usage.input_tokens} | cache_read: ${usage.cache_read_input_tokens} | cache_creation: ${usage.cache_creation_input_tokens} | output: ${usage.output_tokens}`,
         );
 
         return c.json(resp);
@@ -515,6 +528,7 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
 
           const contentBlocks: Anthropic.Messages.ContentBlock[] = [];
           let accumulatedText = "";
+          let responseUsage: AnthropicTokenUsage | undefined;
           let stopReason: Anthropic.Messages.StopReason = "end_turn";
 
           try {
@@ -592,6 +606,10 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
                 });
 
                 accumulatedText += JSON.stringify(chunk);
+              } else {
+                responseUsage =
+                  extractAnthropicTokenUsageFromVSCodeChunk(chunk) ??
+                  responseUsage;
               }
             }
           } catch (streamError) {
@@ -620,6 +638,12 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
           const outputTokenCount = accumulatedText
             ? await countAnthropicMessageTokens(accumulatedText, client)
             : { original: 1, calibrated: 1 };
+          const usage = responseUsage ?? {
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+            input_tokens: inputTokenCount.calibrated,
+            output_tokens: outputTokenCount.calibrated,
+          };
 
           await writeSSE({
             type: "message_delta",
@@ -635,10 +659,10 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
               stop_sequence: null,
             },
             usage: {
-              input_tokens: inputTokenCount.calibrated,
-              output_tokens: outputTokenCount.calibrated,
-              cache_creation_input_tokens: 0,
-              cache_read_input_tokens: 0,
+              input_tokens: usage.input_tokens,
+              output_tokens: usage.output_tokens,
+              cache_creation_input_tokens: usage.cache_creation_input_tokens,
+              cache_read_input_tokens: usage.cache_read_input_tokens,
               server_tool_use: null,
             },
           });
@@ -646,7 +670,7 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
           await writeSSE({ type: "message_stop" });
 
           logger.info(
-            `← /v1/messages (stream) | input: ${inputTokenCount.original} → ${inputTokenCount.calibrated} | output: ${outputTokenCount.original} → ${outputTokenCount.calibrated}`,
+            `← /v1/messages (stream) | input: ${usage.input_tokens} | cache_read: ${usage.cache_read_input_tokens} | cache_creation: ${usage.cache_creation_input_tokens} | output: ${usage.output_tokens}`,
           );
         },
         async (error, _stream) => {

--- a/src/server/routes/anthropicRoutes.ts
+++ b/src/server/routes/anthropicRoutes.ts
@@ -7,6 +7,7 @@ import * as vscode from "vscode";
 import { chatModelsCache, getChatModelClient } from "../../utils/chatModels";
 import { resolveClaudeCodeModelId } from "../../utils/claude";
 import { logger } from "../../utils/logger";
+import { LanguageModelDataPart } from "../../utils/vscode";
 import { AnthropicErrorResponseSchema } from "../schemas/anthropic";
 import {
   type AnthropicTokenUsage,
@@ -429,7 +430,10 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
               });
 
               accumulatedText += JSON.stringify(chunk);
-            } else {
+            } else if (
+              LanguageModelDataPart &&
+              chunk instanceof LanguageModelDataPart
+            ) {
               responseUsage =
                 extractAnthropicTokenUsageFromVSCodeChunk(chunk) ??
                 responseUsage;
@@ -605,7 +609,10 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
                 });
 
                 accumulatedText += JSON.stringify(chunk);
-              } else {
+              } else if (
+                LanguageModelDataPart &&
+                chunk instanceof LanguageModelDataPart
+              ) {
                 responseUsage =
                   extractAnthropicTokenUsageFromVSCodeChunk(chunk) ??
                   responseUsage;

--- a/src/server/routes/anthropicRoutes.ts
+++ b/src/server/routes/anthropicRoutes.ts
@@ -26,10 +26,8 @@ import { isResponseTooLongError } from "../utils/languageModelErrors";
 
 const prepareAnthropicMessages = async ({
   requestBody,
-  client,
 }: {
   requestBody: Anthropic.Messages.MessageCreateParams;
-  client: vscode.LanguageModelChat;
 }) => {
   logger.debug("/v1/messages payload:");
   logger.debug(JSON.stringify(requestBody, null, 2));
@@ -42,14 +40,9 @@ const prepareAnthropicMessages = async ({
   ];
 
   const cancellationToken = new vscode.CancellationTokenSource().token;
-  const inputTokenCount = await countAnthropicMessageTokens(
-    JSON.stringify(requestBody),
-    client,
-  );
 
   return {
     vsCodeLmMessages,
-    inputTokenCount,
     cancellationToken,
   };
 };
@@ -327,10 +320,8 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
   // POST /v1/messages - Anthropic-compatible messages endpoint
   app.openapi(messagesRoute, async (c: Context): Promise<Response> => {
     let effectiveModelId = "";
-    let maxInputTokens = 0;
     let rawRequestBody;
     let lmChatMessages: vscode.LanguageModelChatMessage[] | undefined;
-    let inputTokens = 0;
 
     try {
       // Parse request body
@@ -356,7 +347,6 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
 
       if (initialClient) {
         effectiveModelId = initialClient.id;
-        maxInputTokens = initialClient.maxInputTokens;
       }
 
       if (clientError) {
@@ -365,18 +355,16 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
 
       let client = initialClient!;
 
-      // 3. Map Anthropic messages to VS Code LM API messages and count input tokens
-      const { vsCodeLmMessages, inputTokenCount, cancellationToken } =
+      // 3. Map Anthropic messages to VS Code LM API messages
+      const { vsCodeLmMessages, cancellationToken } =
         await prepareAnthropicMessages({
           requestBody: { ...requestBody, model: resolvedModel },
-          client,
         });
       lmChatMessages = vsCodeLmMessages;
-      inputTokens = inputTokenCount.calibrated;
       logger.info(
         `→ /v1/messages | model: ${
           model === effectiveModelId ? model : `${model} → ${effectiveModelId}`
-        } | input: ${inputTokenCount.original} → ${inputTokenCount.calibrated} | maxInput: ${maxInputTokens}`,
+        }`,
       );
 
       // 4. Build VS Code Language Model request options
@@ -394,6 +382,25 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
         lmRequestOptions,
         cancellationToken,
       );
+
+      const getFallbackUsage = async (
+        accumulatedText: string,
+      ): Promise<AnthropicTokenUsage> => {
+        const inputTokenCount = await countAnthropicMessageTokens(
+          JSON.stringify(requestBody),
+          client,
+        );
+        const outputTokenCount = accumulatedText
+          ? await countAnthropicMessageTokens(accumulatedText, client)
+          : { original: 1, calibrated: 1 };
+
+        return {
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+          input_tokens: inputTokenCount.calibrated,
+          output_tokens: outputTokenCount.calibrated,
+        };
+      };
 
       // 6. Non-streaming response: collect content blocks using unified approach
       if (!msgCreateParams.stream) {
@@ -439,16 +446,8 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
           );
         }
 
-        // Count output tokens
-        const outputTokenCount = accumulatedText
-          ? await countAnthropicMessageTokens(accumulatedText, client)
-          : { original: 1, calibrated: 1 };
-        const usage = responseUsage ?? {
-          cache_creation_input_tokens: 0,
-          cache_read_input_tokens: 0,
-          input_tokens: inputTokenCount.calibrated,
-          output_tokens: outputTokenCount.calibrated,
-        };
+        const usage =
+          responseUsage ?? (await getFallbackUsage(accumulatedText));
 
         // https://docs.anthropic.com/en/api/messages#response-id
         const resp: Anthropic.Messages.Message = {
@@ -515,7 +514,7 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
               stop_sequence: null,
               usage: {
                 cache_creation: null,
-                input_tokens: inputTokenCount.calibrated,
+                input_tokens: 1,
                 output_tokens: 1,
                 cache_creation_input_tokens: 0,
                 cache_read_input_tokens: 0,
@@ -634,16 +633,8 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
             });
           }
 
-          // Count output tokens for the complete response
-          const outputTokenCount = accumulatedText
-            ? await countAnthropicMessageTokens(accumulatedText, client)
-            : { original: 1, calibrated: 1 };
-          const usage = responseUsage ?? {
-            cache_creation_input_tokens: 0,
-            cache_read_input_tokens: 0,
-            input_tokens: inputTokenCount.calibrated,
-            output_tokens: outputTokenCount.calibrated,
-          };
+          const usage =
+            responseUsage ?? (await getFallbackUsage(accumulatedText));
 
           await writeSSE({
             type: "message_delta",
@@ -682,7 +673,6 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
 
       const logFilePath = await handleErrorWithLogging({
         requestBody: rawRequestBody,
-        inputTokens,
         lmChatMessages,
         error,
         endpoint: "/api/anthropic/v1/messages",
@@ -691,119 +681,6 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
 
       const errorMessage =
         error instanceof Error ? error.message : JSON.stringify(error);
-
-      const isContextWindowExceeded =
-        errorMessage.includes(
-          "unexpected `tool_use_id` found in `tool_result` blocks",
-        ) &&
-        maxInputTokens > 0 &&
-        inputTokens > maxInputTokens;
-
-      if (isContextWindowExceeded) {
-        const model = rawRequestBody?.model ?? effectiveModelId;
-        const modelLabel =
-          model === effectiveModelId
-            ? effectiveModelId
-            : `${model} → ${effectiveModelId}`;
-
-        logger.warn(
-          `/v1/messages | context window exceeded | input: ${inputTokens} > max: ${maxInputTokens} | model: ${modelLabel}`,
-        );
-
-        vscode.window.showWarningMessage(
-          "The model has reached its context window limit. Please use the /compact command to reduce the conversation history. You can adjust 'agent-maestro.anthropic.tokenCountScaleFactor' in settings to fine-tune token estimation.",
-        );
-
-        if (rawRequestBody?.stream) {
-          return streamSSE(
-            c,
-            async (stream) => {
-              const writeSSE = async (
-                message: Anthropic.Messages.RawMessageStreamEvent,
-              ) => {
-                await stream.writeSSE({
-                  event: message.type,
-                  data: JSON.stringify(message),
-                });
-              };
-
-              await writeSSE({
-                type: "message_start",
-                message: {
-                  id: `msg_${Date.now()}`,
-                  type: "message",
-                  role: "assistant",
-                  model,
-                  container: null,
-                  content: [],
-                  stop_details: null,
-                  stop_reason: null,
-                  stop_sequence: null,
-                  usage: {
-                    cache_creation: null,
-                    input_tokens: inputTokens,
-                    output_tokens: 0,
-                    cache_creation_input_tokens: 0,
-                    cache_read_input_tokens: 0,
-                    inference_geo: null,
-                    server_tool_use: null,
-                    service_tier: "standard",
-                  },
-                },
-              });
-
-              await writeSSE({
-                type: "message_delta",
-                delta: {
-                  container: null,
-                  stop_details: null,
-                  stop_reason:
-                    "model_context_window_exceeded" as Anthropic.Messages.StopReason,
-                  stop_sequence: null,
-                },
-                usage: {
-                  input_tokens: inputTokens * 2, // Inflate to ensure Claude Code triggers auto-compact before next message
-                  output_tokens: 0,
-                  cache_creation_input_tokens: 0,
-                  cache_read_input_tokens: 0,
-                  server_tool_use: null,
-                },
-              });
-
-              await writeSSE({ type: "message_stop" });
-            },
-            async (err, _stream) => {
-              logger.error(
-                "✕ /v1/messages (context window exceeded stream) |",
-                err,
-              );
-            },
-          );
-        }
-
-        return c.json({
-          id: `msg_${Date.now()}`,
-          type: "message",
-          role: "assistant",
-          model,
-          container: null,
-          content: [],
-          stop_details: null,
-          stop_reason:
-            "model_context_window_exceeded" as Anthropic.Messages.StopReason,
-          stop_sequence: null,
-          usage: {
-            cache_creation: null,
-            cache_creation_input_tokens: 0,
-            cache_read_input_tokens: 0,
-            inference_geo: null,
-            input_tokens: inputTokens * 2, // Inflate to ensure Claude Code triggers auto-compact before next message
-            output_tokens: 0,
-            server_tool_use: null,
-            service_tier: null,
-          },
-        } as Anthropic.Messages.Message);
-      }
 
       const isModelNotSupportedError = errorMessage.includes(
         "model_not_supported",
@@ -845,10 +722,10 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
       if (clientError) {
         return c.json(clientError, 404);
       }
-      const { inputTokenCount } = await prepareAnthropicMessages({
-        requestBody: { ...requestBody, model: resolvedModel },
+      const inputTokenCount = await countAnthropicMessageTokens(
+        JSON.stringify(requestBody),
         client,
-      });
+      );
 
       return c.json(
         {

--- a/src/server/utils/anthropic.ts
+++ b/src/server/utils/anthropic.ts
@@ -340,16 +340,14 @@ function isCopilotUsagePayload(value: unknown): value is CopilotUsagePayload {
 }
 
 /**
- * Extracts hidden Copilot usage metadata from VS Code LM response data parts.
+ * Decodes Copilot usage metadata from a VS Code LM `LanguageModelDataPart`.
+ * Caller is responsible for verifying the chunk is a data part.
  */
-export function extractAnthropicTokenUsageFromVSCodeChunk(
-  chunk: unknown,
-): AnthropicTokenUsage | undefined {
-  if (
-    !LanguageModelDataPart ||
-    !(chunk instanceof LanguageModelDataPart) ||
-    chunk.mimeType !== "usage"
-  ) {
+export function extractAnthropicTokenUsageFromVSCodeChunk(chunk: {
+  data: Uint8Array;
+  mimeType: string;
+}): AnthropicTokenUsage | undefined {
+  if (chunk.mimeType !== "usage") {
     return undefined;
   }
 

--- a/src/server/utils/anthropic.ts
+++ b/src/server/utils/anthropic.ts
@@ -2,6 +2,7 @@ import Anthropic from "@anthropic-ai/sdk";
 import * as vscode from "vscode";
 
 import { logger } from "../../utils/logger";
+import { LanguageModelDataPart } from "../../utils/vscode";
 
 const textBlockParamToVSCodePart = (param: Anthropic.Messages.TextBlockParam) =>
   new vscode.LanguageModelTextPart(param.text);
@@ -9,11 +10,6 @@ const textBlockParamToVSCodePart = (param: Anthropic.Messages.TextBlockParam) =>
 const imageBlockParamToVSCodePart = (
   param: Anthropic.Messages.ImageBlockParam,
 ) => {
-  /**
-   * A language model response part containing arbitrary data, not an official API yet.
-   */
-  const LanguageModelDataPart = (vscode as any).LanguageModelDataPart;
-
   if (param.source.type === "url" || !LanguageModelDataPart) {
     return new vscode.LanguageModelTextPart(JSON.stringify(param));
   }
@@ -255,9 +251,7 @@ export const convertAnthropicSystemToVSCode = (
  */
 const isUnsupportedServerSideTool = (tool: unknown): boolean => {
   const t = tool as { type?: string; input_schema?: unknown };
-  return (
-    typeof t.type === "string" && t.type !== "custom" && !t.input_schema
-  );
+  return typeof t.type === "string" && t.type !== "custom" && !t.input_schema;
 };
 
 export const convertAnthropicToolToVSCode = (
@@ -315,6 +309,73 @@ const DEFAULT_TOKEN_SCALE_FACTOR = 1.25;
 export interface TokenCounts {
   original: number; // Original VSCode API token count
   calibrated: number; // Scaled token count approximating actual API usage
+}
+
+interface CopilotUsagePayload {
+  completion_tokens: number;
+  prompt_tokens: number;
+  prompt_tokens_details?: {
+    cache_creation_input_tokens?: number;
+    cached_tokens?: number;
+  };
+}
+
+export interface AnthropicTokenUsage {
+  cache_creation_input_tokens: number;
+  cache_read_input_tokens: number;
+  input_tokens: number;
+  output_tokens: number;
+}
+
+function isCopilotUsagePayload(value: unknown): value is CopilotUsagePayload {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const usage = value as Partial<CopilotUsagePayload>;
+  return (
+    typeof usage.prompt_tokens === "number" &&
+    typeof usage.completion_tokens === "number"
+  );
+}
+
+/**
+ * Extracts hidden Copilot usage metadata from VS Code LM response data parts.
+ */
+export function extractAnthropicTokenUsageFromVSCodeChunk(
+  chunk: unknown,
+): AnthropicTokenUsage | undefined {
+  if (
+    !LanguageModelDataPart ||
+    !(chunk instanceof LanguageModelDataPart) ||
+    chunk.mimeType !== "usage"
+  ) {
+    return undefined;
+  }
+
+  try {
+    const usage = JSON.parse(new TextDecoder().decode(chunk.data)) as unknown;
+    if (!isCopilotUsagePayload(usage)) {
+      return undefined;
+    }
+
+    const cacheCreationInputTokens =
+      usage.prompt_tokens_details?.cache_creation_input_tokens ?? 0;
+    const cacheReadInputTokens =
+      usage.prompt_tokens_details?.cached_tokens ?? 0;
+
+    return {
+      cache_creation_input_tokens: cacheCreationInputTokens,
+      cache_read_input_tokens: cacheReadInputTokens,
+      input_tokens: Math.max(
+        0,
+        usage.prompt_tokens - cacheCreationInputTokens - cacheReadInputTokens,
+      ),
+      output_tokens: usage.completion_tokens,
+    };
+  } catch {
+    return undefined;
+  }
 }
 
 /**

--- a/src/server/utils/anthropic.ts
+++ b/src/server/utils/anthropic.ts
@@ -335,9 +335,16 @@ function isCopilotUsagePayload(value: unknown): value is CopilotUsagePayload {
   const usage = value as Partial<CopilotUsagePayload>;
   return (
     typeof usage.prompt_tokens === "number" &&
-    typeof usage.completion_tokens === "number"
+    Number.isFinite(usage.prompt_tokens) &&
+    usage.prompt_tokens >= 0 &&
+    typeof usage.completion_tokens === "number" &&
+    Number.isFinite(usage.completion_tokens) &&
+    usage.completion_tokens >= 0
   );
 }
+
+const clampNonNegative = (value: number | undefined): number =>
+  typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : 0;
 
 /**
  * Decodes Copilot usage metadata from a VS Code LM `LanguageModelDataPart`.
@@ -357,10 +364,12 @@ export function extractAnthropicTokenUsageFromVSCodeChunk(chunk: {
       return undefined;
     }
 
-    const cacheCreationInputTokens =
-      usage.prompt_tokens_details?.cache_creation_input_tokens ?? 0;
-    const cacheReadInputTokens =
-      usage.prompt_tokens_details?.cached_tokens ?? 0;
+    const cacheCreationInputTokens = clampNonNegative(
+      usage.prompt_tokens_details?.cache_creation_input_tokens,
+    );
+    const cacheReadInputTokens = clampNonNegative(
+      usage.prompt_tokens_details?.cached_tokens,
+    );
 
     return {
       cache_creation_input_tokens: cacheCreationInputTokens,

--- a/src/test/server/anthropic.test.ts
+++ b/src/test/server/anthropic.test.ts
@@ -7,6 +7,7 @@ import {
   convertAnthropicSystemToVSCode,
   convertAnthropicToolChoiceToVSCode,
   convertAnthropicToolToVSCode,
+  extractAnthropicTokenUsageFromVSCodeChunk,
 } from "../../server/utils/anthropic";
 import {
   createAnthropicModelsResponse,
@@ -638,6 +639,128 @@ suite("Anthropic Conversion Utils Test Suite", () => {
       assert.strictEqual(isResponseTooLongError("Response too long"), false);
       assert.strictEqual(isResponseTooLongError(null), false);
       assert.strictEqual(isResponseTooLongError(undefined), false);
+    });
+  });
+
+  suite("extractAnthropicTokenUsageFromVSCodeChunk", () => {
+    const encode = (value: unknown): Uint8Array =>
+      new TextEncoder().encode(JSON.stringify(value));
+
+    test("should extract usage and subtract cache tokens from input_tokens", () => {
+      const result = extractAnthropicTokenUsageFromVSCodeChunk({
+        mimeType: "usage",
+        data: encode({
+          prompt_tokens: 1000,
+          completion_tokens: 50,
+          prompt_tokens_details: {
+            cache_creation_input_tokens: 200,
+            cached_tokens: 300,
+          },
+        }),
+      });
+
+      assert.deepStrictEqual(result, {
+        cache_creation_input_tokens: 200,
+        cache_read_input_tokens: 300,
+        input_tokens: 500,
+        output_tokens: 50,
+      });
+    });
+
+    test("should default cache fields to 0 when prompt_tokens_details is missing", () => {
+      const result = extractAnthropicTokenUsageFromVSCodeChunk({
+        mimeType: "usage",
+        data: encode({ prompt_tokens: 100, completion_tokens: 20 }),
+      });
+
+      assert.deepStrictEqual(result, {
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+        input_tokens: 100,
+        output_tokens: 20,
+      });
+    });
+
+    test("should clamp input_tokens to 0 when cache totals exceed prompt_tokens", () => {
+      const result = extractAnthropicTokenUsageFromVSCodeChunk({
+        mimeType: "usage",
+        data: encode({
+          prompt_tokens: 100,
+          completion_tokens: 10,
+          prompt_tokens_details: {
+            cache_creation_input_tokens: 80,
+            cached_tokens: 80,
+          },
+        }),
+      });
+
+      assert.strictEqual(result?.input_tokens, 0);
+    });
+
+    test("should return undefined for non-usage mimeType", () => {
+      const result = extractAnthropicTokenUsageFromVSCodeChunk({
+        mimeType: "image/png",
+        data: encode({ prompt_tokens: 1, completion_tokens: 1 }),
+      });
+
+      assert.strictEqual(result, undefined);
+    });
+
+    test("should return undefined for invalid JSON", () => {
+      const result = extractAnthropicTokenUsageFromVSCodeChunk({
+        mimeType: "usage",
+        data: new TextEncoder().encode("not json {"),
+      });
+
+      assert.strictEqual(result, undefined);
+    });
+
+    test("should return undefined when required fields are missing", () => {
+      const result = extractAnthropicTokenUsageFromVSCodeChunk({
+        mimeType: "usage",
+        data: encode({ prompt_tokens: 100 }),
+      });
+
+      assert.strictEqual(result, undefined);
+    });
+
+    test("should reject non-finite or negative token counts", () => {
+      assert.strictEqual(
+        extractAnthropicTokenUsageFromVSCodeChunk({
+          mimeType: "usage",
+          data: encode({ prompt_tokens: -1, completion_tokens: 10 }),
+        }),
+        undefined,
+      );
+
+      assert.strictEqual(
+        extractAnthropicTokenUsageFromVSCodeChunk({
+          mimeType: "usage",
+          data: encode({ prompt_tokens: 100, completion_tokens: "20" }),
+        }),
+        undefined,
+      );
+    });
+
+    test("should ignore negative or non-finite cache fields", () => {
+      const result = extractAnthropicTokenUsageFromVSCodeChunk({
+        mimeType: "usage",
+        data: encode({
+          prompt_tokens: 100,
+          completion_tokens: 10,
+          prompt_tokens_details: {
+            cache_creation_input_tokens: -5,
+            cached_tokens: Number.POSITIVE_INFINITY,
+          },
+        }),
+      });
+
+      assert.deepStrictEqual(result, {
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+        input_tokens: 100,
+        output_tokens: 10,
+      });
     });
   });
 });

--- a/src/utils/vscode.ts
+++ b/src/utils/vscode.ts
@@ -1,0 +1,18 @@
+import * as vscode from "vscode";
+
+interface LanguageModelDataPartCtor {
+  new (
+    data: Uint8Array,
+    mimeType: string,
+  ): {
+    data: Uint8Array;
+    mimeType: string;
+  };
+}
+
+/**
+ * A language model response part containing arbitrary data, not an official API yet.
+ */
+export const LanguageModelDataPart: LanguageModelDataPartCtor | undefined = (
+  vscode as any
+).LanguageModelDataPart;


### PR DESCRIPTION
## Summary
- Use Copilot-provided usage metadata (extracted from VS Code LM `LanguageModelDataPart` chunks with `mimeType: "usage"`) to populate Anthropic `input_tokens`, `output_tokens`, `cache_read_input_tokens`, and `cache_creation_input_tokens` on `/v1/messages` responses (streaming and non-streaming).
- Defer local tiktoken-based estimation to a fallback path used only when no usage chunk arrives; `count_tokens` and the fallback still apply `anthropic.tokenCountScaleFactor`.
- Raise minimum VS Code engine to `^1.120.0` for `LanguageModelDataPart` availability; centralize the unofficial constructor in `src/utils/vscode.ts`.
- Remove the prior `model_context_window_exceeded` heuristic — with real usage metadata, clients can drive auto-compact themselves.

## Test plan
- [x] `/v1/messages` non-streaming: verify `usage` fields reflect Copilot-reported counts (including non-zero `cache_read_input_tokens` on a cached prompt).
- [x] `/v1/messages` streaming: verify final `message_delta` carries Copilot usage; `message_start` shows placeholder `input_tokens: 1` (acceptable regression).
- [x] Fallback path: simulate missing usage chunk, confirm tiktoken estimates still report and respect `tokenCountScaleFactor`.
- [x] `/v1/messages/count_tokens` continues to return scaled estimates.
- [ ] Confirm context-window overflow now surfaces as a normal error path rather than a synthesized stop reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)