### PR TITLE
Add metrics dashboard and request details

### DIFF
--- a/.changeset/clean-dashboard-metrics-cards.md
+++ b/.changeset/clean-dashboard-metrics-cards.md
@@ -2,4 +2,4 @@
 "agent-maestro": patch
 ---
 
-Remove unsupported cache token KPI/detail capture UI from dashboard metrics and keep request details focused on available data.
+Remove the unsupported cache-token KPIs and the Detail capture card from the dashboard, keeping metrics aligned with data the server actually collects.

--- a/package.json
+++ b/package.json
@@ -101,10 +101,23 @@
           "maximum": 2,
           "description": "Scale factor applied to token counts from VS Code's API to approximate Anthropic's actual token usage. Higher values provide more buffer against context window limits but reduce usable context. Default 1.25 means VS Code token counts are multiplied by 1.25.",
           "scope": "application"
+        },
+        "agent-maestro.dashboard.maxRecords": {
+          "type": "number",
+          "default": 500,
+          "minimum": 50,
+          "maximum": 5000,
+          "description": "Maximum number of recent request records the dashboard retains in memory. Older records are dropped. Resets on extension reload.",
+          "scope": "application"
         }
       }
     },
     "commands": [
+      {
+        "command": "agent-maestro.openDashboard",
+        "title": "Open Dashboard",
+        "category": "Agent Maestro"
+      },
       {
         "command": "agent-maestro.getStatus",
         "title": "Get Extensions Status",

--- a/src/commands/dashboardCommands.ts
+++ b/src/commands/dashboardCommands.ts
@@ -1,0 +1,20 @@
+import * as vscode from "vscode";
+
+import { DashboardPanel } from "../dashboard/DashboardPanel";
+import { ProxyServer } from "../server/ProxyServer";
+import { metricsCollector } from "../server/metrics/MetricsCollector";
+import { createCommandHandler } from "./commandHandler";
+
+export function registerDashboardCommands(
+  context: vscode.ExtensionContext,
+  proxy: ProxyServer,
+) {
+  const disposable = vscode.commands.registerCommand(
+    "agent-maestro.openDashboard",
+    createCommandHandler(() => {
+      DashboardPanel.show(context, metricsCollector, proxy.getStatus().url);
+    }, "Failed to open dashboard"),
+  );
+
+  context.subscriptions.push(disposable);
+}

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -5,6 +5,7 @@ import { McpServer } from "../server/McpServer";
 import { ProxyServer } from "../server/ProxyServer";
 import { registerConfiguratorCommands } from "./configuratorCommands";
 import { registerCopilotFixCommands } from "./copilotFixCommands";
+import { registerDashboardCommands } from "./dashboardCommands";
 import { registerLlmApiKeyCommands } from "./llmApiKeyCommands";
 import { registerMcpCommands } from "./mcpCommands";
 import { registerProxyCommands } from "./proxyCommands";
@@ -22,4 +23,5 @@ export function registerAllCommands(
   registerCopilotFixCommands(context);
   registerStatusCommands(controller, context);
   registerLlmApiKeyCommands(proxy, context);
+  registerDashboardCommands(context, proxy);
 }

--- a/src/dashboard/DashboardPanel.ts
+++ b/src/dashboard/DashboardPanel.ts
@@ -219,13 +219,6 @@ export class DashboardPanel {
   <div class="card"><div class="label">Output tokens (total)</div><div class="value" id="kpiOutput">0</div></div>
 </div>
 
-<div class="grid">
-  <div class="card"><div class="label">Cache read tokens</div><div class="value" id="kpiCacheRead">0</div></div>
-  <div class="card"><div class="label">Cache creation tokens</div><div class="value" id="kpiCacheCreate">0</div></div>
-  <div class="card"><div class="label">Cache hit rate</div><div class="value" id="kpiCacheHit">—</div><div class="sub">read / input</div></div>
-  <div class="card"><div class="label">Detail capture</div><div class="value">Safe</div><div class="sub">headers only, no bodies</div></div>
-</div>
-
 <div class="section">
   <h2>Latency percentiles (5m)</h2>
   <div class="row">
@@ -292,6 +285,8 @@ export class DashboardPanel {
     return '';
   }
 
+  const expandedRequestIds = new Set();
+
   function render(snap) {
     document.getElementById('kpiActive').textContent = snap.activeRequests;
     document.getElementById('kpiTps').textContent = snap.rolling.avgTokensPerSecond ? snap.rolling.avgTokensPerSecond.toFixed(1) : '—';
@@ -303,9 +298,6 @@ export class DashboardPanel {
     document.getElementById('kpiErrors').textContent = fmt(snap.totals.errors);
     document.getElementById('kpiInput').textContent = fmtCompact(snap.totals.inputTokens);
     document.getElementById('kpiOutput').textContent = fmtCompact(snap.totals.outputTokens);
-    document.getElementById('kpiCacheRead').textContent = fmtCompact(snap.totals.cacheReadInputTokens);
-    document.getElementById('kpiCacheCreate').textContent = fmtCompact(snap.totals.cacheCreationInputTokens);
-    document.getElementById('kpiCacheHit').textContent = snap.totals.inputTokens ? fmtPct(snap.totals.cacheReadInputTokens / snap.totals.inputTokens) : '—';
 
     document.getElementById('p50').textContent = fmtDuration(snap.rolling.p50DurationMs);
     document.getElementById('p95').textContent = fmtDuration(snap.rolling.p95DurationMs);
@@ -333,16 +325,21 @@ export class DashboardPanel {
 
     const recentBody = document.querySelector('#recentTable tbody');
     const rows = snap.recent.slice().reverse().slice(0, 50);
+    const visibleRequestIds = new Set(rows.map(r => r.id));
+    expandedRequestIds.forEach((id) => {
+      if (!visibleRequestIds.has(id)) {
+        expandedRequestIds.delete(id);
+      }
+    });
     recentBody.innerHTML = rows.length
       ? rows.map(r => renderRequestRow(r)).join('')
       : '<tr><td colspan="10" class="empty">No requests yet — send a request to your proxy</td></tr>';
   }
 
   function renderRequestRow(r) {
+    const expanded = expandedRequestIds.has(r.id);
     const startedAtTime = new Date(r.startedAt).toLocaleTimeString();
     const badge = badgeForStatus(r.status);
-    const cacheRead = r.details?.cacheReadInputTokens ?? 0;
-    const cacheCreate = r.details?.cacheCreationInputTokens ?? 0;
     const detail = {
       id: r.id,
       method: r.method,
@@ -355,9 +352,6 @@ export class DashboardPanel {
       streaming: r.streaming,
       inputTokens: r.inputTokens ?? null,
       outputTokens: r.outputTokens ?? null,
-      cacheReadInputTokens: cacheRead,
-      cacheCreationInputTokens: cacheCreate,
-      cacheHitRate: r.inputTokens ? fmtPct(cacheRead / r.inputTokens) : null,
       error: r.error ?? null,
       requestHeaders: r.details?.requestHeaders ?? {},
       responseHeaders: r.details?.responseHeaders ?? {},
@@ -373,7 +367,7 @@ export class DashboardPanel {
       '<td class="num">' + (r.outputTokens ? fmtCompact(r.outputTokens) : '—') + '</td>' +
       '<td class="num">' + (r.tokensPerSecond ? r.tokensPerSecond.toFixed(1) : '—') + '</td>' +
       '<td>' + (r.model ? escapeHtml(r.model) : '—') + '</td>' +
-    '</tr><tr class="detail-row" data-detail-for="' + escapeHtml(r.id) + '" hidden><td colspan="10"><div class="detail-grid">' +
+    '</tr><tr class="detail-row" data-detail-for="' + escapeHtml(r.id) + '"' + (expanded ? '' : ' hidden') + '><td colspan="10"><div class="detail-grid">' +
       '<div><div class="detail-title">Summary</div><pre>' + escapeHtml(JSON.stringify(detail, null, 2)) + '</pre></div>' +
       '<div><div class="detail-title">Safe headers</div><pre>' + escapeHtml(JSON.stringify({ request: detail.requestHeaders, response: detail.responseHeaders }, null, 2)) + '</pre></div>' +
     '</div></td></tr>';
@@ -391,8 +385,17 @@ export class DashboardPanel {
   document.getElementById('recentTable').addEventListener('click', (event) => {
     const row = event.target.closest('.request-row');
     if (!row) return;
-    const detail = document.querySelector('[data-detail-for="' + row.dataset.requestId + '"]');
-    if (detail) detail.hidden = !detail.hidden;
+    const requestId = row.dataset.requestId;
+    if (!requestId) return;
+    if (expandedRequestIds.has(requestId)) {
+      expandedRequestIds.delete(requestId);
+    } else {
+      expandedRequestIds.add(requestId);
+    }
+    const detail = document.querySelector('[data-detail-for="' + requestId + '"]');
+    if (detail) {
+      detail.hidden = !expandedRequestIds.has(requestId);
+    }
   });
 
   document.getElementById('resetBtn').addEventListener('click', () => {

--- a/src/dashboard/DashboardPanel.ts
+++ b/src/dashboard/DashboardPanel.ts
@@ -1,0 +1,376 @@
+import * as vscode from "vscode";
+
+import {
+  MetricsCollector,
+  MetricsSnapshot,
+} from "../server/metrics/MetricsCollector";
+import { logger } from "../utils/logger";
+
+const REFRESH_MS = 1000;
+
+export class DashboardPanel {
+  private static current: DashboardPanel | undefined;
+  private readonly panel: vscode.WebviewPanel;
+  private readonly disposables: vscode.Disposable[] = [];
+  private refreshTimer?: NodeJS.Timeout;
+
+  static show(
+    context: vscode.ExtensionContext,
+    collector: MetricsCollector,
+    proxyUrl: string,
+  ) {
+    if (DashboardPanel.current) {
+      DashboardPanel.current.panel.reveal();
+      return;
+    }
+    const panel = vscode.window.createWebviewPanel(
+      "agentMaestroDashboard",
+      "Agent Maestro Dashboard",
+      vscode.ViewColumn.Active,
+      {
+        enableScripts: true,
+        retainContextWhenHidden: true,
+        localResourceRoots: [context.extensionUri],
+      },
+    );
+    DashboardPanel.current = new DashboardPanel(panel, collector, proxyUrl);
+  }
+
+  private constructor(
+    panel: vscode.WebviewPanel,
+    private readonly collector: MetricsCollector,
+    private readonly proxyUrl: string,
+  ) {
+    this.panel = panel;
+    this.panel.webview.html = this.renderHtml();
+
+    this.panel.onDidDispose(() => this.dispose(), null, this.disposables);
+
+    this.panel.webview.onDidReceiveMessage(
+      (msg: { type: string }) => {
+        if (msg.type === "reset") {
+          this.collector.reset();
+          this.push();
+        } else if (msg.type === "ready") {
+          this.push();
+        }
+      },
+      null,
+      this.disposables,
+    );
+
+    this.refreshTimer = setInterval(() => this.push(), REFRESH_MS);
+  }
+
+  private push() {
+    const snapshot = this.collector.snapshot();
+    void this.panel.webview.postMessage({
+      type: "snapshot",
+      snapshot,
+    } satisfies { type: "snapshot"; snapshot: MetricsSnapshot });
+  }
+
+  private dispose() {
+    DashboardPanel.current = undefined;
+    if (this.refreshTimer) {
+      clearInterval(this.refreshTimer);
+    }
+    while (this.disposables.length) {
+      const d = this.disposables.pop();
+      try {
+        d?.dispose();
+      } catch (e) {
+        logger.error("Dashboard dispose error:", e as Error);
+      }
+    }
+  }
+
+  private renderHtml(): string {
+    const nonce = getNonce();
+    const csp = [
+      "default-src 'none'",
+      `style-src 'unsafe-inline'`,
+      `script-src 'nonce-${nonce}'`,
+    ].join("; ");
+
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta http-equiv="Content-Security-Policy" content="${csp}" />
+<title>Agent Maestro Dashboard</title>
+<style>
+  :root {
+    --bg: var(--vscode-editor-background);
+    --fg: var(--vscode-editor-foreground);
+    --muted: var(--vscode-descriptionForeground);
+    --border: var(--vscode-panel-border, rgba(128,128,128,0.3));
+    --accent: var(--vscode-textLink-foreground);
+    --good: #2ea043;
+    --warn: #d29922;
+    --bad: #f85149;
+    --card-bg: var(--vscode-editorWidget-background, rgba(127,127,127,0.06));
+  }
+  * { box-sizing: border-box; }
+  body {
+    font-family: var(--vscode-font-family);
+    font-size: var(--vscode-font-size);
+    color: var(--fg);
+    background: var(--bg);
+    margin: 0;
+    padding: 16px;
+  }
+  header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 16px;
+  }
+  header h1 { font-size: 18px; margin: 0; }
+  header .meta { color: var(--muted); font-size: 12px; }
+  button {
+    background: var(--vscode-button-secondaryBackground);
+    color: var(--vscode-button-secondaryForeground);
+    border: 1px solid var(--border);
+    padding: 4px 10px;
+    cursor: pointer;
+    border-radius: 4px;
+  }
+  button:hover { background: var(--vscode-button-secondaryHoverBackground); }
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 12px;
+    margin-bottom: 16px;
+  }
+  .card {
+    background: var(--card-bg);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 12px;
+  }
+  .card .label { color: var(--muted); font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
+  .card .value { font-size: 22px; font-weight: 600; margin-top: 4px; }
+  .card .sub { color: var(--muted); font-size: 11px; margin-top: 2px; }
+  .section { margin-bottom: 20px; }
+  .section h2 { font-size: 13px; text-transform: uppercase; letter-spacing: 0.5px; color: var(--muted); margin: 0 0 8px; }
+  .row { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+  table { width: 100%; border-collapse: collapse; font-size: 12px; }
+  th, td { text-align: left; padding: 6px 8px; border-bottom: 1px solid var(--border); }
+  th { color: var(--muted); font-weight: 500; }
+  td.num, th.num { text-align: center; font-variant-numeric: tabular-nums; }
+  .bar { height: 6px; background: var(--accent); border-radius: 3px; }
+  .badge { padding: 2px 6px; border-radius: 3px; font-size: 11px; }
+  .badge.ok { background: rgba(46,160,67,0.18); color: var(--good); }
+  .badge.err { background: rgba(248,81,73,0.18); color: var(--bad); }
+  .badge.warn { background: rgba(210,153,34,0.18); color: var(--warn); }
+  .table-scroll { max-height: 360px; overflow: auto; }
+  .table-scroll thead th { position: sticky; top: 0; background: var(--card-bg); z-index: 1; }
+  .recent td { font-family: var(--vscode-editor-font-family, monospace); font-size: 11px; }
+  .empty { color: var(--muted); padding: 16px; text-align: center; font-size: 12px; }
+  .pill {
+    display: inline-block;
+    padding: 1px 6px;
+    border-radius: 8px;
+    background: rgba(127,127,127,0.18);
+    font-size: 10px;
+    margin-right: 4px;
+  }
+</style>
+</head>
+<body>
+<header>
+  <div>
+    <h1>Agent Maestro Dashboard</h1>
+    <div class="meta" id="meta">Proxy: ${escapeHtml(this.proxyUrl)}</div>
+  </div>
+  <div>
+    <button id="resetBtn">Reset metrics</button>
+  </div>
+</header>
+
+<div class="grid">
+  <div class="card"><div class="label">Active</div><div class="value" id="kpiActive">0</div><div class="sub">in-flight</div></div>
+  <div class="card"><div class="label">Output tokens / sec</div><div class="value" id="kpiTps">—</div><div class="sub">avg (5m)</div></div>
+  <div class="card"><div class="label">TTFT</div><div class="value" id="kpiTtft">—</div><div class="sub">avg (5m)</div></div>
+  <div class="card"><div class="label">Success rate (5m)</div><div class="value" id="kpiSuccess">—</div><div class="sub" id="kpiSuccessSub">rolling window</div></div>
+</div>
+
+<div class="grid">
+  <div class="card"><div class="label">Requests (total)</div><div class="value" id="kpiTotal">0</div></div>
+  <div class="card"><div class="label">Errors (total)</div><div class="value" id="kpiErrors">0</div></div>
+  <div class="card"><div class="label">Input tokens (total)</div><div class="value" id="kpiInput">0</div></div>
+  <div class="card"><div class="label">Output tokens (total)</div><div class="value" id="kpiOutput">0</div></div>
+</div>
+
+<div class="section">
+  <h2>Latency percentiles (5m)</h2>
+  <div class="row">
+    <div class="card">
+      <table>
+        <tr><th>P50</th><td class="num" id="p50">—</td></tr>
+        <tr><th>P95</th><td class="num" id="p95">—</td></tr>
+        <tr><th>P99</th><td class="num" id="p99">—</td></tr>
+      </table>
+    </div>
+    <div class="card">
+      <div class="label" style="color:var(--muted);font-size:11px;text-transform:uppercase;letter-spacing:0.5px;margin-bottom:6px;">Status codes</div>
+      <div id="statusBars"></div>
+    </div>
+  </div>
+</div>
+
+<div class="section">
+  <h2>By endpoint</h2>
+  <div class="card"><table id="endpointTable">
+    <thead><tr><th>Endpoint</th><th class="num">Requests</th><th class="num">Errors</th><th class="num">Input tok</th><th class="num">Output tok</th></tr></thead>
+    <tbody></tbody>
+  </table></div>
+</div>
+
+<div class="section">
+  <h2>By model</h2>
+  <div class="card"><table id="modelTable">
+    <thead><tr><th>Model</th><th class="num">Requests</th><th class="num">Input tok</th><th class="num">Output tok</th></tr></thead>
+    <tbody></tbody>
+  </table></div>
+</div>
+
+<div class="section">
+  <h2>Recent requests</h2>
+  <div class="card table-scroll"><table class="recent" id="recentTable">
+    <thead><tr><th>Time</th><th>Endpoint</th><th>Path</th><th>Status</th><th class="num">Dur ms</th><th class="num">TTFT</th><th class="num">Input</th><th class="num">Output</th><th class="num">out/s</th><th>Model</th></tr></thead>
+    <tbody></tbody>
+  </table></div>
+</div>
+
+<script nonce="${nonce}">
+(function() {
+  const vscode = acquireVsCodeApi();
+
+  function fmt(n) { return n === undefined || n === null ? '—' : Number(n).toLocaleString(); }
+  function fmtCompact(n) {
+    if (n === undefined || n === null) return '—';
+    const value = Number(n);
+    if (value >= 1_000_000_000) return (value / 1_000_000_000).toFixed(1).replace(/\.0$/, '') + 'B';
+    if (value >= 1_000_000) return (value / 1_000_000).toFixed(1).replace(/\.0$/, '') + 'M';
+    if (value >= 1_000) return (value / 1_000).toFixed(1).replace(/\.0$/, '') + 'K';
+    return value.toLocaleString();
+  }
+  function fmtPct(n) { return (n * 100).toFixed(1) + '%'; }
+  function fmtDuration(ms) {
+    if (!ms) return '—';
+    return ms >= 1000 ? (ms / 1000).toFixed(2).replace(/\.00$/, '') + ' s' : Math.round(ms) + ' ms';
+  }
+  function badgeForStatus(s) {
+    if (s >= 500) return 'err';
+    if (s >= 400) return 'warn';
+    if (s >= 200) return 'ok';
+    return '';
+  }
+
+  function render(snap) {
+    document.getElementById('kpiActive').textContent = snap.activeRequests;
+    document.getElementById('kpiTps').textContent = snap.rolling.avgTokensPerSecond ? snap.rolling.avgTokensPerSecond.toFixed(1) : '—';
+    document.getElementById('kpiTtft').textContent = fmtDuration(snap.rolling.avgTtftMs);
+    document.getElementById('kpiSuccess').textContent = snap.rolling.requests ? fmtPct(snap.rolling.successRate) : '—';
+    document.getElementById('kpiSuccessSub').textContent = snap.rolling.requests + ' req / ' + snap.rolling.errors + ' err';
+
+    document.getElementById('kpiTotal').textContent = fmt(snap.totals.requests);
+    document.getElementById('kpiErrors').textContent = fmt(snap.totals.errors);
+    document.getElementById('kpiInput').textContent = fmtCompact(snap.totals.inputTokens);
+    document.getElementById('kpiOutput').textContent = fmtCompact(snap.totals.outputTokens);
+
+    document.getElementById('p50').textContent = fmtDuration(snap.rolling.p50DurationMs);
+    document.getElementById('p95').textContent = fmtDuration(snap.rolling.p95DurationMs);
+    document.getElementById('p99').textContent = fmtDuration(snap.rolling.p99DurationMs);
+
+    const statusEl = document.getElementById('statusBars');
+    const total = Object.values(snap.statusCounts).reduce((a,b)=>a+b,0) || 1;
+    statusEl.innerHTML = Object.entries(snap.statusCounts).sort().map(([k,v]) => {
+      const pct = (v/total)*100;
+      const klass = k.startsWith('2') ? 'ok' : k.startsWith('4') ? 'warn' : k.startsWith('5') ? 'err' : '';
+      return '<div style="margin-bottom:6px"><span class="badge ' + klass + '">' + k + '</span> <span style="color:var(--muted);font-size:11px">' + v + '</span><div class="bar" style="width:' + pct + '%; margin-top:3px; background: ' + (klass==='err'?'var(--bad)':klass==='warn'?'var(--warn)':'var(--good)') + '"></div></div>';
+    }).join('') || '<div class="empty">No data</div>';
+
+    const epBody = document.querySelector('#endpointTable tbody');
+    epBody.innerHTML = Object.entries(snap.byEndpoint)
+      .filter(([_,v]) => v.requests > 0)
+      .map(([k,v]) => '<tr><td>' + k + '</td><td class="num">' + fmt(v.requests) + '</td><td class="num">' + fmt(v.errors) + '</td><td class="num">' + fmtCompact(v.inputTokens) + '</td><td class="num">' + fmtCompact(v.outputTokens) + '</td></tr>')
+      .join('') || '<tr><td colspan="5" class="empty">No requests yet</td></tr>';
+
+    const modelBody = document.querySelector('#modelTable tbody');
+    const modelEntries = Object.entries(snap.byModel).sort((a,b)=>b[1].requests - a[1].requests);
+    modelBody.innerHTML = modelEntries.length
+      ? modelEntries.map(([k,v]) => '<tr><td>' + escapeHtml(k) + '</td><td class="num">' + fmt(v.requests) + '</td><td class="num">' + fmtCompact(v.inputTokens) + '</td><td class="num">' + fmtCompact(v.outputTokens) + '</td></tr>').join('')
+      : '<tr><td colspan="4" class="empty">No model usage tracked</td></tr>';
+
+    const recentBody = document.querySelector('#recentTable tbody');
+    const rows = snap.recent.slice().reverse().slice(0, 50);
+    recentBody.innerHTML = rows.length
+      ? rows.map(r => {
+          const t = new Date(r.startedAt).toLocaleTimeString();
+          const badge = badgeForStatus(r.status);
+          return '<tr>' +
+            '<td>' + t + '</td>' +
+            '<td>' + r.endpoint + (r.streaming ? ' <span class="pill">stream</span>' : '') + '</td>' +
+            '<td>' + escapeHtml(r.path) + '</td>' +
+            '<td><span class="badge ' + badge + '">' + r.status + '</span></td>' +
+            '<td class="num">' + fmtDuration(r.durationMs) + '</td>' +
+            '<td class="num">' + (r.ttftMs ? fmtDuration(r.ttftMs) : '—') + '</td>' +
+            '<td class="num">' + (r.inputTokens ? fmtCompact(r.inputTokens) : '—') + '</td>' +
+            '<td class="num">' + (r.outputTokens ? fmtCompact(r.outputTokens) : '—') + '</td>' +
+            '<td class="num">' + (r.tokensPerSecond ? r.tokensPerSecond.toFixed(1) : '—') + '</td>' +
+            '<td>' + (r.model ? escapeHtml(r.model) : '—') + '</td>' +
+          '</tr>';
+        }).join('')
+      : '<tr><td colspan="10" class="empty">No requests yet — send a request to your proxy</td></tr>';
+  }
+
+  function escapeHtml(s) {
+    return String(s).replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+  }
+
+  window.addEventListener('message', (event) => {
+    const msg = event.data;
+    if (msg.type === 'snapshot') render(msg.snapshot);
+  });
+
+  document.getElementById('resetBtn').addEventListener('click', () => {
+    vscode.postMessage({ type: 'reset' });
+  });
+
+  vscode.postMessage({ type: 'ready' });
+})();
+</script>
+</body>
+</html>`;
+  }
+}
+
+function getNonce(): string {
+  let text = "";
+  const chars =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  for (let i = 0; i < 32; i++) {
+    text += chars.charAt(Math.floor(Math.random() * chars.length));
+  }
+  return text;
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/[&<>"']/g, (c) => {
+    switch (c) {
+      case "&":
+        return "&amp;";
+      case "<":
+        return "&lt;";
+      case ">":
+        return "&gt;";
+      case '"':
+        return "&quot;";
+      default:
+        return "&#39;";
+    }
+  });
+}

--- a/src/dashboard/DashboardPanel.ts
+++ b/src/dashboard/DashboardPanel.ts
@@ -176,6 +176,22 @@ export class DashboardPanel {
     font-size: 10px;
     margin-right: 4px;
   }
+  .recent tr.request-row { cursor: pointer; }
+  .recent tr.request-row:hover { background: rgba(127,127,127,0.08); }
+  .detail-row pre {
+    white-space: pre-wrap;
+    word-break: break-word;
+    margin: 0;
+    font-family: var(--vscode-editor-font-family, monospace);
+    font-size: 11px;
+    color: var(--fg);
+  }
+  .detail-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 10px;
+  }
+  .detail-title { color: var(--muted); font-size: 10px; text-transform: uppercase; margin-bottom: 4px; }
 </style>
 </head>
 <body>
@@ -201,6 +217,13 @@ export class DashboardPanel {
   <div class="card"><div class="label">Errors (total)</div><div class="value" id="kpiErrors">0</div></div>
   <div class="card"><div class="label">Input tokens (total)</div><div class="value" id="kpiInput">0</div></div>
   <div class="card"><div class="label">Output tokens (total)</div><div class="value" id="kpiOutput">0</div></div>
+</div>
+
+<div class="grid">
+  <div class="card"><div class="label">Cache read tokens</div><div class="value" id="kpiCacheRead">0</div></div>
+  <div class="card"><div class="label">Cache creation tokens</div><div class="value" id="kpiCacheCreate">0</div></div>
+  <div class="card"><div class="label">Cache hit rate</div><div class="value" id="kpiCacheHit">—</div><div class="sub">read / input</div></div>
+  <div class="card"><div class="label">Detail capture</div><div class="value">Safe</div><div class="sub">headers only, no bodies</div></div>
 </div>
 
 <div class="section">
@@ -280,6 +303,9 @@ export class DashboardPanel {
     document.getElementById('kpiErrors').textContent = fmt(snap.totals.errors);
     document.getElementById('kpiInput').textContent = fmtCompact(snap.totals.inputTokens);
     document.getElementById('kpiOutput').textContent = fmtCompact(snap.totals.outputTokens);
+    document.getElementById('kpiCacheRead').textContent = fmtCompact(snap.totals.cacheReadInputTokens);
+    document.getElementById('kpiCacheCreate').textContent = fmtCompact(snap.totals.cacheCreationInputTokens);
+    document.getElementById('kpiCacheHit').textContent = snap.totals.inputTokens ? fmtPct(snap.totals.cacheReadInputTokens / snap.totals.inputTokens) : '—';
 
     document.getElementById('p50').textContent = fmtDuration(snap.rolling.p50DurationMs);
     document.getElementById('p95').textContent = fmtDuration(snap.rolling.p95DurationMs);
@@ -308,23 +334,49 @@ export class DashboardPanel {
     const recentBody = document.querySelector('#recentTable tbody');
     const rows = snap.recent.slice().reverse().slice(0, 50);
     recentBody.innerHTML = rows.length
-      ? rows.map(r => {
-          const t = new Date(r.startedAt).toLocaleTimeString();
-          const badge = badgeForStatus(r.status);
-          return '<tr>' +
-            '<td>' + t + '</td>' +
-            '<td>' + r.endpoint + (r.streaming ? ' <span class="pill">stream</span>' : '') + '</td>' +
-            '<td>' + escapeHtml(r.path) + '</td>' +
-            '<td><span class="badge ' + badge + '">' + r.status + '</span></td>' +
-            '<td class="num">' + fmtDuration(r.durationMs) + '</td>' +
-            '<td class="num">' + (r.ttftMs ? fmtDuration(r.ttftMs) : '—') + '</td>' +
-            '<td class="num">' + (r.inputTokens ? fmtCompact(r.inputTokens) : '—') + '</td>' +
-            '<td class="num">' + (r.outputTokens ? fmtCompact(r.outputTokens) : '—') + '</td>' +
-            '<td class="num">' + (r.tokensPerSecond ? r.tokensPerSecond.toFixed(1) : '—') + '</td>' +
-            '<td>' + (r.model ? escapeHtml(r.model) : '—') + '</td>' +
-          '</tr>';
-        }).join('')
+      ? rows.map(r => renderRequestRow(r)).join('')
       : '<tr><td colspan="10" class="empty">No requests yet — send a request to your proxy</td></tr>';
+  }
+
+  function renderRequestRow(r) {
+    const startedAtTime = new Date(r.startedAt).toLocaleTimeString();
+    const badge = badgeForStatus(r.status);
+    const cacheRead = r.details?.cacheReadInputTokens ?? 0;
+    const cacheCreate = r.details?.cacheCreationInputTokens ?? 0;
+    const detail = {
+      id: r.id,
+      method: r.method,
+      path: r.path,
+      endpoint: r.endpoint,
+      status: r.status,
+      duration: fmtDuration(r.durationMs),
+      ttft: r.ttftMs ? fmtDuration(r.ttftMs) : null,
+      model: r.model ?? null,
+      streaming: r.streaming,
+      inputTokens: r.inputTokens ?? null,
+      outputTokens: r.outputTokens ?? null,
+      cacheReadInputTokens: cacheRead,
+      cacheCreationInputTokens: cacheCreate,
+      cacheHitRate: r.inputTokens ? fmtPct(cacheRead / r.inputTokens) : null,
+      error: r.error ?? null,
+      requestHeaders: r.details?.requestHeaders ?? {},
+      responseHeaders: r.details?.responseHeaders ?? {},
+    };
+    return '<tr class="request-row" data-request-id="' + escapeHtml(r.id) + '">' +
+      '<td>' + startedAtTime + '</td>' +
+      '<td>' + r.endpoint + (r.streaming ? ' <span class="pill">stream</span>' : '') + '</td>' +
+      '<td>' + escapeHtml(r.path) + '</td>' +
+      '<td><span class="badge ' + badge + '">' + r.status + '</span></td>' +
+      '<td class="num">' + fmtDuration(r.durationMs) + '</td>' +
+      '<td class="num">' + (r.ttftMs ? fmtDuration(r.ttftMs) : '—') + '</td>' +
+      '<td class="num">' + (r.inputTokens ? fmtCompact(r.inputTokens) : '—') + '</td>' +
+      '<td class="num">' + (r.outputTokens ? fmtCompact(r.outputTokens) : '—') + '</td>' +
+      '<td class="num">' + (r.tokensPerSecond ? r.tokensPerSecond.toFixed(1) : '—') + '</td>' +
+      '<td>' + (r.model ? escapeHtml(r.model) : '—') + '</td>' +
+    '</tr><tr class="detail-row" data-detail-for="' + escapeHtml(r.id) + '" hidden><td colspan="10"><div class="detail-grid">' +
+      '<div><div class="detail-title">Summary</div><pre>' + escapeHtml(JSON.stringify(detail, null, 2)) + '</pre></div>' +
+      '<div><div class="detail-title">Safe headers</div><pre>' + escapeHtml(JSON.stringify({ request: detail.requestHeaders, response: detail.responseHeaders }, null, 2)) + '</pre></div>' +
+    '</div></td></tr>';
   }
 
   function escapeHtml(s) {
@@ -334,6 +386,13 @@ export class DashboardPanel {
   window.addEventListener('message', (event) => {
     const msg = event.data;
     if (msg.type === 'snapshot') render(msg.snapshot);
+  });
+
+  document.getElementById('recentTable').addEventListener('click', (event) => {
+    const row = event.target.closest('.request-row');
+    if (!row) return;
+    const detail = document.querySelector('[data-detail-for="' + row.dataset.requestId + '"]');
+    if (detail) detail.hidden = !detail.hidden;
   });
 
   document.getElementById('resetBtn').addEventListener('click', () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,7 @@ import { registerAllCommands } from "./commands";
 import { ExtensionController } from "./core/controller";
 import { McpServer } from "./server/McpServer";
 import { ProxyServer } from "./server/ProxyServer";
+import { metricsCollector } from "./server/metrics/MetricsCollector";
 import { chatModelsCache } from "./utils/chatModels";
 import { performClaudeCodeSelfCheck } from "./utils/claude";
 import { readConfiguration } from "./utils/config";
@@ -45,6 +46,11 @@ export async function activate(context: vscode.ExtensionContext) {
 
   // Get configuration
   const config = readConfiguration();
+
+  const dashboardMaxRecords = vscode.workspace
+    .getConfiguration()
+    .get<number>("agent-maestro.dashboard.maxRecords", 500);
+  metricsCollector.setMaxRecords(dashboardMaxRecords);
 
   mcpServer = new McpServer({
     controller,

--- a/src/server/ProxyServer.ts
+++ b/src/server/ProxyServer.ts
@@ -18,6 +18,7 @@ import {
   createGeminiAuthMiddleware,
   createOpenAIAuthMiddleware,
 } from "./middleware/authMiddleware";
+import { metricsMiddleware } from "./middleware/metricsMiddleware";
 import { registerAnthropicRoutes } from "./routes/anthropicRoutes";
 import { registerClineRoutes } from "./routes/clineRoutes";
 import { registerFsRoutes } from "./routes/fsRoutes";
@@ -55,6 +56,11 @@ export class ProxyServer {
       logger.debug(`Incoming request: ${c.req.method} ${c.req.url}`);
       await next();
     });
+
+    // Metrics collection for proxy API endpoints
+    this.app.use("/api/anthropic/*", metricsMiddleware);
+    this.app.use("/api/openai/*", metricsMiddleware);
+    this.app.use("/api/gemini/*", metricsMiddleware);
 
     // Register authentication middleware for API routes
     this.app.use(

--- a/src/server/metrics/MetricsCollector.ts
+++ b/src/server/metrics/MetricsCollector.ts
@@ -1,0 +1,344 @@
+import { EventEmitter } from "events";
+
+export type ApiEndpoint = "anthropic" | "openai" | "gemini" | "other";
+
+export interface RequestRecord {
+  id: string;
+  endpoint: ApiEndpoint;
+  method: string;
+  path: string;
+  model?: string;
+  status: number;
+  startedAt: number;
+  durationMs: number;
+  ttftMs?: number;
+  inputTokens?: number;
+  outputTokens?: number;
+  tokensPerSecond?: number;
+  streaming: boolean;
+  error?: string;
+}
+
+export interface MetricsSnapshot {
+  recent: RequestRecord[];
+  totals: {
+    requests: number;
+    errors: number;
+    inputTokens: number;
+    outputTokens: number;
+  };
+  rolling: {
+    windowMs: number;
+    requests: number;
+    errors: number;
+    successRate: number;
+    avgTtftMs: number;
+    avgTokensPerSecond: number;
+    p50DurationMs: number;
+    p95DurationMs: number;
+    p99DurationMs: number;
+  };
+  byEndpoint: Record<
+    ApiEndpoint,
+    {
+      requests: number;
+      errors: number;
+      inputTokens: number;
+      outputTokens: number;
+    }
+  >;
+  byModel: Record<
+    string,
+    {
+      requests: number;
+      inputTokens: number;
+      outputTokens: number;
+    }
+  >;
+  statusCounts: Record<string, number>;
+  activeRequests: number;
+}
+
+const DEFAULT_MAX_RECORDS = 500;
+const ROLLING_WINDOW_MS = 5 * 60_000;
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) {
+    return 0;
+  }
+  const idx = Math.min(
+    sorted.length - 1,
+    Math.floor((p / 100) * sorted.length),
+  );
+  return sorted[idx];
+}
+
+function emptyEndpointAgg() {
+  return { requests: 0, errors: 0, inputTokens: 0, outputTokens: 0 };
+}
+
+export class MetricsCollector extends EventEmitter {
+  private buffer: RequestRecord[] = [];
+  private maxRecords: number;
+  private activeIds = new Set<string>();
+  private totals = {
+    requests: 0,
+    errors: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+  };
+  private byEndpoint: Record<ApiEndpoint, ReturnType<typeof emptyEndpointAgg>> =
+    {
+      anthropic: emptyEndpointAgg(),
+      openai: emptyEndpointAgg(),
+      gemini: emptyEndpointAgg(),
+      other: emptyEndpointAgg(),
+    };
+  private byModel = new Map<
+    string,
+    { requests: number; inputTokens: number; outputTokens: number }
+  >();
+  private statusCounts = new Map<string, number>();
+  private pendingTokenInfo = new Map<
+    string,
+    {
+      inputTokens?: number;
+      outputTokens?: number;
+      ttftMs?: number;
+      model?: string;
+    }
+  >();
+
+  constructor(maxRecords: number = DEFAULT_MAX_RECORDS) {
+    super();
+    this.maxRecords = Math.max(50, maxRecords);
+  }
+
+  setMaxRecords(n: number) {
+    this.maxRecords = Math.max(50, n);
+    while (this.buffer.length > this.maxRecords) {
+      this.buffer.shift();
+    }
+  }
+
+  beginRequest(): { id: string; startedAt: number } {
+    const id = Date.now().toString(36) + Math.random().toString(36).slice(2, 8);
+    this.activeIds.add(id);
+    this.emit("active", this.activeIds.size);
+    return { id, startedAt: Date.now() };
+  }
+
+  endRequest(record: Omit<RequestRecord, "id"> & { id: string }) {
+    if (!this.activeIds.delete(record.id)) {
+      return;
+    }
+    this.emit("active", this.activeIds.size);
+
+    const pendingInfo = this.pendingTokenInfo.get(record.id);
+    if (pendingInfo) {
+      record.inputTokens = pendingInfo.inputTokens ?? record.inputTokens;
+      record.outputTokens = pendingInfo.outputTokens ?? record.outputTokens;
+      record.ttftMs = pendingInfo.ttftMs ?? record.ttftMs;
+      record.model = pendingInfo.model ?? record.model;
+      this.pendingTokenInfo.delete(record.id);
+    }
+
+    if (
+      record.tokensPerSecond === undefined &&
+      record.outputTokens &&
+      record.durationMs > 0
+    ) {
+      record.tokensPerSecond = +(
+        (record.outputTokens / record.durationMs) *
+        1000
+      ).toFixed(2);
+    }
+
+    this.buffer.push(record);
+    if (this.buffer.length > this.maxRecords) {
+      this.buffer.shift();
+    }
+
+    this.totals.requests++;
+    if (record.status >= 400) {
+      this.totals.errors++;
+    }
+    if (record.inputTokens) {
+      this.totals.inputTokens += record.inputTokens;
+    }
+    if (record.outputTokens) {
+      this.totals.outputTokens += record.outputTokens;
+    }
+
+    const ep = this.byEndpoint[record.endpoint];
+    ep.requests++;
+    if (record.status >= 400) {
+      ep.errors++;
+    }
+    if (record.inputTokens) {
+      ep.inputTokens += record.inputTokens;
+    }
+    if (record.outputTokens) {
+      ep.outputTokens += record.outputTokens;
+    }
+
+    if (record.model) {
+      const m = this.byModel.get(record.model) ?? {
+        requests: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+      };
+      m.requests++;
+      if (record.inputTokens) {
+        m.inputTokens += record.inputTokens;
+      }
+      if (record.outputTokens) {
+        m.outputTokens += record.outputTokens;
+      }
+      this.byModel.set(record.model, m);
+    }
+
+    const sc = `${Math.floor(record.status / 100)}xx`;
+    this.statusCounts.set(sc, (this.statusCounts.get(sc) ?? 0) + 1);
+
+    this.emit("request", record);
+  }
+
+  /**
+   * Attach token usage info to the most recent record matching the given id.
+   * Routes call this once they know final token counts (e.g. after stream end).
+   */
+  attachTokens(
+    id: string,
+    info: {
+      inputTokens?: number;
+      outputTokens?: number;
+      ttftMs?: number;
+      model?: string;
+    },
+  ) {
+    const rec = this.buffer.find((r) => r.id === id);
+    if (!rec) {
+      this.pendingTokenInfo.set(id, info);
+      return;
+    }
+    if (info.inputTokens !== undefined) {
+      const delta = info.inputTokens - (rec.inputTokens ?? 0);
+      rec.inputTokens = info.inputTokens;
+      this.totals.inputTokens += delta;
+      this.byEndpoint[rec.endpoint].inputTokens += delta;
+      if (rec.model) {
+        const m = this.byModel.get(rec.model);
+        if (m) {
+          m.inputTokens += delta;
+        }
+      }
+    }
+    if (info.outputTokens !== undefined) {
+      const delta = info.outputTokens - (rec.outputTokens ?? 0);
+      rec.outputTokens = info.outputTokens;
+      this.totals.outputTokens += delta;
+      this.byEndpoint[rec.endpoint].outputTokens += delta;
+      if (rec.model) {
+        const m = this.byModel.get(rec.model);
+        if (m) {
+          m.outputTokens += delta;
+        }
+      }
+    }
+    if (info.ttftMs !== undefined) {
+      rec.ttftMs = info.ttftMs;
+    }
+    if (info.model && !rec.model) {
+      rec.model = info.model;
+      const m = this.byModel.get(info.model) ?? {
+        requests: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+      };
+      m.requests++;
+      m.inputTokens += rec.inputTokens ?? 0;
+      m.outputTokens += rec.outputTokens ?? 0;
+      this.byModel.set(info.model, m);
+    }
+    if (rec.outputTokens && rec.durationMs > 0) {
+      rec.tokensPerSecond = +(
+        (rec.outputTokens / rec.durationMs) *
+        1000
+      ).toFixed(2);
+    }
+    this.emit("update", rec);
+  }
+
+  snapshot(): MetricsSnapshot {
+    const now = Date.now();
+    const recentWindow = this.buffer.filter(
+      (r) => now - (r.startedAt + r.durationMs) <= ROLLING_WINDOW_MS,
+    );
+    const durations = recentWindow
+      .map((r) => r.durationMs)
+      .sort((a, b) => a - b);
+    const ttfts = recentWindow
+      .map((r) => r.ttftMs)
+      .filter((v): v is number => typeof v === "number");
+    const tps = recentWindow
+      .map((r) => r.tokensPerSecond)
+      .filter((v): v is number => typeof v === "number" && v > 0);
+    const errors = recentWindow.filter((r) => r.status >= 400).length;
+
+    return {
+      recent: this.buffer.slice(-100),
+      totals: { ...this.totals },
+      rolling: {
+        windowMs: ROLLING_WINDOW_MS,
+        requests: recentWindow.length,
+        errors,
+        successRate:
+          recentWindow.length === 0 ? 1 : 1 - errors / recentWindow.length,
+        avgTtftMs:
+          ttfts.length === 0
+            ? 0
+            : +(ttfts.reduce((a, b) => a + b, 0) / ttfts.length).toFixed(1),
+        avgTokensPerSecond:
+          tps.length === 0
+            ? 0
+            : +(tps.reduce((a, b) => a + b, 0) / tps.length).toFixed(2),
+        p50DurationMs: percentile(durations, 50),
+        p95DurationMs: percentile(durations, 95),
+        p99DurationMs: percentile(durations, 99),
+      },
+      byEndpoint: {
+        anthropic: { ...this.byEndpoint.anthropic },
+        openai: { ...this.byEndpoint.openai },
+        gemini: { ...this.byEndpoint.gemini },
+        other: { ...this.byEndpoint.other },
+      },
+      byModel: Object.fromEntries(this.byModel.entries()),
+      statusCounts: Object.fromEntries(this.statusCounts.entries()),
+      activeRequests: this.activeIds.size,
+    };
+  }
+
+  reset() {
+    this.buffer = [];
+    this.activeIds.clear();
+    this.totals = {
+      requests: 0,
+      errors: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+    };
+    this.byEndpoint = {
+      anthropic: emptyEndpointAgg(),
+      openai: emptyEndpointAgg(),
+      gemini: emptyEndpointAgg(),
+      other: emptyEndpointAgg(),
+    };
+    this.byModel.clear();
+    this.statusCounts.clear();
+    this.pendingTokenInfo.clear();
+    this.emit("reset");
+  }
+}
+
+export const metricsCollector = new MetricsCollector();

--- a/src/server/metrics/MetricsCollector.ts
+++ b/src/server/metrics/MetricsCollector.ts
@@ -2,6 +2,13 @@ import { EventEmitter } from "events";
 
 export type ApiEndpoint = "anthropic" | "openai" | "gemini" | "other";
 
+export interface RequestDetails {
+  requestHeaders?: Record<string, string>;
+  responseHeaders?: Record<string, string>;
+  cacheCreationInputTokens?: number;
+  cacheReadInputTokens?: number;
+}
+
 export interface RequestRecord {
   id: string;
   endpoint: ApiEndpoint;
@@ -17,6 +24,7 @@ export interface RequestRecord {
   tokensPerSecond?: number;
   streaming: boolean;
   error?: string;
+  details?: RequestDetails;
 }
 
 export interface MetricsSnapshot {
@@ -26,6 +34,8 @@ export interface MetricsSnapshot {
     errors: number;
     inputTokens: number;
     outputTokens: number;
+    cacheCreationInputTokens: number;
+    cacheReadInputTokens: number;
   };
   rolling: {
     windowMs: number;
@@ -62,6 +72,15 @@ export interface MetricsSnapshot {
 const DEFAULT_MAX_RECORDS = 500;
 const ROLLING_WINDOW_MS = 5 * 60_000;
 
+type TokenInfo = {
+  inputTokens?: number;
+  outputTokens?: number;
+  ttftMs?: number;
+  model?: string;
+  cacheCreationInputTokens?: number;
+  cacheReadInputTokens?: number;
+};
+
 function percentile(sorted: number[], p: number): number {
   if (sorted.length === 0) {
     return 0;
@@ -86,6 +105,8 @@ export class MetricsCollector extends EventEmitter {
     errors: 0,
     inputTokens: 0,
     outputTokens: 0,
+    cacheCreationInputTokens: 0,
+    cacheReadInputTokens: 0,
   };
   private byEndpoint: Record<ApiEndpoint, ReturnType<typeof emptyEndpointAgg>> =
     {
@@ -99,15 +120,7 @@ export class MetricsCollector extends EventEmitter {
     { requests: number; inputTokens: number; outputTokens: number }
   >();
   private statusCounts = new Map<string, number>();
-  private pendingTokenInfo = new Map<
-    string,
-    {
-      inputTokens?: number;
-      outputTokens?: number;
-      ttftMs?: number;
-      model?: string;
-    }
-  >();
+  private pendingTokenInfo = new Map<string, TokenInfo>();
 
   constructor(maxRecords: number = DEFAULT_MAX_RECORDS) {
     super();
@@ -140,6 +153,15 @@ export class MetricsCollector extends EventEmitter {
       record.outputTokens = pendingInfo.outputTokens ?? record.outputTokens;
       record.ttftMs = pendingInfo.ttftMs ?? record.ttftMs;
       record.model = pendingInfo.model ?? record.model;
+      record.details = {
+        ...record.details,
+        cacheCreationInputTokens:
+          pendingInfo.cacheCreationInputTokens ??
+          record.details?.cacheCreationInputTokens,
+        cacheReadInputTokens:
+          pendingInfo.cacheReadInputTokens ??
+          record.details?.cacheReadInputTokens,
+      };
       this.pendingTokenInfo.delete(record.id);
     }
 
@@ -168,6 +190,13 @@ export class MetricsCollector extends EventEmitter {
     }
     if (record.outputTokens) {
       this.totals.outputTokens += record.outputTokens;
+    }
+    if (record.details?.cacheCreationInputTokens) {
+      this.totals.cacheCreationInputTokens +=
+        record.details.cacheCreationInputTokens;
+    }
+    if (record.details?.cacheReadInputTokens) {
+      this.totals.cacheReadInputTokens += record.details.cacheReadInputTokens;
     }
 
     const ep = this.byEndpoint[record.endpoint];
@@ -208,15 +237,7 @@ export class MetricsCollector extends EventEmitter {
    * Attach token usage info to the most recent record matching the given id.
    * Routes call this once they know final token counts (e.g. after stream end).
    */
-  attachTokens(
-    id: string,
-    info: {
-      inputTokens?: number;
-      outputTokens?: number;
-      ttftMs?: number;
-      model?: string;
-    },
-  ) {
+  attachTokens(id: string, info: TokenInfo) {
     const rec = this.buffer.find((r) => r.id === id);
     if (!rec) {
       this.pendingTokenInfo.set(id, info);
@@ -248,6 +269,25 @@ export class MetricsCollector extends EventEmitter {
     }
     if (info.ttftMs !== undefined) {
       rec.ttftMs = info.ttftMs;
+    }
+    if (info.cacheCreationInputTokens !== undefined) {
+      const delta =
+        info.cacheCreationInputTokens -
+        (rec.details?.cacheCreationInputTokens ?? 0);
+      rec.details = {
+        ...rec.details,
+        cacheCreationInputTokens: info.cacheCreationInputTokens,
+      };
+      this.totals.cacheCreationInputTokens += delta;
+    }
+    if (info.cacheReadInputTokens !== undefined) {
+      const delta =
+        info.cacheReadInputTokens - (rec.details?.cacheReadInputTokens ?? 0);
+      rec.details = {
+        ...rec.details,
+        cacheReadInputTokens: info.cacheReadInputTokens,
+      };
+      this.totals.cacheReadInputTokens += delta;
     }
     if (info.model && !rec.model) {
       rec.model = info.model;
@@ -327,6 +367,8 @@ export class MetricsCollector extends EventEmitter {
       errors: 0,
       inputTokens: 0,
       outputTokens: 0,
+      cacheCreationInputTokens: 0,
+      cacheReadInputTokens: 0,
     };
     this.byEndpoint = {
       anthropic: emptyEndpointAgg(),

--- a/src/server/metrics/MetricsCollector.ts
+++ b/src/server/metrics/MetricsCollector.ts
@@ -5,8 +5,6 @@ export type ApiEndpoint = "anthropic" | "openai" | "gemini" | "other";
 export interface RequestDetails {
   requestHeaders?: Record<string, string>;
   responseHeaders?: Record<string, string>;
-  cacheCreationInputTokens?: number;
-  cacheReadInputTokens?: number;
 }
 
 export interface RequestRecord {
@@ -34,8 +32,6 @@ export interface MetricsSnapshot {
     errors: number;
     inputTokens: number;
     outputTokens: number;
-    cacheCreationInputTokens: number;
-    cacheReadInputTokens: number;
   };
   rolling: {
     windowMs: number;
@@ -77,8 +73,6 @@ type TokenInfo = {
   outputTokens?: number;
   ttftMs?: number;
   model?: string;
-  cacheCreationInputTokens?: number;
-  cacheReadInputTokens?: number;
 };
 
 function percentile(sorted: number[], p: number): number {
@@ -105,8 +99,6 @@ export class MetricsCollector extends EventEmitter {
     errors: 0,
     inputTokens: 0,
     outputTokens: 0,
-    cacheCreationInputTokens: 0,
-    cacheReadInputTokens: 0,
   };
   private byEndpoint: Record<ApiEndpoint, ReturnType<typeof emptyEndpointAgg>> =
     {
@@ -153,15 +145,6 @@ export class MetricsCollector extends EventEmitter {
       record.outputTokens = pendingInfo.outputTokens ?? record.outputTokens;
       record.ttftMs = pendingInfo.ttftMs ?? record.ttftMs;
       record.model = pendingInfo.model ?? record.model;
-      record.details = {
-        ...record.details,
-        cacheCreationInputTokens:
-          pendingInfo.cacheCreationInputTokens ??
-          record.details?.cacheCreationInputTokens,
-        cacheReadInputTokens:
-          pendingInfo.cacheReadInputTokens ??
-          record.details?.cacheReadInputTokens,
-      };
       this.pendingTokenInfo.delete(record.id);
     }
 
@@ -190,13 +173,6 @@ export class MetricsCollector extends EventEmitter {
     }
     if (record.outputTokens) {
       this.totals.outputTokens += record.outputTokens;
-    }
-    if (record.details?.cacheCreationInputTokens) {
-      this.totals.cacheCreationInputTokens +=
-        record.details.cacheCreationInputTokens;
-    }
-    if (record.details?.cacheReadInputTokens) {
-      this.totals.cacheReadInputTokens += record.details.cacheReadInputTokens;
     }
 
     const ep = this.byEndpoint[record.endpoint];
@@ -269,25 +245,6 @@ export class MetricsCollector extends EventEmitter {
     }
     if (info.ttftMs !== undefined) {
       rec.ttftMs = info.ttftMs;
-    }
-    if (info.cacheCreationInputTokens !== undefined) {
-      const delta =
-        info.cacheCreationInputTokens -
-        (rec.details?.cacheCreationInputTokens ?? 0);
-      rec.details = {
-        ...rec.details,
-        cacheCreationInputTokens: info.cacheCreationInputTokens,
-      };
-      this.totals.cacheCreationInputTokens += delta;
-    }
-    if (info.cacheReadInputTokens !== undefined) {
-      const delta =
-        info.cacheReadInputTokens - (rec.details?.cacheReadInputTokens ?? 0);
-      rec.details = {
-        ...rec.details,
-        cacheReadInputTokens: info.cacheReadInputTokens,
-      };
-      this.totals.cacheReadInputTokens += delta;
     }
     if (info.model && !rec.model) {
       rec.model = info.model;
@@ -367,8 +324,6 @@ export class MetricsCollector extends EventEmitter {
       errors: 0,
       inputTokens: 0,
       outputTokens: 0,
-      cacheCreationInputTokens: 0,
-      cacheReadInputTokens: 0,
     };
     this.byEndpoint = {
       anthropic: emptyEndpointAgg(),

--- a/src/server/middleware/metricsMiddleware.ts
+++ b/src/server/middleware/metricsMiddleware.ts
@@ -1,0 +1,134 @@
+import type { Context, MiddlewareHandler } from "hono";
+
+import { ApiEndpoint, metricsCollector } from "../metrics/MetricsCollector";
+
+declare module "hono" {
+  interface ContextVariableMap {
+    metricsRequestId?: string;
+    metricsStartedAt?: number;
+    metricsEndpoint?: ApiEndpoint;
+    metricsPath?: string;
+    metricsMethod?: string;
+    metricsDeferEnd?: boolean;
+  }
+}
+
+function detectEndpoint(path: string): ApiEndpoint {
+  if (path.startsWith("/api/anthropic")) {
+    return "anthropic";
+  }
+  if (path.startsWith("/api/openai")) {
+    return "openai";
+  }
+  if (path.startsWith("/api/gemini")) {
+    return "gemini";
+  }
+  return "other";
+}
+
+export const metricsMiddleware: MiddlewareHandler = async (c, next) => {
+  const path = new URL(c.req.url).pathname;
+  const endpoint = detectEndpoint(path);
+  const { id, startedAt } = metricsCollector.beginRequest();
+  c.set("metricsRequestId", id);
+  c.set("metricsStartedAt", startedAt);
+  c.set("metricsEndpoint", endpoint);
+  c.set("metricsPath", path);
+  c.set("metricsMethod", c.req.method);
+
+  let status = 0;
+  let err: unknown;
+  try {
+    await next();
+    status = c.res.status;
+  } catch (e) {
+    err = e;
+    status = 500;
+    throw e;
+  } finally {
+    if (c.get("metricsDeferEnd")) {
+      return;
+    }
+    finishMetricsRequest(c, {
+      status,
+      streaming: (c.res?.headers.get("content-type") ?? "").includes(
+        "event-stream",
+      ),
+      error: err ? String((err as Error).message ?? err) : undefined,
+    });
+  }
+};
+
+export function keepMetricsActiveUntilStreamEnd(c: Context) {
+  c.set("metricsDeferEnd", true);
+  c.req.raw.signal.addEventListener(
+    "abort",
+    () => {
+      finishMetricsRequest(c, {
+        status: 499,
+        streaming: true,
+        error: "client aborted request",
+      });
+    },
+    { once: true },
+  );
+}
+
+export function finishMetricsRequest(
+  c: Context,
+  info: {
+    status?: number;
+    streaming?: boolean;
+    error?: string;
+    inputTokens?: number;
+    outputTokens?: number;
+    ttftMs?: number;
+    model?: string;
+  } = {},
+) {
+  const id = c.get("metricsRequestId");
+  const startedAt = c.get("metricsStartedAt");
+  const endpoint = c.get("metricsEndpoint");
+  const path = c.get("metricsPath");
+  const method = c.get("metricsMethod");
+
+  if (!id || !startedAt || !endpoint || !path || !method) {
+    return;
+  }
+
+  metricsCollector.endRequest({
+    id,
+    endpoint,
+    method,
+    path,
+    status: info.status ?? c.res.status,
+    startedAt,
+    durationMs: Date.now() - startedAt,
+    streaming: info.streaming ?? false,
+    inputTokens: info.inputTokens,
+    outputTokens: info.outputTokens,
+    ttftMs: info.ttftMs,
+    model: info.model,
+    error: info.error,
+  });
+}
+
+export function recordMetricsTokens(
+  c: Context,
+  info: {
+    inputTokens?: number;
+    outputTokens?: number;
+    ttftMs?: number;
+    model?: string;
+  },
+) {
+  const id = c.get("metricsRequestId");
+  if (!id) {
+    return;
+  }
+  metricsCollector.attachTokens(id, info);
+}
+
+export function getMetricsStartedAt(c: Context): number | undefined {
+  return c.get("metricsStartedAt");
+}

--- a/src/server/middleware/metricsMiddleware.ts
+++ b/src/server/middleware/metricsMiddleware.ts
@@ -35,8 +35,6 @@ type MetricsTokenInfo = {
   outputTokens?: number;
   ttftMs?: number;
   model?: string;
-  cacheCreationInputTokens?: number;
-  cacheReadInputTokens?: number;
 };
 
 function detectEndpoint(path: string): ApiEndpoint {
@@ -153,8 +151,6 @@ export function finishMetricsRequest(
       responseHeaders: c.res
         ? pickHeaders(c.res.headers, SAFE_RESPONSE_HEADERS)
         : undefined,
-      cacheCreationInputTokens: info.cacheCreationInputTokens,
-      cacheReadInputTokens: info.cacheReadInputTokens,
     },
   });
 }

--- a/src/server/middleware/metricsMiddleware.ts
+++ b/src/server/middleware/metricsMiddleware.ts
@@ -10,8 +10,34 @@ declare module "hono" {
     metricsPath?: string;
     metricsMethod?: string;
     metricsDeferEnd?: boolean;
+    metricsRequestHeaders?: Record<string, string>;
   }
 }
+
+const SAFE_REQUEST_HEADERS = new Set([
+  "anthropic-beta",
+  "anthropic-version",
+  "content-type",
+  "user-agent",
+  "x-app",
+  "x-stainless-arch",
+  "x-stainless-lang",
+  "x-stainless-os",
+  "x-stainless-package-version",
+  "x-stainless-runtime",
+  "x-stainless-runtime-version",
+]);
+
+const SAFE_RESPONSE_HEADERS = new Set(["content-type", "content-length"]);
+
+type MetricsTokenInfo = {
+  inputTokens?: number;
+  outputTokens?: number;
+  ttftMs?: number;
+  model?: string;
+  cacheCreationInputTokens?: number;
+  cacheReadInputTokens?: number;
+};
 
 function detectEndpoint(path: string): ApiEndpoint {
   if (path.startsWith("/api/anthropic")) {
@@ -26,6 +52,17 @@ function detectEndpoint(path: string): ApiEndpoint {
   return "other";
 }
 
+function pickHeaders(headers: Headers, allowlist: Set<string>) {
+  const picked: Record<string, string> = {};
+  headers.forEach((value, key) => {
+    const normalized = key.toLowerCase();
+    if (allowlist.has(normalized)) {
+      picked[normalized] = value;
+    }
+  });
+  return picked;
+}
+
 export const metricsMiddleware: MiddlewareHandler = async (c, next) => {
   const path = new URL(c.req.url).pathname;
   const endpoint = detectEndpoint(path);
@@ -35,6 +72,10 @@ export const metricsMiddleware: MiddlewareHandler = async (c, next) => {
   c.set("metricsEndpoint", endpoint);
   c.set("metricsPath", path);
   c.set("metricsMethod", c.req.method);
+  c.set(
+    "metricsRequestHeaders",
+    pickHeaders(c.req.raw.headers, SAFE_REQUEST_HEADERS),
+  );
 
   let status = 0;
   let err: unknown;
@@ -80,17 +121,14 @@ export function finishMetricsRequest(
     status?: number;
     streaming?: boolean;
     error?: string;
-    inputTokens?: number;
-    outputTokens?: number;
-    ttftMs?: number;
-    model?: string;
-  } = {},
+  } & MetricsTokenInfo = {},
 ) {
   const id = c.get("metricsRequestId");
   const startedAt = c.get("metricsStartedAt");
   const endpoint = c.get("metricsEndpoint");
   const path = c.get("metricsPath");
   const method = c.get("metricsMethod");
+  const requestHeaders = c.get("metricsRequestHeaders");
 
   if (!id || !startedAt || !endpoint || !path || !method) {
     return;
@@ -110,18 +148,18 @@ export function finishMetricsRequest(
     ttftMs: info.ttftMs,
     model: info.model,
     error: info.error,
+    details: {
+      requestHeaders,
+      responseHeaders: c.res
+        ? pickHeaders(c.res.headers, SAFE_RESPONSE_HEADERS)
+        : undefined,
+      cacheCreationInputTokens: info.cacheCreationInputTokens,
+      cacheReadInputTokens: info.cacheReadInputTokens,
+    },
   });
 }
 
-export function recordMetricsTokens(
-  c: Context,
-  info: {
-    inputTokens?: number;
-    outputTokens?: number;
-    ttftMs?: number;
-    model?: string;
-  },
-) {
+export function recordMetricsTokens(c: Context, info: MetricsTokenInfo) {
   const id = c.get("metricsRequestId");
   if (!id) {
     return;

--- a/src/server/routes/anthropicRoutes.ts
+++ b/src/server/routes/anthropicRoutes.ts
@@ -367,6 +367,8 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
         recordMetricsTokens(c, {
           inputTokens: inputTokenCount.calibrated,
           outputTokens: outputTokenCount.calibrated,
+          cacheCreationInputTokens: 0,
+          cacheReadInputTokens: 0,
           model: effectiveModelId ?? model,
         });
 
@@ -541,6 +543,8 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
             streaming: true,
             inputTokens: inputTokenCount.calibrated,
             outputTokens: outputTokenCount.calibrated,
+            cacheCreationInputTokens: 0,
+            cacheReadInputTokens: 0,
             ttftMs,
             model: effectiveModelId ?? model,
           });

--- a/src/server/routes/anthropicRoutes.ts
+++ b/src/server/routes/anthropicRoutes.ts
@@ -367,8 +367,6 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
         recordMetricsTokens(c, {
           inputTokens: inputTokenCount.calibrated,
           outputTokens: outputTokenCount.calibrated,
-          cacheCreationInputTokens: 0,
-          cacheReadInputTokens: 0,
           model: effectiveModelId ?? model,
         });
 
@@ -543,8 +541,6 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
             streaming: true,
             inputTokens: inputTokenCount.calibrated,
             outputTokens: outputTokenCount.calibrated,
-            cacheCreationInputTokens: 0,
-            cacheReadInputTokens: 0,
             ttftMs,
             model: effectiveModelId ?? model,
           });

--- a/src/server/routes/anthropicRoutes.ts
+++ b/src/server/routes/anthropicRoutes.ts
@@ -6,6 +6,12 @@ import * as vscode from "vscode";
 
 import { getChatModelClient } from "../../utils/chatModels";
 import { logger } from "../../utils/logger";
+import {
+  finishMetricsRequest,
+  getMetricsStartedAt,
+  keepMetricsActiveUntilStreamEnd,
+  recordMetricsTokens,
+} from "../middleware/metricsMiddleware";
 import { AnthropicErrorResponseSchema } from "../schemas/anthropic";
 import {
   convertAnthropicMessagesToVSCode,
@@ -358,10 +364,17 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
           `← /v1/messages | input: ${inputTokenCount.original} → ${inputTokenCount.calibrated} | output: ${outputTokenCount.original} → ${outputTokenCount.calibrated}`,
         );
 
+        recordMetricsTokens(c, {
+          inputTokens: inputTokenCount.calibrated,
+          outputTokens: outputTokenCount.calibrated,
+          model: effectiveModelId ?? model,
+        });
+
         return c.json(resp);
       }
 
       // 7. If streaming, pipe chunks as SSE
+      keepMetricsActiveUntilStreamEnd(c);
       return streamSSE(
         c,
         async (stream) => {
@@ -398,8 +411,13 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
 
           const contentBlocks: Anthropic.Messages.ContentBlock[] = [];
           let accumulatedText = "";
+          let firstChunkAt: number | undefined;
+          const requestStartedAt = getMetricsStartedAt(c);
 
           for await (const chunk of response.stream) {
+            if (firstChunkAt === undefined) {
+              firstChunkAt = Date.now();
+            }
             const lastBlock = contentBlocks.at(-1);
             if (chunk instanceof vscode.LanguageModelTextPart) {
               // Stop last non-text block if it exists
@@ -513,9 +531,28 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
           logger.info(
             `← /v1/messages (stream) | input: ${inputTokenCount.original} → ${inputTokenCount.calibrated} | output: ${outputTokenCount.original} → ${outputTokenCount.calibrated}`,
           );
+
+          const ttftMs =
+            firstChunkAt !== undefined && requestStartedAt !== undefined
+              ? firstChunkAt - requestStartedAt
+              : undefined;
+          finishMetricsRequest(c, {
+            status: 200,
+            streaming: true,
+            inputTokens: inputTokenCount.calibrated,
+            outputTokens: outputTokenCount.calibrated,
+            ttftMs,
+            model: effectiveModelId ?? model,
+          });
         },
         async (error, _stream) => {
           logger.error("✕ /v1/messages |", error);
+          finishMetricsRequest(c, {
+            status: 500,
+            streaming: true,
+            error: error instanceof Error ? error.message : String(error),
+            model: effectiveModelId ?? model,
+          });
         },
       );
     } catch (error) {


### PR DESCRIPTION
## Summary
- add a VS Code dashboard for live metrics (active requests, rates, latency, endpoint/model tables, recent requests)
- add stream-aware request lifecycle metrics and request detail capture (safe headers only)
- remove unavailable cache-token KPIs/aggregation so dashboard only shows real, populated metrics

## Screenshot
<img width="1667" height="980" alt="image" src="https://github.com/user-attachments/assets/dd9c8742-edf4-4f33-a4ab-d521e45ca28b" />
<img width="1672" height="423" alt="image" src="https://github.com/user-attachments/assets/c81ba2a9-d7b1-47e7-af94-4b8fcc83ab88" />

## Test plan
- [x] pnpm run build
- [x] Open dashboard in VS Code and verify recent request details expand/collapse correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)