### PR TITLE
fix(gemini): use streamed usage metadata

### DIFF
--- a/.changeset/wise-lemons-juggle.md
+++ b/.changeset/wise-lemons-juggle.md
@@ -1,0 +1,5 @@
+---
+"agent-maestro": patch
+---
+
+Use Copilot usage metadata for Gemini-compatible responses, including cached prompt and reasoning token counts, with token counting retained as a fallback.

--- a/src/server/routes/geminiRoutes.ts
+++ b/src/server/routes/geminiRoutes.ts
@@ -13,10 +13,12 @@ import {
 } from "../schemas/gemini";
 import { handleErrorWithLogging } from "../utils/errorDiagnostics";
 import {
+  type GeminiTokenUsage,
   convertGeminiContentsToVSCode,
   convertGeminiSystemInstructionToVSCode,
   convertGeminiToolConfigToVSCode,
   convertGeminiToolsToVSCode,
+  extractGeminiUsage,
 } from "../utils/gemini";
 
 // ============================================================================
@@ -24,17 +26,12 @@ import {
 // ============================================================================
 
 /**
- * Prepare Gemini request by converting to VSCode format and counting tokens
- * Used by both generateContent and countTokens endpoints
+ * Prepare Gemini request by converting to VSCode format.
  */
-const prepareGeminiRequest = async ({
+const prepareGeminiRequest = ({
   requestBody,
-  client,
-  cancellationToken,
 }: {
   requestBody: GenerateContentRequest;
-  client: vscode.LanguageModelChat;
-  cancellationToken: vscode.CancellationToken;
 }) => {
   logger.debug("Gemini request payload:");
   logger.debug(JSON.stringify(requestBody, null, 2));
@@ -47,15 +44,6 @@ const prepareGeminiRequest = async ({
     ...convertGeminiSystemInstructionToVSCode(systemInstruction),
     ...convertGeminiContentsToVSCode(contents || []),
   ];
-
-  // NOTE: Rough estimation of input tokens for Gemini API
-  // We pass the stringified request body to VSCode's countTokens() API, which is technically
-  // a misuse since it's designed for LanguageModelChatMessage objects. However, we intentionally
-  // do this to leverage the official tokenizer instead of building our own wheel.
-  const inputTokenCount = await client.countTokens(
-    JSON.stringify(requestBody),
-    cancellationToken,
-  );
 
   // Build request options
   const lmRequestOptions: vscode.LanguageModelChatRequestOptions = {
@@ -70,8 +58,34 @@ const prepareGeminiRequest = async ({
 
   return {
     vsCodeLmMessages,
-    inputTokenCount,
     lmRequestOptions,
+  };
+};
+
+const getFallbackGeminiUsage = async ({
+  accumulatedText,
+  cancellationToken,
+  client,
+  requestBody,
+}: {
+  accumulatedText: string;
+  cancellationToken: vscode.CancellationToken;
+  client: vscode.LanguageModelChat;
+  requestBody: GenerateContentRequest;
+}): Promise<GeminiTokenUsage> => {
+  const [promptTokenCount, candidatesTokenCount] = await Promise.all([
+    client.countTokens(JSON.stringify(requestBody), cancellationToken),
+    accumulatedText
+      ? client.countTokens(accumulatedText, cancellationToken)
+      : 0,
+  ]);
+
+  return {
+    cachedContentTokenCount: 0,
+    candidatesTokenCount,
+    promptTokenCount,
+    thoughtsTokenCount: 0,
+    totalTokenCount: promptTokenCount + candidatesTokenCount,
   };
 };
 
@@ -321,19 +335,15 @@ export function registerGeminiRoutes(app: OpenAPIHono) {
 
       // 2. Prepare request
       cancellationTokenSource = new vscode.CancellationTokenSource();
-      const { vsCodeLmMessages, inputTokenCount, lmRequestOptions } =
-        await prepareGeminiRequest({
-          requestBody,
-          client,
-          cancellationToken: cancellationTokenSource.token,
-        });
+      const { vsCodeLmMessages, lmRequestOptions } = prepareGeminiRequest({
+        requestBody,
+      });
       lmChatMessages = vsCodeLmMessages;
-      inputTokens = inputTokenCount;
 
       logger.info(
         `→ /v1beta/models/${modelWithMethod} | model: ${
           modelId === client.id ? modelId : `${modelId} → ${client.id}`
-        } | input: ${inputTokenCount}`,
+        }`,
       );
 
       // 3. Send request to VSCode LM API
@@ -346,6 +356,7 @@ export function registerGeminiRoutes(app: OpenAPIHono) {
       // 4. Process response (always non-streaming for generateContent)
       const parts: Part[] = [];
       let accumulatedText = "";
+      let responseUsage: GeminiTokenUsage | undefined;
 
       for await (const chunk of response.stream) {
         if (chunk instanceof vscode.LanguageModelTextPart) {
@@ -361,14 +372,20 @@ export function registerGeminiRoutes(app: OpenAPIHono) {
             },
           });
           accumulatedText += JSON.stringify(chunk);
+        } else if (chunk instanceof vscode.LanguageModelDataPart) {
+          responseUsage = extractGeminiUsage(chunk) ?? responseUsage;
         }
-        // Now chunk could be reasoning part (vscode_reasoning_done), so we skip it
       }
 
-      // Count output tokens
-      const outputTokenCount = accumulatedText
-        ? await client.countTokens(accumulatedText)
-        : 0;
+      const usageMetadata =
+        responseUsage ??
+        (await getFallbackGeminiUsage({
+          accumulatedText,
+          cancellationToken: cancellationTokenSource.token,
+          client,
+          requestBody,
+        }));
+      inputTokens = usageMetadata.promptTokenCount;
 
       const geminiResponse: GenerateContentResponse = {
         candidates: [
@@ -381,19 +398,14 @@ export function registerGeminiRoutes(app: OpenAPIHono) {
             index: 0,
           },
         ],
-        usageMetadata: {
-          promptTokenCount: inputTokenCount,
-          cachedContentTokenCount: 0,
-          candidatesTokenCount: outputTokenCount,
-          totalTokenCount: inputTokenCount + outputTokenCount,
-        },
+        usageMetadata,
         modelVersion: modelId,
       };
 
       logger.debug("generateContent response:");
       logger.debug(JSON.stringify(geminiResponse, null, 2));
       logger.info(
-        `← /v1beta/models/${modelWithMethod} | input: ${inputTokenCount} | output: ${outputTokenCount}`,
+        `← /v1beta/models/${modelWithMethod} | input: ${usageMetadata.promptTokenCount} | cache_read: ${usageMetadata.cachedContentTokenCount} | output: ${usageMetadata.candidatesTokenCount} | thoughts: ${usageMetadata.thoughtsTokenCount}`,
       );
 
       cancellationTokenSource.dispose();
@@ -462,26 +474,23 @@ export function registerGeminiRoutes(app: OpenAPIHono) {
 
         // 2. Prepare request
         cancellationTokenSource = new vscode.CancellationTokenSource();
-        const { vsCodeLmMessages, inputTokenCount, lmRequestOptions } =
-          await prepareGeminiRequest({
-            requestBody,
-            client,
-            cancellationToken: cancellationTokenSource.token,
-          });
+        const { vsCodeLmMessages, lmRequestOptions } = prepareGeminiRequest({
+          requestBody,
+        });
         lmChatMessages = vsCodeLmMessages;
-        inputTokens = inputTokenCount;
 
         logger.info(
           `→ /v1beta/models/${modelWithMethod} | model: ${
             modelId === client.id ? modelId : `${modelId} → ${client.id}`
-          } | input: ${inputTokenCount}`,
+          }`,
         );
 
         // 3. Send request to VSCode LM API
+        const cancellationToken = cancellationTokenSource.token;
         const response = await client.sendRequest(
           vsCodeLmMessages,
           lmRequestOptions,
-          cancellationTokenSource.token,
+          cancellationToken,
         );
 
         // 4. Always stream the response
@@ -489,6 +498,7 @@ export function registerGeminiRoutes(app: OpenAPIHono) {
           c,
           async (stream) => {
             let accumulatedText = "";
+            let responseUsage: GeminiTokenUsage | undefined;
 
             for await (const chunk of response.stream) {
               if (chunk instanceof vscode.LanguageModelTextPart) {
@@ -537,14 +547,21 @@ export function registerGeminiRoutes(app: OpenAPIHono) {
                 await stream.writeSSE({
                   data: JSON.stringify(streamChunk),
                 });
+              } else if (chunk instanceof vscode.LanguageModelDataPart) {
+                responseUsage = extractGeminiUsage(chunk) ?? responseUsage;
               }
-              // Now chunk could be reasoning part (vscode_reasoning_done), so we skip it
             }
 
             // Send final chunk with usage metadata
-            const outputTokenCount = accumulatedText
-              ? await client.countTokens(accumulatedText)
-              : 0;
+            const usageMetadata =
+              responseUsage ??
+              (await getFallbackGeminiUsage({
+                accumulatedText,
+                cancellationToken,
+                client,
+                requestBody,
+              }));
+            inputTokens = usageMetadata.promptTokenCount;
 
             const finalChunk: GenerateContentResponse = {
               candidates: [
@@ -553,12 +570,7 @@ export function registerGeminiRoutes(app: OpenAPIHono) {
                   index: 0,
                 },
               ],
-              usageMetadata: {
-                promptTokenCount: inputTokenCount,
-                cachedContentTokenCount: 0,
-                candidatesTokenCount: outputTokenCount,
-                totalTokenCount: inputTokenCount + outputTokenCount,
-              },
+              usageMetadata,
               modelVersion: modelId,
             };
 
@@ -567,7 +579,7 @@ export function registerGeminiRoutes(app: OpenAPIHono) {
             });
 
             logger.info(
-              `← /v1beta/models/${modelWithMethod} (stream) | input: ${inputTokenCount} | output: ${outputTokenCount}`,
+              `← /v1beta/models/${modelWithMethod} (stream) | input: ${usageMetadata.promptTokenCount} | cache_read: ${usageMetadata.cachedContentTokenCount} | output: ${usageMetadata.candidatesTokenCount} | thoughts: ${usageMetadata.thoughtsTokenCount}`,
             );
             cancellationTokenSource?.dispose();
           },
@@ -595,10 +607,10 @@ export function registerGeminiRoutes(app: OpenAPIHono) {
                 },
               ],
               usageMetadata: {
-                promptTokenCount: inputTokenCount,
+                promptTokenCount: inputTokens,
                 cachedContentTokenCount: 0,
                 candidatesTokenCount: 0,
-                totalTokenCount: inputTokenCount,
+                totalTokenCount: inputTokens,
               },
               modelVersion: modelId,
             };
@@ -668,13 +680,13 @@ export function registerGeminiRoutes(app: OpenAPIHono) {
         );
       }
 
-      // 2. Prepare request and get token count
+      // 2. Count tokens using the simple fallback path. countTokens has no
+      // response stream, so no real Copilot usage metadata is available.
       cancellationTokenSource = new vscode.CancellationTokenSource();
-      const { inputTokenCount } = await prepareGeminiRequest({
-        requestBody,
-        client,
-        cancellationToken: cancellationTokenSource.token,
-      });
+      const inputTokenCount = await client.countTokens(
+        JSON.stringify(requestBody),
+        cancellationTokenSource.token,
+      );
       cancellationTokenSource.dispose();
 
       logger.info(

--- a/src/server/utils/gemini.ts
+++ b/src/server/utils/gemini.ts
@@ -462,6 +462,11 @@ export interface GeminiTokenUsage {
   totalTokenCount: number;
 }
 
+const asNonNegativeFiniteNumber = (value: unknown): number | undefined =>
+  typeof value === "number" && Number.isFinite(value) && value >= 0
+    ? value
+    : undefined;
+
 export const extractGeminiUsage = (
   chunk: vscode.LanguageModelDataPart,
 ): GeminiTokenUsage | undefined => {
@@ -470,11 +475,17 @@ export const extractGeminiUsage = (
     return undefined;
   }
 
-  const cachedTokens = usage.prompt_tokens_details?.cached_tokens ?? 0;
+  const cachedTokens =
+    asNonNegativeFiniteNumber(usage.prompt_tokens_details?.cached_tokens) ?? 0;
   const reasoningTokens =
-    usage.completion_tokens_details?.reasoning_tokens ??
-    (usage as { reasoning_tokens?: number }).reasoning_tokens ??
+    asNonNegativeFiniteNumber(
+      usage.completion_tokens_details?.reasoning_tokens,
+    ) ??
+    asNonNegativeFiniteNumber(
+      (usage as { reasoning_tokens?: unknown }).reasoning_tokens,
+    ) ??
     0;
+  const totalTokens = asNonNegativeFiniteNumber(usage.total_tokens);
   const promptTokenCount = Math.max(0, usage.prompt_tokens - cachedTokens);
 
   return {
@@ -483,7 +494,7 @@ export const extractGeminiUsage = (
     promptTokenCount,
     thoughtsTokenCount: reasoningTokens,
     totalTokenCount:
-      usage.total_tokens ??
+      totalTokens ??
       usage.prompt_tokens + usage.completion_tokens + reasoningTokens,
   };
 };

--- a/src/server/utils/gemini.ts
+++ b/src/server/utils/gemini.ts
@@ -9,6 +9,7 @@ import {
 import * as vscode from "vscode";
 
 import { logger } from "../../utils/logger";
+import { extractCopilotUsagePayload } from "./copilotUsage";
 
 /**
  * Map of uppercase/mixed-case type values to lowercase JSON Schema types.
@@ -451,4 +452,38 @@ export const convertGeminiToolConfigToVSCode = (
     default:
       return undefined;
   }
+};
+
+export interface GeminiTokenUsage {
+  cachedContentTokenCount: number;
+  candidatesTokenCount: number;
+  promptTokenCount: number;
+  thoughtsTokenCount: number;
+  totalTokenCount: number;
+}
+
+export const extractGeminiUsage = (
+  chunk: vscode.LanguageModelDataPart,
+): GeminiTokenUsage | undefined => {
+  const usage = extractCopilotUsagePayload(chunk);
+  if (!usage) {
+    return undefined;
+  }
+
+  const cachedTokens = usage.prompt_tokens_details?.cached_tokens ?? 0;
+  const reasoningTokens =
+    usage.completion_tokens_details?.reasoning_tokens ??
+    (usage as { reasoning_tokens?: number }).reasoning_tokens ??
+    0;
+  const promptTokenCount = Math.max(0, usage.prompt_tokens - cachedTokens);
+
+  return {
+    cachedContentTokenCount: cachedTokens,
+    candidatesTokenCount: usage.completion_tokens,
+    promptTokenCount,
+    thoughtsTokenCount: reasoningTokens,
+    totalTokenCount:
+      usage.total_tokens ??
+      usage.prompt_tokens + usage.completion_tokens + reasoningTokens,
+  };
 };

--- a/src/test/server/gemini.test.ts
+++ b/src/test/server/gemini.test.ts
@@ -8,10 +8,79 @@ import {
   convertGeminiSystemInstructionToVSCode,
   convertGeminiToolConfigToVSCode,
   convertGeminiToolsToVSCode,
+  extractGeminiUsage,
   normalizeSchemaTypes,
 } from "../../server/utils/gemini";
 
 suite("Gemini Conversion Utils Test Suite", () => {
+  suite("extractGeminiUsage", () => {
+    const usagePart = (usage: unknown) =>
+      new vscode.LanguageModelDataPart(
+        Buffer.from(JSON.stringify(usage)),
+        "usage",
+      );
+
+    test("should parse uncached Copilot usage", () => {
+      const result = extractGeminiUsage(
+        usagePart({
+          completion_tokens: 406,
+          prompt_tokens: 16748,
+          prompt_tokens_details: { cached_tokens: 0 },
+          total_tokens: 17154,
+          reasoning_tokens: 0,
+        }),
+      );
+
+      assert.deepStrictEqual(result, {
+        cachedContentTokenCount: 0,
+        candidatesTokenCount: 406,
+        promptTokenCount: 16748,
+        thoughtsTokenCount: 0,
+        totalTokenCount: 17154,
+      });
+    });
+
+    test("should subtract cached prompt tokens from promptTokenCount", () => {
+      const result = extractGeminiUsage(
+        usagePart({
+          completion_tokens: 15,
+          prompt_tokens: 14127,
+          prompt_tokens_details: { cached_tokens: 13429 },
+          total_tokens: 14142,
+          reasoning_tokens: 0,
+        }),
+      );
+
+      assert.deepStrictEqual(result, {
+        cachedContentTokenCount: 13429,
+        candidatesTokenCount: 15,
+        promptTokenCount: 698,
+        thoughtsTokenCount: 0,
+        totalTokenCount: 14142,
+      });
+    });
+
+    test("should map reasoning tokens to thoughtsTokenCount", () => {
+      const result = extractGeminiUsage(
+        usagePart({
+          completion_tokens: 36,
+          prompt_tokens: 14055,
+          prompt_tokens_details: { cached_tokens: 0 },
+          total_tokens: 14188,
+          reasoning_tokens: 97,
+        }),
+      );
+
+      assert.deepStrictEqual(result, {
+        cachedContentTokenCount: 0,
+        candidatesTokenCount: 36,
+        promptTokenCount: 14055,
+        thoughtsTokenCount: 97,
+        totalTokenCount: 14188,
+      });
+    });
+  });
+
   suite("convertGeminiContentToVSCode", () => {
     test("should convert user role with text part", () => {
       const content = {

--- a/src/test/server/gemini.test.ts
+++ b/src/test/server/gemini.test.ts
@@ -79,6 +79,27 @@ suite("Gemini Conversion Utils Test Suite", () => {
         totalTokenCount: 14188,
       });
     });
+
+    test("should ignore invalid nested usage values", () => {
+      const result = extractGeminiUsage(
+        usagePart({
+          completion_tokens: 20,
+          completion_tokens_details: { reasoning_tokens: -7 },
+          prompt_tokens: 100,
+          prompt_tokens_details: { cached_tokens: -10 },
+          reasoning_tokens: Number.NaN,
+          total_tokens: -1,
+        }),
+      );
+
+      assert.deepStrictEqual(result, {
+        cachedContentTokenCount: 0,
+        candidatesTokenCount: 20,
+        promptTokenCount: 100,
+        thoughtsTokenCount: 0,
+        totalTokenCount: 120,
+      });
+    });
   });
 
   suite("convertGeminiContentToVSCode", () => {


### PR DESCRIPTION
## Summary
- use Copilot usage data parts for Gemini-compatible usage metadata when available
- remove request-start Gemini input token counting and keep countTokens fallback only after completion
- map cached prompt and reasoning tokens into Gemini usage fields

## Test plan
- pnpm check-types
- pnpm lint

## Manual verification
Debug server: http://localhost:33333

- POST /api/gemini/v1beta/models/gemini-3.5-flash:countTokens returned 200 with {"totalTokens":24}
- POST /api/gemini/v1beta/models/gemini-3.5-flash:generateContent returned 200 with text "gemini nonstream ok" and usageMetadata including promptTokenCount 220, candidatesTokenCount 5, thoughtsTokenCount 185, totalTokenCount 410
- POST /api/gemini/v1beta/models/gemini-3.5-flash:streamGenerateContent returned 200 with final SSE usageMetadata including promptTokenCount 219, candidatesTokenCount 4, thoughtsTokenCount 167, totalTokenCount 390
- Repeated generateContent stayed healthy and returned streamed usage metadata again; cachedContentTokenCount remained 0 in this debug run