### PR TITLE
fix(proxy): pass Copilot context size to LM requests

### DIFF
--- a/.changeset/quiet-badgers-wave.md
+++ b/.changeset/quiet-badgers-wave.md
@@ -1,0 +1,5 @@
+---
+"agent-maestro": patch
+---
+
+Pass Copilot's advertised max input tokens as the VS Code context size for proxied model requests.

--- a/src/server/routes/anthropicRoutes.ts
+++ b/src/server/routes/anthropicRoutes.ts
@@ -7,7 +7,7 @@ import * as vscode from "vscode";
 import {
   chatModelsCache,
   getChatModelClient,
-  withCopilotLongContextConfiguration,
+  withCopilotContextSize,
 } from "../../utils/chatModels";
 import { resolveClaudeCodeModelId } from "../../utils/claude";
 import { logger } from "../../utils/logger";
@@ -382,7 +382,7 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
       // 5. Send request to the VS Code LM API
       const response = await client.sendRequest(
         vsCodeLmMessages,
-        withCopilotLongContextConfiguration(client, lmRequestOptions),
+        withCopilotContextSize(client, lmRequestOptions),
         cancellationToken,
       );
 

--- a/src/server/routes/geminiRoutes.ts
+++ b/src/server/routes/geminiRoutes.ts
@@ -4,7 +4,10 @@ import { Context } from "hono";
 import { streamSSE } from "hono/streaming";
 import * as vscode from "vscode";
 
-import { getChatModelClient } from "../../utils/chatModels";
+import {
+  getChatModelClient,
+  withCopilotContextSize,
+} from "../../utils/chatModels";
 import { logger } from "../../utils/logger";
 import {
   GeminiErrorResponseSchema,
@@ -349,7 +352,7 @@ export function registerGeminiRoutes(app: OpenAPIHono) {
       // 3. Send request to VSCode LM API
       const response = await client.sendRequest(
         vsCodeLmMessages,
-        lmRequestOptions,
+        withCopilotContextSize(client, lmRequestOptions),
         cancellationTokenSource.token,
       );
 
@@ -489,7 +492,7 @@ export function registerGeminiRoutes(app: OpenAPIHono) {
         const cancellationToken = cancellationTokenSource.token;
         const response = await client.sendRequest(
           vsCodeLmMessages,
-          lmRequestOptions,
+          withCopilotContextSize(client, lmRequestOptions),
           cancellationToken,
         );
 

--- a/src/server/routes/openai/openaiChatRoutes.ts
+++ b/src/server/routes/openai/openaiChatRoutes.ts
@@ -4,7 +4,10 @@ import { streamSSE } from "hono/streaming";
 import OpenAI from "openai";
 import * as vscode from "vscode";
 
-import { getChatModelClient } from "../../../utils/chatModels";
+import {
+  getChatModelClient,
+  withCopilotContextSize,
+} from "../../../utils/chatModels";
 import { logger } from "../../../utils/logger";
 import { CommonResponseError } from "../../schemas/openai";
 import { handleErrorWithLogging } from "../../utils/errorDiagnostics";
@@ -152,7 +155,7 @@ export function registerOpenaiChatRoutes(app: OpenAPIHono) {
       // 4. Send request to VSCode LM API
       const response = await client.sendRequest(
         vsCodeLmMessages,
-        lmRequestOptions,
+        withCopilotContextSize(client, lmRequestOptions),
         cancellationToken,
       );
 

--- a/src/server/routes/openai/openaiResponsesRoutes.ts
+++ b/src/server/routes/openai/openaiResponsesRoutes.ts
@@ -5,7 +5,10 @@ import OpenAI from "openai";
 import { ResponseUsage, Responses } from "openai/resources/responses/responses";
 import * as vscode from "vscode";
 
-import { getChatModelClient } from "../../../utils/chatModels";
+import {
+  getChatModelClient,
+  withCopilotContextSize,
+} from "../../../utils/chatModels";
 import { logger } from "../../../utils/logger";
 import { CommonResponseError } from "../../schemas/openai";
 import { handleErrorWithLogging } from "../../utils/errorDiagnostics";
@@ -258,7 +261,7 @@ export function registerOpenaiResponsesRoutes(app: OpenAPIHono) {
       // 8. Send request to VSCode LM
       const response = await client.sendRequest(
         vsCodeMessages,
-        lmRequestOptions,
+        withCopilotContextSize(client, lmRequestOptions),
         cancellationToken,
       );
 

--- a/src/test/server/modelResolution.test.ts
+++ b/src/test/server/modelResolution.test.ts
@@ -3,7 +3,7 @@ import * as vscode from "vscode";
 
 import {
   jaccardSimilarity,
-  withCopilotLongContextConfiguration,
+  withCopilotContextSize,
 } from "../../utils/chatModels";
 import {
   resolveClaudeCodeModelId,
@@ -140,10 +140,10 @@ suite("Model Resolution Test Suite", () => {
     });
   });
 
-  suite("withCopilotLongContextConfiguration", () => {
+  suite("withCopilotContextSize", () => {
     test("adds contextSize for Copilot 1M models", () => {
       const model = createMockModel({});
-      const result = withCopilotLongContextConfiguration(model, {
+      const result = withCopilotContextSize(model, {
         justification: "test",
       }) as vscode.LanguageModelChatRequestOptions & {
         configuration?: Record<string, unknown>;
@@ -152,41 +152,58 @@ suite("Model Resolution Test Suite", () => {
       assert.strictEqual(result.configuration?.contextSize, 936000);
     });
 
-    test("does not change regular Copilot models", () => {
+    test("adds contextSize for regular Copilot models", () => {
       const model = createMockModel({
         id: "claude-opus-4.6",
         family: "claude-opus-4.6",
         maxInputTokens: 200000,
       });
-      const options: vscode.LanguageModelChatRequestOptions = {
+      const result = withCopilotContextSize(model, {
         justification: "test",
+      }) as vscode.LanguageModelChatRequestOptions & {
+        configuration?: Record<string, unknown>;
       };
 
-      assert.strictEqual(
-        withCopilotLongContextConfiguration(model, options),
-        options,
-      );
+      assert.strictEqual(result.configuration?.contextSize, 200000);
     });
 
-    test("does not change non-Claude 1M models", () => {
-      const model = createMockModel({
-        id: "gemini-3.5-flash-1m",
-        name: "Gemini 3.5 Flash 1M",
-        family: "gemini",
-      });
+    test("does not change non-Copilot models", () => {
+      const model = createMockModel({ vendor: "custom" });
       const options: vscode.LanguageModelChatRequestOptions = {
         justification: "test",
       };
 
-      assert.strictEqual(
-        withCopilotLongContextConfiguration(model, options),
-        options,
-      );
+      assert.strictEqual(withCopilotContextSize(model, options), options);
+    });
+
+    test("does not change models without an advertised input size", () => {
+      const model = createMockModel({ maxInputTokens: 0 });
+      const options: vscode.LanguageModelChatRequestOptions = {
+        justification: "test",
+      };
+
+      assert.strictEqual(withCopilotContextSize(model, options), options);
+    });
+
+    test("adds contextSize for non-Claude long-context models", () => {
+      const model = createMockModel({
+        id: "gpt-5.5",
+        name: "GPT-5.5",
+        family: "gpt-5.5",
+        maxInputTokens: 921793,
+      });
+      const result = withCopilotContextSize(model, {
+        justification: "test",
+      }) as vscode.LanguageModelChatRequestOptions & {
+        configuration?: Record<string, unknown>;
+      };
+
+      assert.strictEqual(result.configuration?.contextSize, 921793);
     });
 
     test("preserves existing private configuration", () => {
       const model = createMockModel({});
-      const result = withCopilotLongContextConfiguration(model, {
+      const result = withCopilotContextSize(model, {
         justification: "test",
         configuration: { reasoningEffort: "high" },
       } as vscode.LanguageModelChatRequestOptions & {

--- a/src/utils/chatModels.ts
+++ b/src/utils/chatModels.ts
@@ -216,30 +216,16 @@ type LanguageModelChatRequestOptionsWithConfiguration =
     configuration?: Record<string, unknown>;
   };
 
-function shouldUseCopilotLongContextConfiguration(
-  client: vscode.LanguageModelChat,
-): boolean {
-  if (client.vendor !== SUPPORTED_VENDOR || client.maxInputTokens <= 200_000) {
-    return false;
-  }
-
-  const modelText = [client.id, client.family, client.name]
-    .join(" ")
-    .toLowerCase();
-  return modelText.includes("1m") && modelText.includes("claude");
-}
-
 /**
  * VS Code stores provider-specific model configuration separately from public
- * `modelOptions`. Copilot uses `configuration.contextSize` to opt into the
- * long-context tier, so pass the advertised max input size when a selected
- * model exposes a larger context window than Copilot's default configuration.
+ * `modelOptions`. Copilot uses `configuration.contextSize` as the prompt/input
+ * budget, so pass through the model's advertised max input size.
  */
-export function withCopilotLongContextConfiguration(
+export function withCopilotContextSize(
   client: vscode.LanguageModelChat,
   options: vscode.LanguageModelChatRequestOptions,
 ): vscode.LanguageModelChatRequestOptions {
-  if (!shouldUseCopilotLongContextConfiguration(client)) {
+  if (client.vendor !== SUPPORTED_VENDOR || client.maxInputTokens <= 0) {
     return options;
   }
 
@@ -249,9 +235,7 @@ export function withCopilotLongContextConfiguration(
   // controlled separately by max_tokens/max_output_tokens in modelOptions.
   const contextSize = client.maxInputTokens;
 
-  logger.debug(
-    `Using Copilot long-context configuration for ${client.id} (contextSize: ${contextSize})`,
-  );
+  logger.debug(`Setting Copilot contextSize=${contextSize} for ${client.id}`);
 
   return {
     ...options,


### PR DESCRIPTION
## Summary
- Pass Copilot model maxInputTokens through as VS Code configuration.contextSize for proxied LM requests
- Apply the context-size helper across Anthropic, Gemini, OpenAI chat, and OpenAI Responses routes
- Cover regular Copilot, long-context, non-Copilot, zero-token, and configuration-merge cases in tests

## Test Plan
- [x] pnpm check-types
- [x] pnpm lint

## Notes
- VS Code/Copilot maps configuration.contextSize to the prompt/input budget shown as maxPromptTokens. Response tokens remain controlled separately by max_tokens/max_output_tokens.
- Includes changeset: .changeset/quiet-badgers-wave.md