### PR TITLE
refactor: share Copilot usage parsing

### DIFF
--- a/.changeset/openai-copilot-usage.md
+++ b/.changeset/openai-copilot-usage.md
@@ -1,5 +1,0 @@
----
-"agent-maestro": patch
----
-
-Use Copilot usage metadata for OpenAI-compatible chat completions and responses when available, including cached input and reasoning token details.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.9.2 - 2026.05.23
+
+- Use Copilot usage metadata for OpenAI-compatible chat completions and responses when available, including cached input and reasoning token details.
+
 ## v2.9.1 - 2026.05.21
 
 - Use Copilot usage metadata from VS Code language model responses to report Anthropic-compatible input, output, and prompt cache token counts, with the previous token estimation path retained for count_tokens and fallback usage. Also raise the minimum VS Code engine to `^1.120.0`.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "agent-maestro",
   "displayName": "Agent Maestro",
   "description": "Turn VS Code into your compliant AI playground! With Agent Maestro, spin up Cline or Roo on demand and plug Claude Code or Codex straight in through an OpenAI/Anthropic-compatible API.",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "icon": "assets/icons/icon.png",
   "publisher": "Joouis",
   "repository": "https://github.com/Joouis/agent-maestro",

--- a/src/server/routes/anthropicRoutes.ts
+++ b/src/server/routes/anthropicRoutes.ts
@@ -15,7 +15,7 @@ import {
   convertAnthropicToolChoiceToVSCode,
   convertAnthropicToolToVSCode,
   countAnthropicMessageTokens,
-  extractAnthropicTokenUsageFromVSCodeChunk,
+  extractAnthropicUsage,
 } from "../utils/anthropic";
 import {
   createAnthropicModelsResponse,
@@ -430,9 +430,7 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
 
               accumulatedText += JSON.stringify(chunk);
             } else if (chunk instanceof vscode.LanguageModelDataPart) {
-              responseUsage =
-                extractAnthropicTokenUsageFromVSCodeChunk(chunk) ??
-                responseUsage;
+              responseUsage = extractAnthropicUsage(chunk) ?? responseUsage;
             }
           }
         } catch (streamError) {
@@ -606,9 +604,7 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
 
                 accumulatedText += JSON.stringify(chunk);
               } else if (chunk instanceof vscode.LanguageModelDataPart) {
-                responseUsage =
-                  extractAnthropicTokenUsageFromVSCodeChunk(chunk) ??
-                  responseUsage;
+                responseUsage = extractAnthropicUsage(chunk) ?? responseUsage;
               }
             }
           } catch (streamError) {

--- a/src/server/routes/anthropicRoutes.ts
+++ b/src/server/routes/anthropicRoutes.ts
@@ -39,11 +39,8 @@ const prepareAnthropicMessages = async ({
     ...convertAnthropicMessagesToVSCode(messages),
   ];
 
-  const cancellationToken = new vscode.CancellationTokenSource().token;
-
   return {
     vsCodeLmMessages,
-    cancellationToken,
   };
 };
 
@@ -322,6 +319,7 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
     let effectiveModelId = "";
     let rawRequestBody;
     let lmChatMessages: vscode.LanguageModelChatMessage[] | undefined;
+    let cancellationTokenSource: vscode.CancellationTokenSource | undefined;
 
     try {
       // Parse request body
@@ -356,11 +354,12 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
       let client = initialClient!;
 
       // 3. Map Anthropic messages to VS Code LM API messages
-      const { vsCodeLmMessages, cancellationToken } =
-        await prepareAnthropicMessages({
-          requestBody: { ...requestBody, model: resolvedModel },
-        });
+      const { vsCodeLmMessages } = await prepareAnthropicMessages({
+        requestBody: { ...requestBody, model: resolvedModel },
+      });
       lmChatMessages = vsCodeLmMessages;
+      cancellationTokenSource = new vscode.CancellationTokenSource();
+      const cancellationToken = cancellationTokenSource.token;
       logger.info(
         `→ /v1/messages | model: ${
           model === effectiveModelId ? model : `${model} → ${effectiveModelId}`
@@ -482,6 +481,7 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
           `← /v1/messages | input: ${usage.input_tokens} | cache_read: ${usage.cache_read_input_tokens} | cache_creation: ${usage.cache_creation_input_tokens} | output: ${usage.output_tokens}`,
         );
 
+        cancellationTokenSource.dispose();
         return c.json(resp);
       }
 
@@ -659,12 +659,15 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
           logger.info(
             `← /v1/messages (stream) | input: ${usage.input_tokens} | cache_read: ${usage.cache_read_input_tokens} | cache_creation: ${usage.cache_creation_input_tokens} | output: ${usage.output_tokens}`,
           );
+          cancellationTokenSource?.dispose();
         },
         async (error, _stream) => {
           logger.error("✕ /v1/messages |", error);
+          cancellationTokenSource?.dispose();
         },
       );
     } catch (error) {
+      cancellationTokenSource?.dispose();
       logger.error("✕ /v1/messages |", error);
 
       const logFilePath = await handleErrorWithLogging({

--- a/src/server/routes/geminiRoutes.ts
+++ b/src/server/routes/geminiRoutes.ts
@@ -30,9 +30,11 @@ import {
 const prepareGeminiRequest = async ({
   requestBody,
   client,
+  cancellationToken,
 }: {
   requestBody: GenerateContentRequest;
   client: vscode.LanguageModelChat;
+  cancellationToken: vscode.CancellationToken;
 }) => {
   logger.debug("Gemini request payload:");
   logger.debug(JSON.stringify(requestBody, null, 2));
@@ -50,7 +52,6 @@ const prepareGeminiRequest = async ({
   // We pass the stringified request body to VSCode's countTokens() API, which is technically
   // a misuse since it's designed for LanguageModelChatMessage objects. However, we intentionally
   // do this to leverage the official tokenizer instead of building our own wheel.
-  const cancellationToken = new vscode.CancellationTokenSource().token;
   const inputTokenCount = await client.countTokens(
     JSON.stringify(requestBody),
     cancellationToken,
@@ -70,7 +71,6 @@ const prepareGeminiRequest = async ({
   return {
     vsCodeLmMessages,
     inputTokenCount,
-    cancellationToken,
     lmRequestOptions,
   };
 };
@@ -294,6 +294,7 @@ export function registerGeminiRoutes(app: OpenAPIHono) {
     let lmChatMessages: vscode.LanguageModelChatMessage[] | undefined;
     let modelId = "";
     let inputTokens = 0;
+    let cancellationTokenSource: vscode.CancellationTokenSource | undefined;
 
     try {
       // Parse request
@@ -319,12 +320,13 @@ export function registerGeminiRoutes(app: OpenAPIHono) {
       }
 
       // 2. Prepare request
-      const {
-        vsCodeLmMessages,
-        inputTokenCount,
-        cancellationToken,
-        lmRequestOptions,
-      } = await prepareGeminiRequest({ requestBody, client });
+      cancellationTokenSource = new vscode.CancellationTokenSource();
+      const { vsCodeLmMessages, inputTokenCount, lmRequestOptions } =
+        await prepareGeminiRequest({
+          requestBody,
+          client,
+          cancellationToken: cancellationTokenSource.token,
+        });
       lmChatMessages = vsCodeLmMessages;
       inputTokens = inputTokenCount;
 
@@ -338,7 +340,7 @@ export function registerGeminiRoutes(app: OpenAPIHono) {
       const response = await client.sendRequest(
         vsCodeLmMessages,
         lmRequestOptions,
-        cancellationToken,
+        cancellationTokenSource.token,
       );
 
       // 4. Process response (always non-streaming for generateContent)
@@ -394,8 +396,10 @@ export function registerGeminiRoutes(app: OpenAPIHono) {
         `← /v1beta/models/${modelWithMethod} | input: ${inputTokenCount} | output: ${outputTokenCount}`,
       );
 
+      cancellationTokenSource.dispose();
       return c.json(geminiResponse, 200);
     } catch (error) {
+      cancellationTokenSource?.dispose();
       logger.error(`✕ /v1beta/models/${modelId}:generateContent |`, error);
 
       const logFilePath = await handleErrorWithLogging({
@@ -430,6 +434,7 @@ export function registerGeminiRoutes(app: OpenAPIHono) {
       let lmChatMessages: vscode.LanguageModelChatMessage[] | undefined;
       let modelId = "";
       let inputTokens = 0;
+      let cancellationTokenSource: vscode.CancellationTokenSource | undefined;
 
       try {
         // Parse request
@@ -456,12 +461,13 @@ export function registerGeminiRoutes(app: OpenAPIHono) {
         }
 
         // 2. Prepare request
-        const {
-          vsCodeLmMessages,
-          inputTokenCount,
-          cancellationToken,
-          lmRequestOptions,
-        } = await prepareGeminiRequest({ requestBody, client });
+        cancellationTokenSource = new vscode.CancellationTokenSource();
+        const { vsCodeLmMessages, inputTokenCount, lmRequestOptions } =
+          await prepareGeminiRequest({
+            requestBody,
+            client,
+            cancellationToken: cancellationTokenSource.token,
+          });
         lmChatMessages = vsCodeLmMessages;
         inputTokens = inputTokenCount;
 
@@ -475,7 +481,7 @@ export function registerGeminiRoutes(app: OpenAPIHono) {
         const response = await client.sendRequest(
           vsCodeLmMessages,
           lmRequestOptions,
-          cancellationToken,
+          cancellationTokenSource.token,
         );
 
         // 4. Always stream the response
@@ -563,12 +569,14 @@ export function registerGeminiRoutes(app: OpenAPIHono) {
             logger.info(
               `← /v1beta/models/${modelWithMethod} (stream) | input: ${inputTokenCount} | output: ${outputTokenCount}`,
             );
+            cancellationTokenSource?.dispose();
           },
           async (error, stream) => {
             logger.error(
               `✕ /v1beta/models/${modelWithMethod} (stream) |`,
               error,
             );
+            cancellationTokenSource?.dispose();
 
             // Send final chunk with error finish reason
             const errorChunk: GenerateContentResponse = {
@@ -601,6 +609,7 @@ export function registerGeminiRoutes(app: OpenAPIHono) {
           },
         );
       } catch (error) {
+        cancellationTokenSource?.dispose();
         logger.error(
           `✕ /v1beta/models/${modelId}:streamGenerateContent |`,
           error,
@@ -636,6 +645,7 @@ export function registerGeminiRoutes(app: OpenAPIHono) {
   // POST /v1beta/models/{model}:countTokens
   app.openapi(countTokensRoute, async (c: Context) => {
     let modelId = "";
+    let cancellationTokenSource: vscode.CancellationTokenSource | undefined;
     try {
       // Parse request
       const { modelWithMethod } = c.req.param();
@@ -659,10 +669,13 @@ export function registerGeminiRoutes(app: OpenAPIHono) {
       }
 
       // 2. Prepare request and get token count
+      cancellationTokenSource = new vscode.CancellationTokenSource();
       const { inputTokenCount } = await prepareGeminiRequest({
         requestBody,
         client,
+        cancellationToken: cancellationTokenSource.token,
       });
+      cancellationTokenSource.dispose();
 
       logger.info(
         `→ /v1beta/models/${modelWithMethod} | model: ${
@@ -678,6 +691,7 @@ export function registerGeminiRoutes(app: OpenAPIHono) {
         200,
       );
     } catch (error) {
+      cancellationTokenSource?.dispose();
       logger.error(`✕ /v1beta/models/${modelId}:countTokens |`, error);
       return c.json(
         {

--- a/src/server/routes/openai/openaiChatRoutes.ts
+++ b/src/server/routes/openai/openaiChatRoutes.ts
@@ -8,7 +8,7 @@ import { getChatModelClient } from "../../../utils/chatModels";
 import { logger } from "../../../utils/logger";
 import { CommonResponseError } from "../../schemas/openai";
 import { handleErrorWithLogging } from "../../utils/errorDiagnostics";
-import { extractOpenAIChatTokenUsageFromVSCodeChunk } from "../../utils/openai";
+import { extractOpenAIChatUsage } from "../../utils/openai";
 import {
   convertOpenAIChatCompletionToolToVSCode,
   convertOpenAIMessagesToVSCode,
@@ -173,9 +173,7 @@ export function registerOpenaiChatRoutes(app: OpenAPIHono) {
               },
             });
           } else if (chunk instanceof vscode.LanguageModelDataPart) {
-            completionUsage =
-              extractOpenAIChatTokenUsageFromVSCodeChunk(chunk) ??
-              completionUsage;
+            completionUsage = extractOpenAIChatUsage(chunk) ?? completionUsage;
           }
           accumulatedText += JSON.stringify(chunk);
         }
@@ -314,8 +312,7 @@ export function registerOpenaiChatRoutes(app: OpenAPIHono) {
               });
             } else if (chunk instanceof vscode.LanguageModelDataPart) {
               completionUsage =
-                extractOpenAIChatTokenUsageFromVSCodeChunk(chunk) ??
-                completionUsage;
+                extractOpenAIChatUsage(chunk) ?? completionUsage;
             }
             accumulatedText += JSON.stringify(chunk);
           }

--- a/src/server/routes/openai/openaiChatRoutes.ts
+++ b/src/server/routes/openai/openaiChatRoutes.ts
@@ -93,6 +93,7 @@ export function registerOpenaiChatRoutes(app: OpenAPIHono) {
     let lmChatMessages: vscode.LanguageModelChatMessage[] | undefined;
     let requestedModelId = "";
     let inputTokens = 0;
+    let cancellationTokenSource: vscode.CancellationTokenSource | undefined;
 
     try {
       // Parse and validate request body
@@ -121,7 +122,8 @@ export function registerOpenaiChatRoutes(app: OpenAPIHono) {
 
       logger.debug("/v1/chat/completions payload:");
       logger.debug(JSON.stringify(requestBody, null, 2));
-      const cancellationToken = new vscode.CancellationTokenSource().token;
+      cancellationTokenSource = new vscode.CancellationTokenSource();
+      const cancellationToken = cancellationTokenSource.token;
 
       logger.info(
         `→ /v1/chat/completions | model: ${
@@ -220,6 +222,7 @@ export function registerOpenaiChatRoutes(app: OpenAPIHono) {
           `← /v1/chat/completions | input: ${completionUsage.prompt_tokens} | cache_read: ${completionUsage.prompt_tokens_details?.cached_tokens ?? 0} | output: ${completionUsage.completion_tokens}`,
         );
 
+        cancellationTokenSource.dispose();
         return c.json(openaiResponse);
       }
 
@@ -365,9 +368,11 @@ export function registerOpenaiChatRoutes(app: OpenAPIHono) {
           logger.info(
             `← /v1/chat/completions (stream) | input: ${completionUsage.prompt_tokens} | cache_read: ${completionUsage.prompt_tokens_details?.cached_tokens ?? 0} | output: ${completionUsage.completion_tokens}`,
           );
+          cancellationTokenSource?.dispose();
         },
         async (error, stream) => {
           logger.error("✕ /v1/chat/completions (stream) |", error);
+          cancellationTokenSource?.dispose();
 
           // Send error chunk to client before closing
           const errorMessage =
@@ -394,6 +399,7 @@ export function registerOpenaiChatRoutes(app: OpenAPIHono) {
         },
       );
     } catch (error) {
+      cancellationTokenSource?.dispose();
       logger.error("✕ /v1/chat/completions |", error);
 
       const logFilePath = await handleErrorWithLogging({

--- a/src/server/routes/openai/openaiResponsesRoutes.ts
+++ b/src/server/routes/openai/openaiResponsesRoutes.ts
@@ -116,6 +116,7 @@ export function registerOpenaiResponsesRoutes(app: OpenAPIHono) {
     let lmChatMessages: vscode.LanguageModelChatMessage[] | undefined;
     let requestedModelId = "";
     let inputTokens = 0;
+    let cancellationTokenSource: vscode.CancellationTokenSource | undefined;
 
     try {
       // 1. Parse request and extract fields
@@ -225,7 +226,7 @@ export function registerOpenaiResponsesRoutes(app: OpenAPIHono) {
 
       logger.debug("/v1/responses payload:");
       logger.debug(JSON.stringify(requestBody, null, 2));
-      const cancellationTokenSource = new vscode.CancellationTokenSource();
+      cancellationTokenSource = new vscode.CancellationTokenSource();
       const cancellationToken = cancellationTokenSource.token;
 
       logger.info(
@@ -546,8 +547,6 @@ export function registerOpenaiResponsesRoutes(app: OpenAPIHono) {
             outputIndex++;
           }
 
-          cancellationTokenSource.dispose();
-
           if (!responseUsage) {
             const [fallbackInputTokens, outputTokens] = await Promise.all([
               client.countTokens(
@@ -584,10 +583,11 @@ export function registerOpenaiResponsesRoutes(app: OpenAPIHono) {
           logger.info(
             `← /v1/responses (stream) | input: ${responseUsage.input_tokens} | cache_read: ${responseUsage.input_tokens_details.cached_tokens} | output: ${responseUsage.output_tokens}`,
           );
+          cancellationTokenSource?.dispose();
         },
         async (error, sseStream) => {
           logger.error("✕ /v1/responses (stream) |", error);
-          cancellationTokenSource.dispose();
+          cancellationTokenSource?.dispose();
 
           const responseId = generateResponseId();
           const createdAt = getCurrentTimestamp();
@@ -617,6 +617,7 @@ export function registerOpenaiResponsesRoutes(app: OpenAPIHono) {
         },
       );
     } catch (error) {
+      cancellationTokenSource?.dispose();
       logger.error("✕ /v1/responses |", error);
 
       const logFilePath = await handleErrorWithLogging({

--- a/src/server/routes/openai/openaiResponsesRoutes.ts
+++ b/src/server/routes/openai/openaiResponsesRoutes.ts
@@ -9,7 +9,7 @@ import { getChatModelClient } from "../../../utils/chatModels";
 import { logger } from "../../../utils/logger";
 import { CommonResponseError } from "../../schemas/openai";
 import { handleErrorWithLogging } from "../../utils/errorDiagnostics";
-import { extractOpenAIResponsesTokenUsageFromVSCodeChunk } from "../../utils/openai";
+import { extractOpenAIResponsesUsage } from "../../utils/openai";
 import {
   OutputItem,
   ToolChoice,
@@ -278,9 +278,7 @@ export function registerOpenaiResponsesRoutes(app: OpenAPIHono) {
               input: chunk.input,
             });
           } else if (chunk instanceof vscode.LanguageModelDataPart) {
-            responseUsage =
-              extractOpenAIResponsesTokenUsageFromVSCodeChunk(chunk) ??
-              responseUsage;
+            responseUsage = extractOpenAIResponsesUsage(chunk) ?? responseUsage;
           }
         }
 
@@ -530,8 +528,7 @@ export function registerOpenaiResponsesRoutes(app: OpenAPIHono) {
               outputIndex++;
             } else if (chunk instanceof vscode.LanguageModelDataPart) {
               responseUsage =
-                extractOpenAIResponsesTokenUsageFromVSCodeChunk(chunk) ??
-                responseUsage;
+                extractOpenAIResponsesUsage(chunk) ?? responseUsage;
             }
           }
 

--- a/src/server/utils/anthropic.ts
+++ b/src/server/utils/anthropic.ts
@@ -2,6 +2,7 @@ import Anthropic from "@anthropic-ai/sdk";
 import * as vscode from "vscode";
 
 import { logger } from "../../utils/logger";
+import { extractCopilotUsagePayload } from "./copilotUsage";
 
 const textBlockParamToVSCodePart = (param: Anthropic.Messages.TextBlockParam) =>
   new vscode.LanguageModelTextPart(param.text);
@@ -311,36 +312,11 @@ export interface TokenCounts {
   calibrated: number; // Scaled token count approximating actual API usage
 }
 
-interface CopilotUsagePayload {
-  completion_tokens: number;
-  prompt_tokens: number;
-  prompt_tokens_details?: {
-    cache_creation_input_tokens?: number;
-    cached_tokens?: number;
-  };
-}
-
 export interface AnthropicTokenUsage {
   cache_creation_input_tokens: number;
   cache_read_input_tokens: number;
   input_tokens: number;
   output_tokens: number;
-}
-
-function isCopilotUsagePayload(value: unknown): value is CopilotUsagePayload {
-  if (!value || typeof value !== "object") {
-    return false;
-  }
-
-  const usage = value as Partial<CopilotUsagePayload>;
-  return (
-    typeof usage.prompt_tokens === "number" &&
-    Number.isFinite(usage.prompt_tokens) &&
-    usage.prompt_tokens >= 0 &&
-    typeof usage.completion_tokens === "number" &&
-    Number.isFinite(usage.completion_tokens) &&
-    usage.completion_tokens >= 0
-  );
 }
 
 const clampNonNegative = (value: number | undefined): number =>
@@ -350,39 +326,31 @@ const clampNonNegative = (value: number | undefined): number =>
  * Decodes Copilot usage metadata from a VS Code LM `LanguageModelDataPart`.
  * Caller is responsible for verifying the chunk is a data part.
  */
-export function extractAnthropicTokenUsageFromVSCodeChunk(chunk: {
+export function extractAnthropicUsage(chunk: {
   data: Uint8Array;
   mimeType: string;
 }): AnthropicTokenUsage | undefined {
-  if (chunk.mimeType !== "usage") {
+  const usage = extractCopilotUsagePayload(chunk);
+  if (!usage) {
     return undefined;
   }
 
-  try {
-    const usage = JSON.parse(new TextDecoder().decode(chunk.data)) as unknown;
-    if (!isCopilotUsagePayload(usage)) {
-      return undefined;
-    }
+  const cacheCreationInputTokens = clampNonNegative(
+    usage.prompt_tokens_details?.cache_creation_input_tokens,
+  );
+  const cacheReadInputTokens = clampNonNegative(
+    usage.prompt_tokens_details?.cached_tokens,
+  );
 
-    const cacheCreationInputTokens = clampNonNegative(
-      usage.prompt_tokens_details?.cache_creation_input_tokens,
-    );
-    const cacheReadInputTokens = clampNonNegative(
-      usage.prompt_tokens_details?.cached_tokens,
-    );
-
-    return {
-      cache_creation_input_tokens: cacheCreationInputTokens,
-      cache_read_input_tokens: cacheReadInputTokens,
-      input_tokens: Math.max(
-        0,
-        usage.prompt_tokens - cacheCreationInputTokens - cacheReadInputTokens,
-      ),
-      output_tokens: usage.completion_tokens,
-    };
-  } catch {
-    return undefined;
-  }
+  return {
+    cache_creation_input_tokens: cacheCreationInputTokens,
+    cache_read_input_tokens: cacheReadInputTokens,
+    input_tokens: Math.max(
+      0,
+      usage.prompt_tokens - cacheCreationInputTokens - cacheReadInputTokens,
+    ),
+    output_tokens: usage.completion_tokens,
+  };
 }
 
 /**

--- a/src/server/utils/anthropic.ts
+++ b/src/server/utils/anthropic.ts
@@ -372,11 +372,18 @@ export const countAnthropicMessageTokens = async (
     .getConfiguration("agent-maestro.anthropic")
     .get<number>("tokenCountScaleFactor", DEFAULT_TOKEN_SCALE_FACTOR);
 
-  const cancellationToken = new vscode.CancellationTokenSource().token;
-  const tokenCount = await client.countTokens(message, cancellationToken);
+  const cancellationTokenSource = new vscode.CancellationTokenSource();
+  try {
+    const tokenCount = await client.countTokens(
+      message,
+      cancellationTokenSource.token,
+    );
 
-  return {
-    original: tokenCount,
-    calibrated: Math.round(tokenCount * scaleFactor),
-  };
+    return {
+      original: tokenCount,
+      calibrated: Math.round(tokenCount * scaleFactor),
+    };
+  } finally {
+    cancellationTokenSource.dispose();
+  }
 };

--- a/src/server/utils/copilotUsage.ts
+++ b/src/server/utils/copilotUsage.ts
@@ -1,0 +1,46 @@
+export interface CopilotUsagePayload {
+  completion_tokens: number;
+  completion_tokens_details?: {
+    accepted_prediction_tokens?: number;
+    reasoning_tokens?: number;
+    rejected_prediction_tokens?: number;
+  };
+  prompt_tokens: number;
+  prompt_tokens_details?: {
+    cache_creation_input_tokens?: number;
+    cached_tokens?: number;
+  };
+  total_tokens?: number;
+}
+
+function isCopilotUsagePayload(value: unknown): value is CopilotUsagePayload {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const usage = value as Partial<CopilotUsagePayload>;
+  return (
+    typeof usage.prompt_tokens === "number" &&
+    Number.isFinite(usage.prompt_tokens) &&
+    usage.prompt_tokens >= 0 &&
+    typeof usage.completion_tokens === "number" &&
+    Number.isFinite(usage.completion_tokens) &&
+    usage.completion_tokens >= 0
+  );
+}
+
+export function extractCopilotUsagePayload(chunk: {
+  data: Uint8Array;
+  mimeType: string;
+}): CopilotUsagePayload | undefined {
+  if (chunk.mimeType !== "usage") {
+    return undefined;
+  }
+
+  try {
+    const usage = JSON.parse(new TextDecoder().decode(chunk.data)) as unknown;
+    return isCopilotUsagePayload(usage) ? usage : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/server/utils/openai.ts
+++ b/src/server/utils/openai.ts
@@ -1,35 +1,10 @@
 import OpenAI from "openai";
 import { ResponseUsage } from "openai/resources/responses/responses";
 
-interface CopilotUsagePayload {
-  completion_tokens: number;
-  completion_tokens_details?: {
-    accepted_prediction_tokens?: number;
-    reasoning_tokens?: number;
-    rejected_prediction_tokens?: number;
-  };
-  prompt_tokens: number;
-  prompt_tokens_details?: {
-    cached_tokens?: number;
-  };
-  total_tokens?: number;
-}
-
-function isCopilotUsagePayload(value: unknown): value is CopilotUsagePayload {
-  if (!value || typeof value !== "object") {
-    return false;
-  }
-
-  const usage = value as Partial<CopilotUsagePayload>;
-  return (
-    typeof usage.prompt_tokens === "number" &&
-    Number.isFinite(usage.prompt_tokens) &&
-    usage.prompt_tokens >= 0 &&
-    typeof usage.completion_tokens === "number" &&
-    Number.isFinite(usage.completion_tokens) &&
-    usage.completion_tokens >= 0
-  );
-}
+import {
+  type CopilotUsagePayload,
+  extractCopilotUsagePayload,
+} from "./copilotUsage";
 
 const nonNegativeNumberOrZero = (value: number | undefined): number =>
   typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : 0;
@@ -45,7 +20,7 @@ const totalTokensOrFallback = (usage: CopilotUsagePayload): number =>
   nonNegativeNumberOrUndefined(usage.total_tokens) ??
   usage.prompt_tokens + usage.completion_tokens;
 
-export function extractOpenAIChatTokenUsageFromVSCodeChunk(chunk: {
+export function extractOpenAIChatUsage(chunk: {
   data: Uint8Array;
   mimeType: string;
 }): OpenAI.CompletionUsage | undefined {
@@ -77,7 +52,7 @@ export function extractOpenAIChatTokenUsageFromVSCodeChunk(chunk: {
   };
 }
 
-export function extractOpenAIResponsesTokenUsageFromVSCodeChunk(chunk: {
+export function extractOpenAIResponsesUsage(chunk: {
   data: Uint8Array;
   mimeType: string;
 }): ResponseUsage | undefined {
@@ -101,20 +76,4 @@ export function extractOpenAIResponsesTokenUsageFromVSCodeChunk(chunk: {
     },
     total_tokens: totalTokensOrFallback(usage),
   };
-}
-
-function extractCopilotUsagePayload(chunk: {
-  data: Uint8Array;
-  mimeType: string;
-}): CopilotUsagePayload | undefined {
-  if (chunk.mimeType !== "usage") {
-    return undefined;
-  }
-
-  try {
-    const usage = JSON.parse(new TextDecoder().decode(chunk.data)) as unknown;
-    return isCopilotUsagePayload(usage) ? usage : undefined;
-  } catch {
-    return undefined;
-  }
 }

--- a/src/test/server/anthropic.test.ts
+++ b/src/test/server/anthropic.test.ts
@@ -7,7 +7,7 @@ import {
   convertAnthropicSystemToVSCode,
   convertAnthropicToolChoiceToVSCode,
   convertAnthropicToolToVSCode,
-  extractAnthropicTokenUsageFromVSCodeChunk,
+  extractAnthropicUsage,
 } from "../../server/utils/anthropic";
 import {
   createAnthropicModelsResponse,
@@ -641,12 +641,12 @@ suite("Anthropic Conversion Utils Test Suite", () => {
     });
   });
 
-  suite("extractAnthropicTokenUsageFromVSCodeChunk", () => {
+  suite("extractAnthropicUsage", () => {
     const encode = (value: unknown): Uint8Array =>
       new TextEncoder().encode(JSON.stringify(value));
 
     test("should extract usage and subtract cache tokens from input_tokens", () => {
-      const result = extractAnthropicTokenUsageFromVSCodeChunk({
+      const result = extractAnthropicUsage({
         mimeType: "usage",
         data: encode({
           prompt_tokens: 1000,
@@ -667,7 +667,7 @@ suite("Anthropic Conversion Utils Test Suite", () => {
     });
 
     test("should default cache fields to 0 when prompt_tokens_details is missing", () => {
-      const result = extractAnthropicTokenUsageFromVSCodeChunk({
+      const result = extractAnthropicUsage({
         mimeType: "usage",
         data: encode({ prompt_tokens: 100, completion_tokens: 20 }),
       });
@@ -681,7 +681,7 @@ suite("Anthropic Conversion Utils Test Suite", () => {
     });
 
     test("should clamp input_tokens to 0 when cache totals exceed prompt_tokens", () => {
-      const result = extractAnthropicTokenUsageFromVSCodeChunk({
+      const result = extractAnthropicUsage({
         mimeType: "usage",
         data: encode({
           prompt_tokens: 100,
@@ -697,7 +697,7 @@ suite("Anthropic Conversion Utils Test Suite", () => {
     });
 
     test("should return undefined for non-usage mimeType", () => {
-      const result = extractAnthropicTokenUsageFromVSCodeChunk({
+      const result = extractAnthropicUsage({
         mimeType: "image/png",
         data: encode({ prompt_tokens: 1, completion_tokens: 1 }),
       });
@@ -706,7 +706,7 @@ suite("Anthropic Conversion Utils Test Suite", () => {
     });
 
     test("should return undefined for invalid JSON", () => {
-      const result = extractAnthropicTokenUsageFromVSCodeChunk({
+      const result = extractAnthropicUsage({
         mimeType: "usage",
         data: new TextEncoder().encode("not json {"),
       });
@@ -715,7 +715,7 @@ suite("Anthropic Conversion Utils Test Suite", () => {
     });
 
     test("should return undefined when required fields are missing", () => {
-      const result = extractAnthropicTokenUsageFromVSCodeChunk({
+      const result = extractAnthropicUsage({
         mimeType: "usage",
         data: encode({ prompt_tokens: 100 }),
       });
@@ -725,7 +725,7 @@ suite("Anthropic Conversion Utils Test Suite", () => {
 
     test("should reject non-finite or negative token counts", () => {
       assert.strictEqual(
-        extractAnthropicTokenUsageFromVSCodeChunk({
+        extractAnthropicUsage({
           mimeType: "usage",
           data: encode({ prompt_tokens: -1, completion_tokens: 10 }),
         }),
@@ -733,7 +733,7 @@ suite("Anthropic Conversion Utils Test Suite", () => {
       );
 
       assert.strictEqual(
-        extractAnthropicTokenUsageFromVSCodeChunk({
+        extractAnthropicUsage({
           mimeType: "usage",
           data: encode({ prompt_tokens: 100, completion_tokens: "20" }),
         }),
@@ -742,7 +742,7 @@ suite("Anthropic Conversion Utils Test Suite", () => {
     });
 
     test("should ignore negative or non-finite cache fields", () => {
-      const result = extractAnthropicTokenUsageFromVSCodeChunk({
+      const result = extractAnthropicUsage({
         mimeType: "usage",
         data: encode({
           prompt_tokens: 100,

--- a/src/test/server/openaiChat.test.ts
+++ b/src/test/server/openaiChat.test.ts
@@ -1,7 +1,7 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
 
-import { extractOpenAIChatTokenUsageFromVSCodeChunk } from "../../server/utils/openai";
+import { extractOpenAIChatUsage } from "../../server/utils/openai";
 import {
   convertOpenAIChatCompletionToolToVSCode,
   convertOpenAIMessagesToVSCode,
@@ -381,9 +381,9 @@ suite("OpenAI Conversion Utils Test Suite", () => {
     });
   });
 
-  suite("extractOpenAIChatTokenUsageFromVSCodeChunk", () => {
+  suite("extractOpenAIChatUsage", () => {
     test("should map Copilot usage metadata to OpenAI chat usage", () => {
-      const result = extractOpenAIChatTokenUsageFromVSCodeChunk({
+      const result = extractOpenAIChatUsage({
         mimeType: "usage",
         data: encode({
           prompt_tokens: 10445,
@@ -412,7 +412,7 @@ suite("OpenAI Conversion Utils Test Suite", () => {
     });
 
     test("should return undefined for non-usage data parts", () => {
-      const result = extractOpenAIChatTokenUsageFromVSCodeChunk({
+      const result = extractOpenAIChatUsage({
         mimeType: "stateful_marker",
         data: encode({ prompt_tokens: 1, completion_tokens: 1 }),
       });
@@ -421,7 +421,7 @@ suite("OpenAI Conversion Utils Test Suite", () => {
     });
 
     test("should return undefined for malformed JSON", () => {
-      const result = extractOpenAIChatTokenUsageFromVSCodeChunk({
+      const result = extractOpenAIChatUsage({
         mimeType: "usage",
         data: new TextEncoder().encode("not json {"),
       });
@@ -430,7 +430,7 @@ suite("OpenAI Conversion Utils Test Suite", () => {
     });
 
     test("should return undefined when prompt_tokens is missing", () => {
-      const result = extractOpenAIChatTokenUsageFromVSCodeChunk({
+      const result = extractOpenAIChatUsage({
         mimeType: "usage",
         data: encode({ completion_tokens: 1 }),
       });
@@ -439,7 +439,7 @@ suite("OpenAI Conversion Utils Test Suite", () => {
     });
 
     test("should return undefined when completion_tokens is negative", () => {
-      const result = extractOpenAIChatTokenUsageFromVSCodeChunk({
+      const result = extractOpenAIChatUsage({
         mimeType: "usage",
         data: encode({ prompt_tokens: 1, completion_tokens: -1 }),
       });
@@ -448,7 +448,7 @@ suite("OpenAI Conversion Utils Test Suite", () => {
     });
 
     test("should fall back to prompt plus completion when total is invalid", () => {
-      const result = extractOpenAIChatTokenUsageFromVSCodeChunk({
+      const result = extractOpenAIChatUsage({
         mimeType: "usage",
         data: encode({
           prompt_tokens: 100,
@@ -461,7 +461,7 @@ suite("OpenAI Conversion Utils Test Suite", () => {
     });
 
     test("should keep zero total tokens when provided", () => {
-      const result = extractOpenAIChatTokenUsageFromVSCodeChunk({
+      const result = extractOpenAIChatUsage({
         mimeType: "usage",
         data: encode({
           prompt_tokens: 100,

--- a/src/test/server/openaiResponses.test.ts
+++ b/src/test/server/openaiResponses.test.ts
@@ -1,7 +1,7 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
 
-import { extractOpenAIResponsesTokenUsageFromVSCodeChunk } from "../../server/utils/openai";
+import { extractOpenAIResponsesUsage } from "../../server/utils/openai";
 import {
   buildResponseOutput,
   convertInputContentToVSCodePart,
@@ -431,9 +431,9 @@ suite("OpenAI Responses Conversion Utils Test Suite", () => {
     });
   });
 
-  suite("extractOpenAIResponsesTokenUsageFromVSCodeChunk", () => {
+  suite("extractOpenAIResponsesUsage", () => {
     test("should map Copilot usage metadata to OpenAI responses usage", () => {
-      const result = extractOpenAIResponsesTokenUsageFromVSCodeChunk({
+      const result = extractOpenAIResponsesUsage({
         mimeType: "usage",
         data: encode({
           prompt_tokens: 10445,
@@ -454,7 +454,7 @@ suite("OpenAI Responses Conversion Utils Test Suite", () => {
     });
 
     test("should fall back to prompt plus completion when total is missing", () => {
-      const result = extractOpenAIResponsesTokenUsageFromVSCodeChunk({
+      const result = extractOpenAIResponsesUsage({
         mimeType: "usage",
         data: encode({
           prompt_tokens: 100,
@@ -466,7 +466,7 @@ suite("OpenAI Responses Conversion Utils Test Suite", () => {
     });
 
     test("should fall back to prompt plus completion when total is invalid", () => {
-      const result = extractOpenAIResponsesTokenUsageFromVSCodeChunk({
+      const result = extractOpenAIResponsesUsage({
         mimeType: "usage",
         data: encode({
           prompt_tokens: 100,
@@ -479,7 +479,7 @@ suite("OpenAI Responses Conversion Utils Test Suite", () => {
     });
 
     test("should keep zero total tokens when provided", () => {
-      const result = extractOpenAIResponsesTokenUsageFromVSCodeChunk({
+      const result = extractOpenAIResponsesUsage({
         mimeType: "usage",
         data: encode({
           prompt_tokens: 100,
@@ -492,7 +492,7 @@ suite("OpenAI Responses Conversion Utils Test Suite", () => {
     });
 
     test("should return undefined for malformed JSON", () => {
-      const result = extractOpenAIResponsesTokenUsageFromVSCodeChunk({
+      const result = extractOpenAIResponsesUsage({
         mimeType: "usage",
         data: new TextEncoder().encode("not json {"),
       });
@@ -501,7 +501,7 @@ suite("OpenAI Responses Conversion Utils Test Suite", () => {
     });
 
     test("should return undefined when prompt_tokens is missing", () => {
-      const result = extractOpenAIResponsesTokenUsageFromVSCodeChunk({
+      const result = extractOpenAIResponsesUsage({
         mimeType: "usage",
         data: encode({ completion_tokens: 1 }),
       });
@@ -510,7 +510,7 @@ suite("OpenAI Responses Conversion Utils Test Suite", () => {
     });
 
     test("should return undefined when completion_tokens is negative", () => {
-      const result = extractOpenAIResponsesTokenUsageFromVSCodeChunk({
+      const result = extractOpenAIResponsesUsage({
         mimeType: "usage",
         data: encode({ prompt_tokens: 1, completion_tokens: -1 }),
       });


### PR DESCRIPTION
## Summary
- Share Copilot usage payload parsing across Anthropic and OpenAI usage mappers
- Shorten route-facing usage helper names
- Dispose VS Code cancellation token sources explicitly across proxy routes
- Version 2.9.2 from the pending OpenAI Copilot usage changeset

## Test plan
- pnpm check-types
- pnpm lint
- pre-commit lint-staged checks