### PR TITLE
chore: upgrade pnpm to 11.9.0

### DIFF
--- a/.changeset/image-mime-follow-bytes.md
+++ b/.changeset/image-mime-follow-bytes.md
@@ -1,5 +1,0 @@
----
-"agent-maestro": patch
----
-
-Fix Anthropic tool-result images being rejected as a media-type mismatch when large JPEG/WebP bytes were relabeled as PNG. Top-level image parts still keep the VS Code resize workaround, while nested tool-result images now preserve their declared media type.

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # dependencies
 /node_modules
+/.pnpm-store
 /.pnp
 .pnp.*
 .yarn/*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ Agent Maestro is a VS Code extension that:
 - Exposes a local proxy server (default port `23333`) presenting OpenAI-, Anthropic-, and Gemini-compatible APIs backed by the VS Code Language Model API (GitHub Copilot models), used by clients such as Claude Code, Codex, and Gemini.
 - Runs an MCP server (default port `23334`) for Model Context Protocol clients.
 
-Primary language: **TypeScript** (ESM, Node ≥ 22, VS Code ≥ 1.100). Package manager: **pnpm 10**.
+Primary language: **TypeScript** (ESM, Node ≥ 22, VS Code ≥ 1.100). Package manager: **pnpm 11**.
 
 ## Repository layout
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v2.9.7 - 2026.07.04
 
 - Fix Anthropic tool-result images being rejected as a media-type mismatch when large JPEG/GIF/WebP bytes were relabeled as PNG. Top-level image parts still keep the VS Code resize workaround, while nested tool-result images now preserve their declared media type.
+- Stop showing an MCP startup notification during extension activation when no Roo-compatible task manager is available.
 
 ## v2.9.6 - 2026.06.23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.9.7 - 2026.07.04
+
+- Fix Anthropic tool-result images being rejected as a media-type mismatch when large JPEG/GIF/WebP bytes were relabeled as PNG. Top-level image parts still keep the VS Code resize workaround, while nested tool-result images now preserve their declared media type.
+
 ## v2.9.6 - 2026.06.23
 
 - Forward reasoning effort settings to Copilot for OpenAI and Anthropic proxy requests. OpenAI-backed models apply the setting today; Claude/Anthropic requests forward it but require upstream Copilot support to take effect.

--- a/examples/demo-site/pnpm-workspace.yaml
+++ b/examples/demo-site/pnpm-workspace.yaml
@@ -1,4 +1,4 @@
-onlyBuiltDependencies:
-  - "@tailwindcss/oxide"
-  - sharp
-  - unrs-resolver
+allowBuilds:
+  "@tailwindcss/oxide": true
+  sharp: true
+  unrs-resolver: true

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "vscode": "^1.120.0",
     "node": ">=22"
   },
-  "packageManager": "pnpm@10.28.2",
+  "packageManager": "pnpm@11.9.0",
   "categories": [
     "AI",
     "Chat",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "agent-maestro",
   "displayName": "Agent Maestro",
   "description": "Turn VS Code into your compliant AI playground! With Agent Maestro, spin up Cline or Roo on demand and plug Claude Code or Codex straight in through an OpenAI/Anthropic-compatible API.",
-  "version": "2.9.6",
+  "version": "2.9.7",
   "icon": "assets/icons/icon.png",
   "publisher": "Joouis",
   "repository": "https://github.com/Joouis/agent-maestro",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,7 @@
-onlyBuiltDependencies:
-  - "@vscode/vsce-sign"
-  - esbuild
-  - keytar
+allowBuilds:
+  "@vscode/vsce-sign": true
+  esbuild: true
+  keytar: true
 
 packageExtensions:
   "@roo-code/types":

--- a/src/commands/mcpCommands.ts
+++ b/src/commands/mcpCommands.ts
@@ -1,7 +1,10 @@
 import * as vscode from "vscode";
 
 import { McpServer } from "../server/McpServer";
-import { ANOTHER_INSTANCE_RUNNING_MESSAGE } from "../utils/constant";
+import {
+  ANOTHER_INSTANCE_RUNNING_MESSAGE,
+  MCP_TASK_MANAGER_UNAVAILABLE_MESSAGE,
+} from "../utils/constant";
 import { logger } from "../utils/logger";
 import {
   addAgentMaestroMcpConfig,
@@ -25,7 +28,10 @@ export function registerMcpCommands(
           );
         } else {
           // Don't show error message for "another instance running" case
-          if (result.reason === ANOTHER_INSTANCE_RUNNING_MESSAGE) {
+          if (
+            result.reason === ANOTHER_INSTANCE_RUNNING_MESSAGE ||
+            result.reason === MCP_TASK_MANAGER_UNAVAILABLE_MESSAGE
+          ) {
             logger.info(`MCP server startup skipped: ${result.reason}`);
           } else {
             vscode.window.showInformationMessage(

--- a/src/server/McpServer.ts
+++ b/src/server/McpServer.ts
@@ -6,6 +6,7 @@ import { ExtensionController } from "../core/controller";
 import { DEFAULT_CONFIG } from "../utils/config";
 import {
   ANOTHER_INSTANCE_RUNNING_MESSAGE,
+  MCP_TASK_MANAGER_UNAVAILABLE_MESSAGE,
   PORT_MONITOR_INTERVAL_MS,
 } from "../utils/constant";
 import { logger } from "../utils/logger";
@@ -73,8 +74,7 @@ export class McpServer {
       if (!rooAdapter) {
         return {
           started: false,
-          reason:
-            "MCP Server will not start because task manager is not available, this could be no Roo extension is installed nor active.",
+          reason: MCP_TASK_MANAGER_UNAVAILABLE_MESSAGE,
         };
       }
       this.taskManager = new McpTaskManager(rooAdapter);

--- a/src/utils/constant.ts
+++ b/src/utils/constant.ts
@@ -1,6 +1,9 @@
 export const ANOTHER_INSTANCE_RUNNING_MESSAGE =
   "Another instance is already running, monitoring for availability";
 
+export const MCP_TASK_MANAGER_UNAVAILABLE_MESSAGE =
+  "MCP Server will not start because task manager is not available, this could be no Roo extension is installed nor active.";
+
 export const PORT_MONITOR_INTERVAL_MS = 60_000; // 1 minute
 
 export const LLM_API_KEY_SECRET_KEY = "agent-maestro.llmApiKey";

--- a/website/pnpm-workspace.yaml
+++ b/website/pnpm-workspace.yaml
@@ -1,3 +1,3 @@
-onlyBuiltDependencies:
-  - "@swc/core"
-  - esbuild
+allowBuilds:
+  "@swc/core": true
+  esbuild: true


### PR DESCRIPTION
## Summary

- Upgrade the project package manager declaration to pnpm 11.9.0
- Migrate pnpm build-script allowlist from `onlyBuiltDependencies` to pnpm 11 `allowBuilds`
- Ignore the local `.pnpm-store` directory created by pnpm 11
- Bump release metadata to v2.9.7 and consume the image MIME changeset

## Test plan

- [x] `CI=true COREPACK_HOME=/tmp/corepack corepack pnpm install --frozen-lockfile`
- [x] `CI=true COREPACK_HOME=/tmp/corepack corepack pnpm run check-types`
- [x] `CI=true COREPACK_HOME=/tmp/corepack corepack pnpm run lint`
- [x] `CI=true COREPACK_HOME=/tmp/corepack corepack pnpm exec prettier --check --ignore-unknown package.json pnpm-workspace.yaml .gitignore`
- [x] pre-commit hook ran successfully with pnpm 11.9.0