### PR TITLE
fix(copilot): pass long-context configuration to Copilot 1m models

### DIFF
--- a/.changeset/long-context-lions.md
+++ b/.changeset/long-context-lions.md
@@ -1,0 +1,5 @@
+---
+"agent-maestro": patch
+---
+
+Request Copilot's long-context configuration when proxying 1M Claude models so VS Code does not fall back to the default 200K context size.

--- a/.changeset/long-context-lions.md
+++ b/.changeset/long-context-lions.md
@@ -1,5 +1,0 @@
----
-"agent-maestro": patch
----
-
-Request Copilot's long-context configuration when proxying 1M Claude models so VS Code does not fall back to the default 200K context size.

--- a/.changeset/wise-lemons-juggle.md
+++ b/.changeset/wise-lemons-juggle.md
@@ -1,5 +1,0 @@
----
-"agent-maestro": patch
----
-
-Use Copilot usage metadata for Gemini-compatible responses, including cached prompt and reasoning token counts, with token counting retained as a fallback.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.9.3 - 2026.06.02
+
+- Opt into Copilot's long-context configuration for Claude models with larger context windows so VS Code does not fall back to the default 200K prompt budget.
+- Use Copilot usage metadata for Gemini-compatible responses, including cached prompt and reasoning token counts, while retaining token counting as a fallback.
+
 ## v2.9.2 - 2026.05.23
 
 - Use Copilot usage metadata for OpenAI-compatible chat completions and responses when available, including cached input and reasoning token details.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "agent-maestro",
   "displayName": "Agent Maestro",
   "description": "Turn VS Code into your compliant AI playground! With Agent Maestro, spin up Cline or Roo on demand and plug Claude Code or Codex straight in through an OpenAI/Anthropic-compatible API.",
-  "version": "2.9.2",
+  "version": "2.9.3",
   "icon": "assets/icons/icon.png",
   "publisher": "Joouis",
   "repository": "https://github.com/Joouis/agent-maestro",

--- a/src/server/routes/anthropicRoutes.ts
+++ b/src/server/routes/anthropicRoutes.ts
@@ -4,7 +4,11 @@ import { Context } from "hono";
 import { streamSSE } from "hono/streaming";
 import * as vscode from "vscode";
 
-import { chatModelsCache, getChatModelClient } from "../../utils/chatModels";
+import {
+  chatModelsCache,
+  getChatModelClient,
+  withCopilotLongContextConfiguration,
+} from "../../utils/chatModels";
 import { resolveClaudeCodeModelId } from "../../utils/claude";
 import { logger } from "../../utils/logger";
 import { AnthropicErrorResponseSchema } from "../schemas/anthropic";
@@ -378,7 +382,7 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
       // 5. Send request to the VS Code LM API
       const response = await client.sendRequest(
         vsCodeLmMessages,
-        lmRequestOptions,
+        withCopilotLongContextConfiguration(client, lmRequestOptions),
         cancellationToken,
       );
 

--- a/src/test/server/modelResolution.test.ts
+++ b/src/test/server/modelResolution.test.ts
@@ -1,12 +1,35 @@
 import * as assert from "assert";
+import * as vscode from "vscode";
 
-import { jaccardSimilarity } from "../../utils/chatModels";
+import {
+  jaccardSimilarity,
+  withCopilotLongContextConfiguration,
+} from "../../utils/chatModels";
 import {
   resolveClaudeCodeModelId,
   withClaudeCode1mSuffix,
 } from "../../utils/claude";
 
 suite("Model Resolution Test Suite", () => {
+  function createMockModel(
+    overrides: Partial<vscode.LanguageModelChat>,
+  ): vscode.LanguageModelChat {
+    return {
+      id: "claude-opus-4.6-1m",
+      name: "Claude Opus 4.6 (1M context)",
+      family: "claude-opus-4.6-1m",
+      version: "4.6",
+      vendor: "copilot",
+      maxInputTokens: 936000,
+      capabilities: {},
+      sendRequest: async () => {
+        throw new Error("not implemented");
+      },
+      countTokens: async () => 0,
+      ...overrides,
+    } as vscode.LanguageModelChat;
+  }
+
   suite("resolveClaudeCodeModelId", () => {
     test("appends -1m-internal when context-1m beta header is present", () => {
       assert.strictEqual(
@@ -114,6 +137,66 @@ suite("Model Resolution Test Suite", () => {
       const oneM = jaccardSimilarity("claude-opus-4-6", "claude-opus-4.6-1m");
       assert.ok(base >= 0.3, `base (${base.toFixed(3)}) should be >= 0.3`);
       assert.ok(oneM >= 0.3, `1m (${oneM.toFixed(3)}) should be >= 0.3`);
+    });
+  });
+
+  suite("withCopilotLongContextConfiguration", () => {
+    test("adds contextSize for Copilot 1M models", () => {
+      const model = createMockModel({});
+      const result = withCopilotLongContextConfiguration(model, {
+        justification: "test",
+      }) as vscode.LanguageModelChatRequestOptions & {
+        configuration?: Record<string, unknown>;
+      };
+
+      assert.strictEqual(result.configuration?.contextSize, 936000);
+    });
+
+    test("does not change regular Copilot models", () => {
+      const model = createMockModel({
+        id: "claude-opus-4.6",
+        family: "claude-opus-4.6",
+        maxInputTokens: 200000,
+      });
+      const options: vscode.LanguageModelChatRequestOptions = {
+        justification: "test",
+      };
+
+      assert.strictEqual(
+        withCopilotLongContextConfiguration(model, options),
+        options,
+      );
+    });
+
+    test("does not change non-Claude 1M models", () => {
+      const model = createMockModel({
+        id: "gemini-3.5-flash-1m",
+        name: "Gemini 3.5 Flash 1M",
+        family: "gemini",
+      });
+      const options: vscode.LanguageModelChatRequestOptions = {
+        justification: "test",
+      };
+
+      assert.strictEqual(
+        withCopilotLongContextConfiguration(model, options),
+        options,
+      );
+    });
+
+    test("preserves existing private configuration", () => {
+      const model = createMockModel({});
+      const result = withCopilotLongContextConfiguration(model, {
+        justification: "test",
+        configuration: { reasoningEffort: "high" },
+      } as vscode.LanguageModelChatRequestOptions & {
+        configuration: Record<string, unknown>;
+      }) as vscode.LanguageModelChatRequestOptions & {
+        configuration?: Record<string, unknown>;
+      };
+
+      assert.strictEqual(result.configuration?.contextSize, 936000);
+      assert.strictEqual(result.configuration?.reasoningEffort, "high");
     });
   });
 });

--- a/src/utils/chatModels.ts
+++ b/src/utils/chatModels.ts
@@ -211,6 +211,57 @@ export const getChatModelsQuickPickItems = async (
   return modelOptions;
 };
 
+type LanguageModelChatRequestOptionsWithConfiguration =
+  vscode.LanguageModelChatRequestOptions & {
+    configuration?: Record<string, unknown>;
+  };
+
+function shouldUseCopilotLongContextConfiguration(
+  client: vscode.LanguageModelChat,
+): boolean {
+  if (client.vendor !== SUPPORTED_VENDOR || client.maxInputTokens <= 200_000) {
+    return false;
+  }
+
+  const modelText = [client.id, client.family, client.name]
+    .join(" ")
+    .toLowerCase();
+  return modelText.includes("1m") && modelText.includes("claude");
+}
+
+/**
+ * VS Code stores provider-specific model configuration separately from public
+ * `modelOptions`. Copilot uses `configuration.contextSize` to opt into the
+ * long-context tier, so pass the advertised max input size when a selected
+ * model exposes a larger context window than Copilot's default configuration.
+ */
+export function withCopilotLongContextConfiguration(
+  client: vscode.LanguageModelChat,
+  options: vscode.LanguageModelChatRequestOptions,
+): vscode.LanguageModelChatRequestOptions {
+  if (!shouldUseCopilotLongContextConfiguration(client)) {
+    return options;
+  }
+
+  const existingOptions =
+    options as LanguageModelChatRequestOptionsWithConfiguration;
+  // Copilot treats contextSize as the prompt/input budget; response tokens stay
+  // controlled separately by max_tokens/max_output_tokens in modelOptions.
+  const contextSize = client.maxInputTokens;
+
+  logger.debug(
+    `Using Copilot long-context configuration for ${client.id} (contextSize: ${contextSize})`,
+  );
+
+  return {
+    ...options,
+    configuration: {
+      ...existingOptions.configuration,
+      contextSize,
+    },
+  } as LanguageModelChatRequestOptionsWithConfiguration;
+}
+
 /**
  * Calculate Jaccard similarity between two strings based on character bigrams
  */


### PR DESCRIPTION
## Description

When sending requests to Copilot's 1M-context models (e.g., `claude-opus-4.6-1m`), VS Code's Language Model API currently falls back to a default prompt budget (typically ~200K) unless explicitly configured otherwise.

This PR addresses this by explicitly passing Copilot's `configuration.contextSize` parameter during the request, allowing these models to actually leverage their full 1M context windows.

## Key Changes

- **Opt-in for Long Context:** Added `withCopilotLongContextConfiguration` helper to detect Copilot Claude 1M models and automatically pass the model's advertised `maxInputTokens` as `configuration.contextSize`.
- **Targeted Application:** The helper safely targets only the Copilot vendor and explicitly checks for `"1m"` and `"claude"` in model identifiers. Standard models and other vendors are unaffected.
- **Configuration Preservation:** Ensures any existing private configurations on the request are preserved.
- **Comprehensive Testing:** Added a new test suite in `modelResolution.test.ts` to verify the configuration correctly targets 1M models, ignores non-1M/non-Claude models, and preserves existing configs.
- **Release Prep:** Includes the `v2.9.3` manifest and generated changelog update (which groups this patch with a recent Copilot usage metadata fix).