### PR TITLE
fix(proxy): forward reasoning effort to Copilot configuration

### DIFF
--- a/.changeset/loud-windows-think.md
+++ b/.changeset/loud-windows-think.md
@@ -1,0 +1,5 @@
+---
+"agent-maestro": patch
+---
+
+Forward reasoning effort settings to Copilot for OpenAI and Anthropic proxy requests. OpenAI-backed models apply the setting today; Claude/Anthropic requests forward it but require upstream Copilot support to take effect.

--- a/README.md
+++ b/README.md
@@ -257,6 +257,8 @@ Perfect for GitHub Copilot and Claude Code integration:
 - **`POST /api/anthropic/v1/messages`** - Anthropic Claude API compatibility using VS Code's Language Model API
 - **`POST /api/anthropic/v1/messages/count_tokens`** - Token counting for Anthropic-compatible messages
 
+> **Reasoning effort**: `output_config.effort` is forwarded to Copilot but is not yet applied to Anthropic Messages requests, pending upstream Copilot support. It currently has no effect for Claude models.
+
 ### OpenAI-Compatible Endpoints
 
 Perfect for Codex and OpenAI model integration:
@@ -271,6 +273,8 @@ Perfect for Gemini CLI integration:
 - **`POST /api/gemini/v1beta/models/{model}:generateContent`** - Google Gemini API compatibility using VS Code's Language Model API
 - **`POST /api/gemini/v1beta/models/{model}:streamGenerateContent`** - Streaming support for Gemini API
 - **`POST /api/gemini/v1beta/models/{model}:countTokens`** - Token counting for Gemini-compatible messages
+
+> **Thinking levels**: Not forwarded for Gemini. Copilot's Gemini path does not read the `thinkingConfig.thinkingLevel` parameter from the model configuration; it only applies a hardcoded `low` effort behind an internal experiment flag, so any forwarded value would be ignored.
 
 ### RooCode Agent Routes
 

--- a/src/server/routes/anthropicRoutes.ts
+++ b/src/server/routes/anthropicRoutes.ts
@@ -7,7 +7,8 @@ import * as vscode from "vscode";
 import {
   chatModelsCache,
   getChatModelClient,
-  withCopilotContextSize,
+  getCopilotModelConfiguration,
+  withCopilotConfiguration,
 } from "../../utils/chatModels";
 import { logger } from "../../utils/logger";
 import { AnthropicErrorResponseSchema } from "../schemas/anthropic";
@@ -334,6 +335,7 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
         messages,
         tools,
         tool_choice,
+        output_config,
         ...msgCreateParams
       } = requestBody;
       // 1. Get chat model client (handles model mapping internally)
@@ -371,11 +373,19 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
         tools: convertAnthropicToolToVSCode(tools),
         toolMode: convertAnthropicToolChoiceToVSCode(tool_choice),
       };
+      const copilotConfiguration = getCopilotModelConfiguration({
+        reasoningEffort: (output_config as { effort?: unknown } | undefined)
+          ?.effort,
+      });
 
       // 5. Send request to the VS Code LM API
       const response = await client.sendRequest(
         vsCodeLmMessages,
-        withCopilotContextSize(client, lmRequestOptions),
+        withCopilotConfiguration(
+          client,
+          lmRequestOptions,
+          copilotConfiguration,
+        ),
         cancellationToken,
       );
 

--- a/src/server/routes/anthropicRoutes.ts
+++ b/src/server/routes/anthropicRoutes.ts
@@ -373,9 +373,11 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
         tools: convertAnthropicToolToVSCode(tools),
         toolMode: convertAnthropicToolChoiceToVSCode(tool_choice),
       };
+      // Forwarded to Copilot, but Copilot's Anthropic Messages path does not yet
+      // apply reasoning effort to the outgoing request, so this is a no-op until
+      // upstream support lands. Keep forwarding so it works once it does.
       const copilotConfiguration = getCopilotModelConfiguration({
-        reasoningEffort: (output_config as { effort?: unknown } | undefined)
-          ?.effort,
+        reasoningEffort: output_config?.effort,
       });
 
       // 5. Send request to the VS Code LM API

--- a/src/server/routes/geminiRoutes.ts
+++ b/src/server/routes/geminiRoutes.ts
@@ -6,7 +6,7 @@ import * as vscode from "vscode";
 
 import {
   getChatModelClient,
-  withCopilotContextSize,
+  withCopilotConfiguration,
 } from "../../utils/chatModels";
 import { logger } from "../../utils/logger";
 import {
@@ -352,7 +352,7 @@ export function registerGeminiRoutes(app: OpenAPIHono) {
       // 3. Send request to VSCode LM API
       const response = await client.sendRequest(
         vsCodeLmMessages,
-        withCopilotContextSize(client, lmRequestOptions),
+        withCopilotConfiguration(client, lmRequestOptions),
         cancellationTokenSource.token,
       );
 
@@ -492,7 +492,7 @@ export function registerGeminiRoutes(app: OpenAPIHono) {
         const cancellationToken = cancellationTokenSource.token;
         const response = await client.sendRequest(
           vsCodeLmMessages,
-          withCopilotContextSize(client, lmRequestOptions),
+          withCopilotConfiguration(client, lmRequestOptions),
           cancellationToken,
         );
 

--- a/src/server/routes/geminiRoutes.ts
+++ b/src/server/routes/geminiRoutes.ts
@@ -350,6 +350,7 @@ export function registerGeminiRoutes(app: OpenAPIHono) {
       );
 
       // 3. Send request to VSCode LM API
+      // No Gemini request field is currently mapped to Copilot reasoning effort.
       const response = await client.sendRequest(
         vsCodeLmMessages,
         withCopilotConfiguration(client, lmRequestOptions),
@@ -489,6 +490,7 @@ export function registerGeminiRoutes(app: OpenAPIHono) {
         );
 
         // 3. Send request to VSCode LM API
+        // No Gemini request field is currently mapped to Copilot reasoning effort.
         const cancellationToken = cancellationTokenSource.token;
         const response = await client.sendRequest(
           vsCodeLmMessages,

--- a/src/server/routes/openai/openaiChatRoutes.ts
+++ b/src/server/routes/openai/openaiChatRoutes.ts
@@ -6,7 +6,8 @@ import * as vscode from "vscode";
 
 import {
   getChatModelClient,
-  withCopilotContextSize,
+  getCopilotModelConfiguration,
+  withCopilotConfiguration,
 } from "../../../utils/chatModels";
 import { logger } from "../../../utils/logger";
 import { CommonResponseError } from "../../schemas/openai";
@@ -110,10 +111,16 @@ export function registerOpenaiChatRoutes(app: OpenAPIHono) {
         stream = false,
         tools,
         tool_choice,
+        reasoning_effort: reasoningEffort,
+        // Copilot manages prompt caching internally instead of using prompt_cache_key
+        prompt_cache_key: _cacheKey,
         ...otherParams
       } = requestBody;
-      const { prompt_cache_key: _promptCacheKey, ...modelOptions } =
-        otherParams as Record<string, unknown>;
+
+      const modelOptions = otherParams as Record<string, unknown>;
+      const copilotConfiguration = getCopilotModelConfiguration({
+        reasoningEffort,
+      });
       requestedModelId = modelId;
 
       // 1. Get chat model client
@@ -155,7 +162,11 @@ export function registerOpenaiChatRoutes(app: OpenAPIHono) {
       // 4. Send request to VSCode LM API
       const response = await client.sendRequest(
         vsCodeLmMessages,
-        withCopilotContextSize(client, lmRequestOptions),
+        withCopilotConfiguration(
+          client,
+          lmRequestOptions,
+          copilotConfiguration,
+        ),
         cancellationToken,
       );
 

--- a/src/server/routes/openai/openaiResponsesRoutes.ts
+++ b/src/server/routes/openai/openaiResponsesRoutes.ts
@@ -7,7 +7,8 @@ import * as vscode from "vscode";
 
 import {
   getChatModelClient,
-  withCopilotContextSize,
+  getCopilotModelConfiguration,
+  withCopilotConfiguration,
 } from "../../../utils/chatModels";
 import { logger } from "../../../utils/logger";
 import { CommonResponseError } from "../../schemas/openai";
@@ -143,10 +144,12 @@ export function registerOpenaiResponsesRoutes(app: OpenAPIHono) {
         include: _include,
         background: _background,
         prompt: _prompt,
+        // Copilot manages prompt caching internally instead of using prompt_cache_key
         prompt_cache_key: _cacheKey,
         service_tier: _serviceTier,
         user: _user,
         safety_identifier: _safetyId,
+        reasoning: responseReasoning,
         // Remaining params passed through as modelOptions
         ...otherParams
       } = requestBody;
@@ -257,11 +260,18 @@ export function registerOpenaiResponsesRoutes(app: OpenAPIHono) {
           ? convertToolChoice(tool_choice as ToolChoice)
           : undefined,
       };
+      const copilotConfiguration = getCopilotModelConfiguration({
+        reasoningEffort: responseReasoning?.effort,
+      });
 
       // 8. Send request to VSCode LM
       const response = await client.sendRequest(
         vsCodeMessages,
-        withCopilotContextSize(client, lmRequestOptions),
+        withCopilotConfiguration(
+          client,
+          lmRequestOptions,
+          copilotConfiguration,
+        ),
         cancellationToken,
       );
 

--- a/src/test/server/modelResolution.test.ts
+++ b/src/test/server/modelResolution.test.ts
@@ -2,8 +2,10 @@ import * as assert from "assert";
 import * as vscode from "vscode";
 
 import {
+  type CopilotModelConfiguration,
+  getCopilotModelConfiguration,
   jaccardSimilarity,
-  withCopilotContextSize,
+  withCopilotConfiguration,
 } from "../../utils/chatModels";
 import { withClaudeCode1mSuffix } from "../../utils/claude";
 
@@ -94,13 +96,13 @@ suite("Model Resolution Test Suite", () => {
     });
   });
 
-  suite("withCopilotContextSize", () => {
+  suite("withCopilotConfiguration", () => {
     test("adds contextSize for Copilot 1M models", () => {
       const model = createMockModel({});
-      const result = withCopilotContextSize(model, {
+      const result = withCopilotConfiguration(model, {
         justification: "test",
       }) as vscode.LanguageModelChatRequestOptions & {
-        configuration?: Record<string, unknown>;
+        configuration?: CopilotModelConfiguration;
       };
 
       assert.strictEqual(result.configuration?.contextSize, 936000);
@@ -112,10 +114,10 @@ suite("Model Resolution Test Suite", () => {
         family: "claude-opus-4.6",
         maxInputTokens: 200000,
       });
-      const result = withCopilotContextSize(model, {
+      const result = withCopilotConfiguration(model, {
         justification: "test",
       }) as vscode.LanguageModelChatRequestOptions & {
-        configuration?: Record<string, unknown>;
+        configuration?: CopilotModelConfiguration;
       };
 
       assert.strictEqual(result.configuration?.contextSize, 200000);
@@ -127,7 +129,7 @@ suite("Model Resolution Test Suite", () => {
         justification: "test",
       };
 
-      assert.strictEqual(withCopilotContextSize(model, options), options);
+      assert.strictEqual(withCopilotConfiguration(model, options), options);
     });
 
     test("does not change models without an advertised input size", () => {
@@ -136,7 +138,7 @@ suite("Model Resolution Test Suite", () => {
         justification: "test",
       };
 
-      assert.strictEqual(withCopilotContextSize(model, options), options);
+      assert.strictEqual(withCopilotConfiguration(model, options), options);
     });
 
     test("adds contextSize for non-Claude long-context models", () => {
@@ -146,28 +148,44 @@ suite("Model Resolution Test Suite", () => {
         family: "gpt-5.5",
         maxInputTokens: 921793,
       });
-      const result = withCopilotContextSize(model, {
+      const result = withCopilotConfiguration(model, {
         justification: "test",
       }) as vscode.LanguageModelChatRequestOptions & {
-        configuration?: Record<string, unknown>;
+        configuration?: CopilotModelConfiguration;
       };
 
       assert.strictEqual(result.configuration?.contextSize, 921793);
     });
 
-    test("preserves existing private configuration", () => {
+    test("merges request-specific Copilot configuration", () => {
       const model = createMockModel({});
-      const result = withCopilotContextSize(model, {
-        justification: "test",
-        configuration: { reasoningEffort: "high" },
-      } as vscode.LanguageModelChatRequestOptions & {
-        configuration: Record<string, unknown>;
-      }) as vscode.LanguageModelChatRequestOptions & {
-        configuration?: Record<string, unknown>;
+      const result = withCopilotConfiguration(
+        model,
+        { justification: "test" },
+        { reasoningEffort: "medium" },
+      ) as vscode.LanguageModelChatRequestOptions & {
+        configuration?: CopilotModelConfiguration;
       };
 
       assert.strictEqual(result.configuration?.contextSize, 936000);
-      assert.strictEqual(result.configuration?.reasoningEffort, "high");
+      assert.strictEqual(result.configuration?.reasoningEffort, "medium");
+    });
+  });
+
+  suite("getCopilotModelConfiguration", () => {
+    test("extracts reasoningEffort from a non-empty string", () => {
+      assert.deepStrictEqual(
+        getCopilotModelConfiguration({ reasoningEffort: " high " }),
+        { reasoningEffort: "high" },
+      );
+    });
+
+    test("ignores missing or non-string reasoning effort values", () => {
+      assert.deepStrictEqual(getCopilotModelConfiguration({}), {});
+      assert.deepStrictEqual(
+        getCopilotModelConfiguration({ reasoningEffort: 1 }),
+        {},
+      );
     });
   });
 });

--- a/src/utils/chatModels.ts
+++ b/src/utils/chatModels.ts
@@ -214,39 +214,71 @@ export const getChatModelsQuickPickItems = async (
   return modelOptions;
 };
 
-type LanguageModelChatRequestOptionsWithConfiguration =
-  vscode.LanguageModelChatRequestOptions & {
-    configuration?: Record<string, unknown>;
-  };
+export type CopilotReasoningEffort =
+  | "none"
+  | "minimal"
+  | "low"
+  | "medium"
+  | "high"
+  | "xhigh"
+  | "max"
+  | (string & {});
+
+export interface CopilotModelConfiguration {
+  /** Prompt/input token budget used by Copilot for this request. */
+  contextSize?: number;
+  /** Thinking/reasoning effort level, validated by Copilot against the selected model. */
+  reasoningEffort?: CopilotReasoningEffort;
+  [key: string]: unknown;
+}
+
+interface ChatRequestOptionsWithConfig
+  extends vscode.LanguageModelChatRequestOptions {
+  configuration?: CopilotModelConfiguration;
+}
+
+export function getCopilotModelConfiguration({
+  reasoningEffort,
+}: {
+  reasoningEffort?: unknown;
+}): CopilotModelConfiguration {
+  const configuration: CopilotModelConfiguration = {};
+  if (typeof reasoningEffort === "string" && reasoningEffort.trim()) {
+    configuration.reasoningEffort = reasoningEffort.trim();
+  }
+  return configuration;
+}
 
 /**
  * VS Code stores provider-specific model configuration separately from public
- * `modelOptions`. Copilot uses `configuration.contextSize` as the prompt/input
- * budget, so pass through the model's advertised max input size.
+ * `modelOptions`. Copilot reads this bag for settings like context size and
+ * reasoning effort.
  */
-export function withCopilotContextSize(
+export function withCopilotConfiguration(
   client: vscode.LanguageModelChat,
   options: vscode.LanguageModelChatRequestOptions,
+  configuration: CopilotModelConfiguration = {},
 ): vscode.LanguageModelChatRequestOptions {
   if (client.vendor !== SUPPORTED_VENDOR || client.maxInputTokens <= 0) {
     return options;
   }
 
-  const existingOptions =
-    options as LanguageModelChatRequestOptionsWithConfiguration;
   // Copilot treats contextSize as the prompt/input budget; response tokens stay
   // controlled separately by max_tokens/max_output_tokens in modelOptions.
   const contextSize = client.maxInputTokens;
+  const copilotConfiguration: CopilotModelConfiguration = {
+    ...configuration,
+    contextSize,
+  };
 
-  logger.debug(`Setting Copilot contextSize=${contextSize} for ${client.id}`);
+  logger.debug(
+    `Setting Copilot configuration for ${client.id}: contextSize=${copilotConfiguration.contextSize}, reasoningEffort=${copilotConfiguration.reasoningEffort ?? "default"}`,
+  );
 
   return {
     ...options,
-    configuration: {
-      ...existingOptions.configuration,
-      contextSize,
-    },
-  } as LanguageModelChatRequestOptionsWithConfiguration;
+    configuration: copilotConfiguration,
+  } as ChatRequestOptionsWithConfig;
 }
 
 /**


### PR DESCRIPTION
## Summary
- forward OpenAI Chat `reasoning_effort`, OpenAI Responses `reasoning.effort`, and Anthropic `output_config.effort` into Copilot model configuration
- rename the Copilot context helper to cover both context size and request-specific configuration
- strip raw effort fields from OpenAI modelOptions so Copilot configuration is the single path for the setting
- add focused coverage for Copilot configuration merging and reasoning effort extraction

## Notes
- OpenAI-backed Copilot models apply the forwarded effort end-to-end today.
- Claude/Anthropic requests now forward the setting to Copilot, but Anthropic Messages currently requires upstream Copilot support before the setting takes effect in the outgoing request body.

## Test plan
- [x] pnpm check-types
- [x] pnpm lint
- [x] git diff --check main...HEAD
