### PR TITLE
chore(release): v2.9.6

### DIFF
--- a/.changeset/loud-windows-think.md
+++ b/.changeset/loud-windows-think.md
@@ -1,5 +1,0 @@
----
-"agent-maestro": patch
----
-
-Forward reasoning effort settings to Copilot for OpenAI and Anthropic proxy requests. OpenAI-backed models apply the setting today; Claude/Anthropic requests forward it but require upstream Copilot support to take effect.

--- a/.changeset/spicy-mimes-collide.md
+++ b/.changeset/spicy-mimes-collide.md
@@ -1,5 +1,0 @@
----
-"agent-maestro": patch
----
-
-Fix images sent to Copilot vision models being rejected as a media-type mismatch (e.g. "specified image/jpeg, but the image appears to be image/png"). The VS Code Language Model API re-encodes images to PNG when both dimensions exceed 768px without updating their declared MIME type; Agent Maestro now relabels affected images so the type matches the bytes. Applies to the Anthropic, OpenAI Chat, OpenAI Responses, and Gemini routes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.9.6 - 2026.06.23
+
+- Forward reasoning effort settings to Copilot for OpenAI and Anthropic proxy requests. OpenAI-backed models apply the setting today; Claude/Anthropic requests forward it but require upstream Copilot support to take effect.
+- Fix images sent to Copilot vision models being rejected as a media-type mismatch (e.g. "specified image/jpeg, but the image appears to be image/png"). The VS Code Language Model API re-encodes images to PNG when both dimensions exceed 768px without updating their declared MIME type; Agent Maestro now relabels affected images so the type matches the bytes. Applies to the Anthropic, OpenAI Chat, OpenAI Responses, and Gemini routes.
+
 ## v2.9.5 - 2026.06.10
 
 - Fix Claude Code 1M model routing to preserve requested model IDs instead of rewriting them to synthetic internal Copilot variants.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "agent-maestro",
   "displayName": "Agent Maestro",
   "description": "Turn VS Code into your compliant AI playground! With Agent Maestro, spin up Cline or Roo on demand and plug Claude Code or Codex straight in through an OpenAI/Anthropic-compatible API.",
-  "version": "2.9.5",
+  "version": "2.9.6",
   "icon": "assets/icons/icon.png",
   "publisher": "Joouis",
   "repository": "https://github.com/Joouis/agent-maestro",


### PR DESCRIPTION
## Summary

Release **v2.9.6**. Consumes two changesets and bumps the version.

- **Reasoning effort forwarding** (#198) — Forward reasoning effort settings to Copilot for OpenAI and Anthropic proxy requests. OpenAI-backed models apply the setting today; Claude/Anthropic requests forward it but require upstream Copilot support to take effect.
- **Image media-type relabel fix** (#199) — Fix images sent to Copilot vision models being rejected as a media-type mismatch (e.g. `specified image/jpeg, but the image appears to be image/png`). The VS Code Language Model API re-encodes images to PNG when both dimensions exceed 768px without updating their declared MIME type; Agent Maestro now relabels affected images so the type matches the bytes. Applies to the Anthropic, OpenAI Chat, OpenAI Responses, and Gemini routes.

## Changes

- Bump version `2.9.5` → `2.9.6`
- Add `v2.9.6` section to `CHANGELOG.md`
- Remove the two consumed changesets

🤖 Generated with [Claude Code](https://claude.com/claude-code)