### PR TITLE
feat(anthropic): add contextWindowScaleFactor setting

### DIFF
--- a/.changeset/anthropic-context-window-scale.md
+++ b/.changeset/anthropic-context-window-scale.md
@@ -1,0 +1,5 @@
+---
+"agent-maestro": minor
+---
+
+Add `agent-maestro.anthropic.contextWindowScaleFactor` setting to scale the `max_input_tokens` reported for Anthropic models. Lowering it below 1 makes Claude Code compact context earlier, mirroring the existing `agent-maestro.codex.contextWindowScaleFactor` option.

--- a/package.json
+++ b/package.json
@@ -105,8 +105,6 @@
         "agent-maestro.anthropic.contextWindowScaleFactor": {
           "type": "number",
           "default": 1,
-          "minimum": 0.1,
-          "maximum": 2,
           "description": "Scale factor applied to the `max_input_tokens` reported for Anthropic models. Lowering it below 1 makes Claude Code compact context earlier, which can avoid edge cases near the model's full context window. A value of 1 reports 100% of the model's max input tokens.",
           "scope": "application"
         }

--- a/package.json
+++ b/package.json
@@ -101,6 +101,14 @@
           "maximum": 2,
           "description": "Scale factor applied to fallback Anthropic token estimates and count_tokens responses when real Copilot usage metadata is unavailable. Default 1.25 means VS Code token counts are multiplied by 1.25.",
           "scope": "application"
+        },
+        "agent-maestro.anthropic.contextWindowScaleFactor": {
+          "type": "number",
+          "default": 1,
+          "minimum": 0.1,
+          "maximum": 2,
+          "description": "Scale factor applied to the `max_input_tokens` reported for Anthropic models. Lowering it below 1 makes Claude Code compact context earlier, which can avoid edge cases near the model's full context window. A value of 1 reports 100% of the model's max input tokens.",
+          "scope": "application"
         }
       }
     },

--- a/src/server/utils/anthropicModels.ts
+++ b/src/server/utils/anthropicModels.ts
@@ -16,8 +16,6 @@ const supported = { supported: true };
 const unsupported = { supported: false };
 
 const DEFAULT_CONTEXT_WINDOW_SCALE_FACTOR = 1;
-const MIN_CONTEXT_WINDOW_SCALE_FACTOR = 0.1;
-const MAX_CONTEXT_WINDOW_SCALE_FACTOR = 2;
 
 function getContextWindowScaleFactor(): number {
   const scaleFactor = vscode.workspace
@@ -30,8 +28,7 @@ function getContextWindowScaleFactor(): number {
   if (
     typeof scaleFactor !== "number" ||
     !Number.isFinite(scaleFactor) ||
-    scaleFactor < MIN_CONTEXT_WINDOW_SCALE_FACTOR ||
-    scaleFactor > MAX_CONTEXT_WINDOW_SCALE_FACTOR
+    scaleFactor <= 0
   ) {
     return DEFAULT_CONTEXT_WINDOW_SCALE_FACTOR;
   }

--- a/src/server/utils/anthropicModels.ts
+++ b/src/server/utils/anthropicModels.ts
@@ -15,6 +15,34 @@ const UNKNOWN_MODEL_CREATED_AT = "1970-01-01T00:00:00Z";
 const supported = { supported: true };
 const unsupported = { supported: false };
 
+const DEFAULT_CONTEXT_WINDOW_SCALE_FACTOR = 1;
+const MIN_CONTEXT_WINDOW_SCALE_FACTOR = 0.1;
+const MAX_CONTEXT_WINDOW_SCALE_FACTOR = 2;
+
+function getContextWindowScaleFactor(): number {
+  const scaleFactor = vscode.workspace
+    .getConfiguration("agent-maestro.anthropic")
+    .get<number>(
+      "contextWindowScaleFactor",
+      DEFAULT_CONTEXT_WINDOW_SCALE_FACTOR,
+    );
+
+  if (
+    typeof scaleFactor !== "number" ||
+    !Number.isFinite(scaleFactor) ||
+    scaleFactor < MIN_CONTEXT_WINDOW_SCALE_FACTOR ||
+    scaleFactor > MAX_CONTEXT_WINDOW_SCALE_FACTOR
+  ) {
+    return DEFAULT_CONTEXT_WINDOW_SCALE_FACTOR;
+  }
+
+  return scaleFactor;
+}
+
+function scaleMaxInputTokens(maxInputTokens: number): number {
+  return Math.floor(maxInputTokens * getContextWindowScaleFactor());
+}
+
 interface VSCodeModelCapabilities {
   supportsImageToText?: boolean;
   supportsToolCalling?: boolean;
@@ -79,7 +107,9 @@ export function convertVSCodeModelToAnthropicModel(
     capabilities: convertVSCodeCapabilitiesToAnthropic(model),
     created_at: UNKNOWN_MODEL_CREATED_AT,
     display_name: model.name,
-    max_input_tokens: model.maxInputTokens,
+    max_input_tokens: model.maxInputTokens
+      ? scaleMaxInputTokens(model.maxInputTokens)
+      : model.maxInputTokens,
     max_tokens: null,
     type: "model",
   };


### PR DESCRIPTION
## Summary

Adds a new `agent-maestro.anthropic.contextWindowScaleFactor` setting that scales the `max_input_tokens` reported for Anthropic models, mirroring the existing `agent-maestro.codex.contextWindowScaleFactor` option for Codex.

## Why

When using Claude Code through Agent Maestro's Anthropic-compatible proxy, the `max_input_tokens` value is passed through verbatim from the upstream VS Code Language Model (GitHub Copilot). Claude Code trusts this value to decide when to compact/trim conversation context.

In practice, `claude-opus-4.8` reports a **232K** context window (vs 202K for 4.7). With the larger window, Claude Code's context-compaction kicks in later and more aggressively right at the window boundary. This has repeatedly produced **truncation failures** — e.g. a `tool_use` block getting dropped while its matching `tool_result` survives, yielding:

```
400 invalid_request_error: messages.0.content.0: unexpected `tool_use_id`
found in `tool_result` blocks ... Each `tool_result` block must have a
corresponding `tool_use` block in the previous message.
```

The only way to influence the window today is to edit source, and there was **no equivalent of the Codex scale factor on the Anthropic path** — so every model would otherwise need a case-by-case hardcoded cap.

This setting gives users a single knob to scale down the reported window (e.g. `0.86` to bring a 232K model back to ~200K) so Claude Code compacts earlier and avoids the boundary edge cases — without patching `max_input_tokens` per model.

## Changes

- **`package.json`** — declare `agent-maestro.anthropic.contextWindowScaleFactor` (default `1`, `scope: application`). No min/max bounds — the value is the user's responsibility.
- **`src/server/utils/anthropicModels.ts`** — apply the factor when reporting `max_input_tokens` (`Math.floor(maxInputTokens * factor)`). Non-finite or non-positive values fall back to `1`; `0`/falsy `maxInputTokens` is preserved as before.
- **`.changeset/`** — minor changeset.

A value of `1` (default) is a no-op, so existing behavior is unchanged.

## Test plan

- [x] `pnpm run check-types` — passes
- [x] `pnpm run lint` — passes
- [x] `pnpm test` — 294 passing (incl. `createAnthropicModelsResponse` tests; default factor `1` keeps `200000`/`1000000` reported as-is and `0` preserved)