### PR TITLE
fix(anthropic): label image parts by real bytes, not force-PNG for large images

### DIFF
--- a/.changeset/image-mime-follow-bytes.md
+++ b/.changeset/image-mime-follow-bytes.md
@@ -1,0 +1,5 @@
+---
+"agent-maestro": patch
+---
+
+Fix images sent to Copilot vision models being rejected as a media-type mismatch (e.g. "specified image/png, but the image appears to be image/jpeg"). The image MIME label now always follows the real bytes (magic-byte sniff, then `image-size`, then the declared type) instead of force-labeling large images as PNG, which broke on VS Code builds that no longer re-encode large images to PNG. Signature detection also handles short-but-valid headers. Applies to the Anthropic, OpenAI Chat, OpenAI Responses, and Gemini routes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ Primary language: **TypeScript** (ESM, Node ≥ 22, VS Code ≥ 1.100). Package 
 
 ## Known upstream (VS Code) issues
 
-- **Image MIME re-encode** — the VS Code LM API re-encodes images to PNG when both dimensions exceed 768px without updating their declared MIME type, which breaks providers that sniff bytes (e.g. Anthropic vision). Worked around in `src/server/utils/imageMime.ts`. **Re-check this whenever bumping `engines.vscode`** — if upstream starts preserving the source format, the workaround must be removed or it will cause a new mismatch. See `docs/vscode-image-mime-defect.md`.
+- **Image MIME labeling** — providers that sniff image bytes (e.g. Anthropic vision) reject any byte/label mismatch. `src/server/utils/imageMime.ts` makes the declared MIME follow the real bytes (magic-byte sniff, then `image-size`, then the declared type); it no longer relabels large images to PNG. **Re-check whenever bumping `engines.vscode`** — if a VS Code build is found to still re-encode large images to PNG on the LM API path (`mainThreadLanguageModels.ts` -> `resizeImage` with no mimeType), the fix is to transcode the buffer to PNG there, not to relabel. See `docs/vscode-image-mime-defect.md`.
 
 ## Commands
 

--- a/docs/vscode-image-mime-defect.md
+++ b/docs/vscode-image-mime-defect.md
@@ -1,78 +1,70 @@
-# VS Code LM API image MIME re-encode defect
+# VS Code LM API image MIME handling
 
 ## Summary
 
-The VS Code Language Model API silently re-encodes images to PNG when sending
-them to a model provider, but does **not** update the part's declared MIME type.
-Providers that validate image bytes against the declared type (notably Anthropic)
-reject the request:
+Providers that validate image bytes against the declared MIME type (notably
+Anthropic vision) reject any request where the two disagree:
 
 ```
 messages.0.content.4.image.source.base64: The image was specified using the
-image/jpeg media type, but the image appears to be a image/png image
+image/png media type, but the image appears to be a image/jpeg image
 ```
 
-This affects every proxy route that forwards images to Copilot vision models:
-Anthropic (`/v1/messages`), OpenAI Chat, OpenAI Responses, and Gemini.
+Two independent things can cause that mismatch on the proxy routes that forward
+images to Copilot vision models (Anthropic `/v1/messages`, OpenAI Chat, OpenAI
+Responses, Gemini):
 
-(The same error can also originate from a client that mislabels its bytes —
-e.g. PNG data under an `image/jpeg` label. The workaround below handles both,
-since both reduce to "declared type disagrees with bytes".)
+1. A client mislabels its bytes (e.g. JPEG bytes under an `image/png` label).
+2. Historically, the VS Code LM API re-encoded large images to PNG without
+   updating the declared MIME type (see the version note below).
 
-## Root cause (VS Code side)
-
-On the request path, `mainThreadLanguageModels.ts` runs every `image_url` part
-through `resizeImage()` (`vs/workbench/contrib/chat/browser/chatImageUtils.ts`):
-
-- `resizeImage(data)` is called **without** the source MIME type.
-- With no MIME, the canvas re-encode always picks `image/png`
-  (`outputMimeType = mimeType && jpegTypes.includes(mimeType) ? 'image/jpeg' : 'image/png'`).
-- The part's `mimeType` field is left untouched at its original value.
-
-The resize only triggers when **both** dimensions exceed 768px — the early
-return is `(width <= 768 || height <= 768)`. This is uniform across formats on
-the LM API path:
-
-| Input               | VS Code behavior               | Result                        |
-| ------------------- | ------------------------------ | ----------------------------- |
-| Either side ≤ 768px | passes through verbatim        | label must match bytes        |
-| Both sides > 768px  | re-encodes to PNG, keeps label | **mismatch unless relabeled** |
-
-PNG inputs are unaffected because the forced PNG output happens to match the
-PNG label. (`resizeImage()` has an `isGif` branch that re-encodes GIFs at any
-size, but the LM API path never passes a mimeType, so it never fires here.)
-
-## Workaround (this repo)
+## Current behavior (this repo)
 
 `src/server/utils/imageMime.ts` exports `mimeForVscodeLm(buffer, originalMime)`,
-applied at all four image-construction sites. It sniffs the real format from the
-bytes (header-only, via `image-size`, which also yields the dimensions) and
-returns:
+applied at all image-construction sites. It makes the declared type follow the
+bytes we actually forward, since those bytes pass through unchanged:
 
-- both sides > 768px → `image/png` (VS Code will re-encode it to PNG)
-- otherwise → the **sniffed** true MIME type (the bytes pass through unchanged)
-- bytes not recognizable as an image → fall back to the declared `originalMime`
+1. sniff the real format from the leading magic bytes (JPEG/PNG/GIF/WebP/BMP) —
+   the most reliable signal;
+2. otherwise use the format reported by `image-size`;
+3. otherwise fall back to the declared `originalMime`.
 
-Using the sniffed type for the pass-through case fixes a second, independent
-source of mismatch: a client that mislabels the bytes (e.g. PNG bytes under an
-`image/jpeg` label). Such an image, if small enough to skip VS Code's re-encode,
-would otherwise ship the wrong label unchanged and be rejected. Trusting the
-bytes over the caller's label corrects both that and the VS Code re-encode in
-one rule.
+There is **no size-based relabeling**. The label is purely a function of the
+bytes, which fixes the client-mislabel case at any size and never invents a
+type the bytes don't have.
 
-This makes the declared type match the bytes the provider actually receives.
+## History: the VS Code re-encode defect
 
-## ⚠️ When VS Code fixes this, revisit the workaround
+Earlier, on the request path, `mainThreadLanguageModels.ts` ran every
+`image_url` part through `resizeImage()`
+(`vs/workbench/contrib/chat/browser/chatImageUtils.ts`) **without** the source
+MIME type. With no MIME the canvas re-encode picked `image/png`, and the part's
+`mimeType` field was left untouched — so a large JPEG/WebP arrived at the
+provider as PNG bytes under a non-PNG label. The resize only triggered when
+**both** dimensions exceeded 768px (early return `(width <= 768 || height <= 768)`).
 
-The **re-encode half** is coupled to the VS Code defect. If VS Code starts
-preserving the source format (e.g. passing the MIME into `resizeImage`, or
-re-encoding JPEG as JPEG), then forcing `image/png` for large JPEG/WebP becomes
-a _new_ mismatch.
+To match that, `imageMime.ts` used to force `image/png` for any image with both
+sides > 768px. That branch has been removed:
 
-Check this whenever bumping the VS Code engine (`engines.vscode` in
-`package.json`). If the upstream resize path preserves format, drop the
-`width/height > 768 → image/png` branch. The **byte-sniffing half** (returning
-the sniffed true type) is not VS Code-specific and should stay — it guards
-against mislabeled client input regardless of the resize behavior.
+- VS Code's `resizeImage` now takes a `mimeType` and preserves the source format
+  when one is supplied
+  (`outputMimeType = mimeType && jpegTypes.includes(mimeType) ? 'image/jpeg' : 'image/png'`).
+- On observed builds, large JPEG/WebP images are no longer delivered as PNG
+  bytes on this path, so force-labeling to PNG produced a **new** mismatch
+  (PNG label on JPEG bytes) — the exact failure this workaround exists to avoid.
+
+## ⚠️ Version dependency — re-check when bumping `engines.vscode`
+
+The upstream caller `mainThreadLanguageModels.ts` still invokes
+`resizeImage(part.value.data.buffer)` **without** a mimeType on the LM API path.
+Whether a given VS Code build actually re-encodes large images to PNG there
+therefore depends on the exact build.
+
+- If a build is found to **still** re-encode large images to PNG on this path,
+  following the original bytes is wrong for those images. The correct fix is to
+  **transcode the buffer to PNG** in `imageMime.ts` (so bytes and label are both
+  PNG), **not** to relabel bytes we don't convert.
+- The byte-sniffing itself is not VS Code-specific and should stay regardless —
+  it guards against mislabeled client input.
 
 Tests: `src/test/utils/imageMime.test.ts` (fixtures in `imageMime.fixtures.ts`).

--- a/src/server/utils/imageMime.ts
+++ b/src/server/utils/imageMime.ts
@@ -14,47 +14,45 @@ const TYPE_TO_MIME: Record<string, string> = {
 /**
  * Sniff the true image format from the leading magic bytes.
  *
- * This is the most reliable signal we have and is independent of both the
- * caller's declared label and `image-size`'s dimension parsing. Returns
- * `undefined` when the buffer does not start with a recognized signature.
+ * Each signature is length-checked independently so short-but-valid buffers
+ * (a 3-byte JPEG/GIF header, a 2-byte BMP header) are still recognized; only
+ * WebP needs the full 12-byte `RIFF....WEBP` prefix. Returns `undefined` when
+ * the buffer matches no known signature.
  */
 function sniffMimeFromBytes(buffer: Buffer): string | undefined {
-  if (!buffer || buffer.length < 12) {
+  if (!buffer || buffer.length < 2) {
     return undefined;
   }
 
+  const at = (i: number, v: number) => buffer.length > i && buffer[i] === v;
+
   // JPEG: FF D8 FF
-  if (buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff) {
+  if (at(0, 0xff) && at(1, 0xd8) && at(2, 0xff)) {
     return "image/jpeg";
   }
   // PNG: 89 50 4E 47
-  if (
-    buffer[0] === 0x89 &&
-    buffer[1] === 0x50 &&
-    buffer[2] === 0x4e &&
-    buffer[3] === 0x47
-  ) {
+  if (at(0, 0x89) && at(1, 0x50) && at(2, 0x4e) && at(3, 0x47)) {
     return "image/png";
   }
   // GIF: 47 49 46
-  if (buffer[0] === 0x47 && buffer[1] === 0x49 && buffer[2] === 0x46) {
+  if (at(0, 0x47) && at(1, 0x49) && at(2, 0x46)) {
     return "image/gif";
   }
   // WebP: RIFF....WEBP
   if (
-    buffer[0] === 0x52 &&
-    buffer[1] === 0x49 &&
-    buffer[2] === 0x46 &&
-    buffer[3] === 0x46 &&
-    buffer[8] === 0x57 &&
-    buffer[9] === 0x45 &&
-    buffer[10] === 0x42 &&
-    buffer[11] === 0x50
+    at(0, 0x52) &&
+    at(1, 0x49) &&
+    at(2, 0x46) &&
+    at(3, 0x46) &&
+    at(8, 0x57) &&
+    at(9, 0x45) &&
+    at(10, 0x42) &&
+    at(11, 0x50)
   ) {
     return "image/webp";
   }
   // BMP: 42 4D
-  if (buffer[0] === 0x42 && buffer[1] === 0x4d) {
+  if (at(0, 0x42) && at(1, 0x4d)) {
     return "image/bmp";
   }
 
@@ -68,20 +66,21 @@ function sniffMimeFromBytes(buffer: Buffer): string | undefined {
  * that sniff the payload (Anthropic) reject any byte/label mismatch ("specified
  * image/png, but the image appears to be image/jpeg").
  *
- * We therefore trust the real bytes over the caller's declared label:
+ * Because the bytes are forwarded unchanged, the label simply follows them:
  *   1. magic-byte signature (most reliable) — used whenever recognized;
  *   2. otherwise the format reported by `image-size`;
  *   3. otherwise fall back to the declared mimeType.
  *
- * NOTE: An earlier version force-labeled any image whose width AND height
- * exceeded 768px as `image/png`, on the assumption that the VS Code LM API
- * re-encodes large images to PNG (`mainThreadLanguageModels.ts` →
- * `resizeImage`) while leaving the label untouched. That assumption no longer
- * holds — when VS Code does not re-encode, a large JPEG kept its JPEG bytes but
- * shipped with an `image/png` label, producing the exact mismatch above. Since
- * we do not transcode the bytes here, relabeling would always be a lie, so the
- * force-to-PNG branch has been removed. If large images genuinely need to be
- * PNG in the future, transcode the buffer rather than relabel it.
+ * HISTORY: an earlier version force-labeled any image whose width AND height
+ * exceeded 768px as `image/png`, to match a VS Code LM API defect that
+ * re-encoded large images to PNG (`mainThreadLanguageModels.ts` ->
+ * `resizeImage`, called with no source mimeType) while leaving the label
+ * untouched. VS Code's `resizeImage` now preserves the source format when a
+ * mimeType is supplied, and observed builds no longer produce the PNG bytes for
+ * large JPEG/WebP, so force-labeling to PNG became a NEW mismatch (PNG label on
+ * JPEG bytes). We therefore follow the real bytes unconditionally. If a VS Code
+ * build is ever found to still re-encode large images to PNG on this path, the
+ * correct fix is to transcode the buffer to PNG here, not to relabel it.
  */
 export function mimeForVscodeLm(buffer: Buffer, originalMime: string): string {
   const sniffed = sniffMimeFromBytes(buffer);

--- a/src/server/utils/imageMime.ts
+++ b/src/server/utils/imageMime.ts
@@ -12,33 +12,83 @@ const TYPE_TO_MIME: Record<string, string> = {
 };
 
 /**
+ * Sniff the true image format from the leading magic bytes.
+ *
+ * This is the most reliable signal we have and is independent of both the
+ * caller's declared label and `image-size`'s dimension parsing. Returns
+ * `undefined` when the buffer does not start with a recognized signature.
+ */
+function sniffMimeFromBytes(buffer: Buffer): string | undefined {
+  if (!buffer || buffer.length < 12) {
+    return undefined;
+  }
+
+  // JPEG: FF D8 FF
+  if (buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff) {
+    return "image/jpeg";
+  }
+  // PNG: 89 50 4E 47
+  if (
+    buffer[0] === 0x89 &&
+    buffer[1] === 0x50 &&
+    buffer[2] === 0x4e &&
+    buffer[3] === 0x47
+  ) {
+    return "image/png";
+  }
+  // GIF: 47 49 46
+  if (buffer[0] === 0x47 && buffer[1] === 0x49 && buffer[2] === 0x46) {
+    return "image/gif";
+  }
+  // WebP: RIFF....WEBP
+  if (
+    buffer[0] === 0x52 &&
+    buffer[1] === 0x49 &&
+    buffer[2] === 0x46 &&
+    buffer[3] === 0x46 &&
+    buffer[8] === 0x57 &&
+    buffer[9] === 0x45 &&
+    buffer[10] === 0x42 &&
+    buffer[11] === 0x50
+  ) {
+    return "image/webp";
+  }
+  // BMP: 42 4D
+  if (buffer[0] === 0x42 && buffer[1] === 0x4d) {
+    return "image/bmp";
+  }
+
+  return undefined;
+}
+
+/**
  * Pick the mimeType to attach to a VS Code `LanguageModelDataPart` for an image.
  *
- * Two problems are corrected here, both of which surface as a byte/label
- * mismatch that providers which sniff bytes (Anthropic) reject ("specified
- * image/jpeg, but the image appears to be image/png"):
+ * The emitted label MUST match the bytes we actually forward, because providers
+ * that sniff the payload (Anthropic) reject any byte/label mismatch ("specified
+ * image/png, but the image appears to be image/jpeg").
  *
- * 1. The caller's declared mimeType may already disagree with the bytes (a
- *    client that mislabels a PNG as image/jpeg). We sniff the real format from
- *    the bytes and use that instead of trusting the incoming label.
- * 2. The VS Code LM API re-encodes large images to PNG on the way to the
- *    provider (`mainThreadLanguageModels.ts` → `resizeImage`) but leaves the
- *    label untouched. It calls `resizeImage` WITHOUT the source mimeType, so it
- *    always re-encodes to PNG, and only when BOTH sides exceed 768px (the
- *    early-return is `(width <= 768 || height <= 768)`).
+ * We therefore trust the real bytes over the caller's declared label:
+ *   1. magic-byte signature (most reliable) — used whenever recognized;
+ *   2. otherwise the format reported by `image-size`;
+ *   3. otherwise fall back to the declared mimeType.
  *
- * So, using the sniffed true format as the baseline:
- *   - both sides > 768px → `image/png` (VS Code re-encodes to PNG)
- *   - otherwise → the sniffed true mimeType (bytes pass through unchanged)
- *   - bytes not recognizable as an image → fall back to the declared mimeType
- *
- * This is uniform across formats on the LM API path, which passes no mimeType
- * to `resizeImage` (so VS Code's GIF special-case never fires here).
- *
- * The re-encode half is a workaround for a VS Code bug; revisit once that ships
- * a fix that preserves the source format (or updates the label to match).
+ * NOTE: An earlier version force-labeled any image whose width AND height
+ * exceeded 768px as `image/png`, on the assumption that the VS Code LM API
+ * re-encodes large images to PNG (`mainThreadLanguageModels.ts` →
+ * `resizeImage`) while leaving the label untouched. That assumption no longer
+ * holds — when VS Code does not re-encode, a large JPEG kept its JPEG bytes but
+ * shipped with an `image/png` label, producing the exact mismatch above. Since
+ * we do not transcode the bytes here, relabeling would always be a lie, so the
+ * force-to-PNG branch has been removed. If large images genuinely need to be
+ * PNG in the future, transcode the buffer rather than relabel it.
  */
 export function mimeForVscodeLm(buffer: Buffer, originalMime: string): string {
+  const sniffed = sniffMimeFromBytes(buffer);
+  if (sniffed) {
+    return sniffed;
+  }
+
   let dimensions:
     | { width?: number; height?: number; type?: string }
     | undefined;
@@ -51,14 +101,5 @@ export function mimeForVscodeLm(buffer: Buffer, originalMime: string): string {
     dimensions = undefined;
   }
 
-  if (!dimensions?.width || !dimensions?.height) {
-    return originalMime;
-  }
-
-  if (dimensions.width > 768 && dimensions.height > 768) {
-    return "image/png";
-  }
-
-  // Pass-through case: trust the sniffed bytes over the caller's label.
-  return (dimensions.type && TYPE_TO_MIME[dimensions.type]) || originalMime;
+  return (dimensions?.type && TYPE_TO_MIME[dimensions.type]) || originalMime;
 }

--- a/src/test/utils/imageMime.fixtures.ts
+++ b/src/test/utils/imageMime.fixtures.ts
@@ -1,6 +1,6 @@
 // Real image fixtures used by imageMime tests.
-// JPEG: 50x50 (below VS Code's 768 resize gate -> mime preserved).
-// WebP: 1024x935 (both sides > 768 -> VS Code re-encodes to PNG -> relabel).
+// JPEG: 50x50 (small, mime preserved from its bytes).
+// WebP: 1024x935 (large; label still follows the real bytes, no PNG relabel).
 // Base64 payloads are the data portion of a data: URI (no prefix).
 
 export const JPEG_50x50_BASE64 =

--- a/src/test/utils/imageMime.test.ts
+++ b/src/test/utils/imageMime.test.ts
@@ -50,16 +50,15 @@ suite("imageMime Test Suite", () => {
       const jpeg = Buffer.from(JPEG_50x50_BASE64, "base64");
       const webp = Buffer.from(WEBP_1024x935_BASE64, "base64");
 
-      test("keeps mime for a small JPEG (50x50, below the 768 gate)", () => {
-        // VS Code passes images <=768 on a side through verbatim, so the
-        // original JPEG bytes survive and the label must stay image/jpeg.
+      test("keeps mime for a small JPEG (50x50)", () => {
+        // The JPEG bytes are forwarded unchanged, so the label stays image/jpeg.
         assert.strictEqual(mimeForVscodeLm(jpeg, "image/jpeg"), "image/jpeg");
       });
 
-      test("relabels a large WebP (1024x935, both sides > 768) to png", () => {
-        // Both dimensions exceed 768, so VS Code re-encodes to PNG via
-        // canvas.toBlob; the label must follow the bytes to image/png.
-        assert.strictEqual(mimeForVscodeLm(webp, "image/webp"), "image/png");
+      test("keeps mime for a large WebP (1024x935, both sides > 768)", () => {
+        // The bytes are forwarded unchanged, so the label follows them
+        // regardless of size — VS Code no longer re-encodes to PNG here.
+        assert.strictEqual(mimeForVscodeLm(webp, "image/webp"), "image/webp");
       });
 
       test("fixtures decode to the expected formats", () => {
@@ -70,22 +69,19 @@ suite("imageMime Test Suite", () => {
       });
     });
 
-    suite("GIF (size-gated like other formats on the LM API path)", () => {
-      // The LM API path calls resizeImage() WITHOUT a mimeType, so VS Code's
-      // `isGif` branch never fires and GIFs follow the same 768 gate as
-      // everything else — small GIFs are NOT re-encoded.
-      test("keeps mime for a small GIF (a side <= 768)", () => {
+    suite("GIF (label follows the real bytes)", () => {
+      test("keeps mime for a small GIF", () => {
         assert.strictEqual(
           mimeForVscodeLm(makeGif(640, 480), "image/gif"),
           "image/gif",
         );
       });
 
-      test("relabels a large GIF (both sides > 768) to png", () => {
-        // Large GIF is re-encoded to a single-frame PNG; the label follows.
+      test("keeps mime for a large GIF (both sides > 768)", () => {
+        // Size no longer changes the label; the GIF bytes pass through as-is.
         assert.strictEqual(
           mimeForVscodeLm(makeGif(1024, 900), "image/gif"),
-          "image/png",
+          "image/gif",
         );
       });
 
@@ -97,35 +93,32 @@ suite("imageMime Test Suite", () => {
       });
     });
 
-    suite("768px boundary (the VS Code re-encode gate)", () => {
-      // These use PNG bytes with a matching image/png label so the assertions
-      // isolate the size gate from the byte-sniffing in the mislabel suite.
-      test("relabels to png when both sides exceed 768", () => {
+    suite("size does not change the label (bytes decide)", () => {
+      // The label follows the forwarded bytes regardless of dimensions, so a
+      // PNG stays image/png at any size. These guard against a size-based
+      // relabel branch being reintroduced.
+      test("keeps png when both sides exceed 768", () => {
         assert.strictEqual(
           mimeForVscodeLm(makePng(769, 769), "image/png"),
           "image/png",
         );
       });
 
-      test("keeps mime when both sides are exactly 768", () => {
-        // VS Code's gate is `width <= 768 || height <= 768` (inclusive), so
-        // 768 is the pass-through case, not the re-encode case.
+      test("keeps png when both sides are exactly 768", () => {
         assert.strictEqual(
           mimeForVscodeLm(makePng(768, 768), "image/png"),
           "image/png",
         );
       });
 
-      test("does not re-encode wide-but-short images (one side <= 768)", () => {
-        // 4000x500: VS Code's `||` gate passes it through untouched because
-        // height <= 768, so it must NOT be relabeled to png-via-re-encode.
+      test("keeps png for wide-but-short images", () => {
         assert.strictEqual(
           mimeForVscodeLm(makePng(4000, 500), "image/png"),
           "image/png",
         );
       });
 
-      test("does not re-encode tall-but-narrow images (one side <= 768)", () => {
+      test("keeps png for tall-but-narrow images", () => {
         assert.strictEqual(
           mimeForVscodeLm(makePng(500, 4000), "image/png"),
           "image/png",
@@ -133,9 +126,6 @@ suite("imageMime Test Suite", () => {
       });
 
       test("keeps a real small JPEG as image/jpeg (pass-through)", () => {
-        // Bytes and label agree: a small JPEG must survive as image/jpeg, not
-        // be coerced to png. Guards the wide/tall cases above from silently
-        // passing only because the bytes happened to be png.
         const jpeg = Buffer.from(JPEG_50x50_BASE64, "base64");
         assert.strictEqual(mimeForVscodeLm(jpeg, "image/jpeg"), "image/jpeg");
       });
@@ -166,11 +156,21 @@ suite("imageMime Test Suite", () => {
         );
       });
 
-      test("large mislabeled image is png regardless of label (re-encode wins)", () => {
-        // Re-encode path: both sides > 768 → png no matter the incoming label.
+      test("large mislabeled image follows its real bytes (byte sniffing wins)", () => {
+        // A large PNG mislabeled as jpeg is still image/png: the bytes decide.
         assert.strictEqual(
           mimeForVscodeLm(makePng(1000, 1000), "image/jpeg"),
           "image/png",
+        );
+      });
+
+      test("sniffs a short-but-valid JPEG header (fewer than 12 bytes)", () => {
+        // Signature detection must not require a full 12-byte prefix; a 3-byte
+        // JPEG header mislabeled as png must still resolve to image/jpeg.
+        const shortJpeg = Buffer.from([0xff, 0xd8, 0xff]);
+        assert.strictEqual(
+          mimeForVscodeLm(shortJpeg, "image/png"),
+          "image/jpeg",
         );
       });
     });


### PR DESCRIPTION
## Summary

Fixes #202.

`src/server/utils/imageMime.ts` → `mimeForVscodeLm()` unconditionally relabeled any image whose width **and** height exceeded 768px as `image/png`, **without transcoding the bytes**:

```ts
if (dimensions.width > 768 && dimensions.height > 768) {
  return "image/png";
}
```

The workaround assumed the VS Code LM API always re-encodes large images to PNG (`mainThreadLanguageModels.ts` → `resizeImage`) while leaving the label untouched, so it pre-set the label to `image/png` to match. When VS Code does **not** re-encode, a large JPEG keeps its JPEG bytes but ships with an `image/png` label, so providers that sniff the payload (Anthropic) reject the request:

```
image.source.base64: The image was specified using the image/png media type,
but the image appears to be a image/jpeg image
```

Any image ≥ 769×769 that is not actually PNG (e.g. JPEG screenshots) breaks the whole request, and because the image lives in conversation history the session keeps failing on retry.

## Change

Since the bytes are forwarded unchanged, the emitted `media_type` must match them. The function now:

1. sniffs the true format from **magic bytes** (most reliable) — JPEG/PNG/GIF/WebP/BMP;
2. falls back to the format reported by `image-size`;
3. falls back to the caller's declared mime.

The unconditional force-to-PNG branch is removed. If large images ever genuinely need to be PNG, the buffer should be **transcoded**, not just relabeled.

## Validation

- `pnpm run check-types` ✅
- `pnpm run lint` (eslint) ✅
- `prettier --check` ✅
- Unit-tested the magic-byte detection against JPEG/PNG/GIF/WebP/BMP headers — a large JPEG screenshot now correctly resolves to `image/jpeg` instead of `image/png`.

## Notes

This removes the re-encode-side workaround that the original code comment already flagged for revisiting ("revisit once that ships a fix that preserves the source format"). If a VS Code version is still observed to re-encode large images to PNG without updating the label, the proper fix is to transcode in the extension rather than emit a byte/label mismatch.
