### PR TITLE
feat(copilot): enable experimental GPT-5 web search

### DIFF
--- a/.changeset/enable-gpt-web-search.md
+++ b/.changeset/enable-gpt-web-search.md
@@ -1,0 +1,5 @@
+---
+"agent-maestro": minor
+---
+
+Add experimental commands that patch the currently loaded Copilot Chat bundle to append the OpenAI web search tool declaration for GPT major version 5 or newer language model requests, and restore backups created by that patch.

--- a/README.md
+++ b/README.md
@@ -83,6 +83,24 @@ Additionally, it creates or updates `settings.json` in the same folder to skip t
 }
 ```
 
+### Experimental GPT-5+ Web Search Patch
+
+Run `Agent Maestro: Enable Experimental GPT-5+ Web Search` to patch the built-in Copilot bundle for the currently running VS Code app and append the server-side web search tool from GPT-5+ OpenAI Responses requests.
+
+This command:
+
+- Uses the currently loaded GitHub Copilot Chat extension bundle, including Extension Development Host bundles; falls back to the current VS Code app root when needed
+- Creates a timestamped backup before writing changes
+- Enables `agent-maestro.experimentalGpt5PlusWebSearchEnabled` so OpenAI Responses requests that include web search tools can signal the patched Copilot bundle
+- Applies the patch only once when the expected Copilot bundle shape is found
+- Reloads VS Code after the patch is applied
+
+To undo the local patch, run `Agent Maestro: Restore Experimental GPT-5+ Web Search Backup`, choose one of the backups created for the currently loaded Copilot bundle, and Agent Maestro will restore it, disable `agent-maestro.experimentalGpt5PlusWebSearchEnabled`, and reload VS Code.
+
+This is an experimental local modification. Agent Maestro only injects the web search tool declaration from the OpenAI Responses request, following the [OpenAI web search tool guide](https://developers.openai.com/api/docs/guides/tools-web-search); actual availability, behavior, and errors depend on the active Copilot model backend. VS Code updates can overwrite this patch.
+
+See [docs/experimental-gpt5-plus-web-search.md](docs/experimental-gpt5-plus-web-search.md) for implementation details, restore behavior, and troubleshooting notes.
+
 ### Usage
 
 1. **Explore API Capabilities**: Access the complete OpenAPI specification at [`http://localhost:23333/openapi.json`](http://localhost:23333/openapi.json).
@@ -112,6 +130,8 @@ Additionally, it creates or updates `settings.json` in the same folder to skip t
    - `Agent Maestro: Configure Claude Code Settings` - One-click Claude Code setup
    - `Agent Maestro: Configure Codex Settings` - One-click Codex setup
    - `Agent Maestro: Configure Gemini CLI Settings` - One-click Gemini CLI setup
+   - `Agent Maestro: Enable Experimental GPT-5+ Web Search` - Patch the current VS Code Copilot bundle to append web search for GPT major version 5 or newer model requests
+   - `Agent Maestro: Restore Experimental GPT-5+ Web Search Backup` - Restore a Copilot bundle backup created by the experimental patch command
    - `Agent Maestro: Set LLM API Key` - Configure authentication for LLM API endpoints
 
 3. **Development Resources**:

--- a/docs/experimental-gpt5-plus-web-search.md
+++ b/docs/experimental-gpt5-plus-web-search.md
@@ -69,5 +69,6 @@ If that development bundle is rebuilt or overwritten after reload, the patch can
 - Check Agent Maestro output for `Experimental GPT-5+ web search: ... injected=true`.
 - If the log says `injected=false`, verify the setting is enabled, the request includes a `web_search*` tool, and the selected model resolves to GPT major version 5 or newer.
 - If the model says it has no local `web_search` tool, that is not definitive. Hosted web search is inserted into the server-side Responses tool list, not exposed as a local function tool.
+- On Windows, a system VS Code install under `C:\Program Files` usually requires running VS Code as Administrator before the patch command can write the bundle and create a backup. The VS Code User Installer avoids this by installing under a user-writable location.
 - If the backend returns a 400 error, the hosted tool shape or selected model variant may not be accepted by that Copilot backend.
 - If a reload or rebuild happened after enabling, run the enable command again because the bundle may have been regenerated.

--- a/docs/experimental-gpt5-plus-web-search.md
+++ b/docs/experimental-gpt5-plus-web-search.md
@@ -1,0 +1,73 @@
+# Experimental GPT-5+ Web Search Patch
+
+Agent Maestro can locally patch the currently running VS Code Copilot bundle so OpenAI Responses requests can carry hosted web search tool declarations through `vscode.lm.sendRequest()` for GPT major version 5 or newer models.
+
+This is intentionally experimental. Agent Maestro does not implement web search itself, does not call a local `web_search` function tool, and does not guarantee that a Copilot backend model will accept or use the hosted web search tool. It only preserves and forwards the web search tool declaration already present in the OpenAI Responses request, following OpenAI's hosted web search tool shape:
+
+https://developers.openai.com/api/docs/guides/tools-web-search
+
+## Why a Patch Is Needed
+
+The VS Code Language Model API accepts function-style tools through request options. Copilot's internal OpenAI Responses route also builds a final `tools` array for the server request, but unsupported hosted tool declarations such as `web_search` are not exposed as normal VS Code function tools.
+
+Agent Maestro therefore uses a marker function tool as a transport envelope:
+
+- Tool name: `__agent_maestro_web_search__`
+- Parameter name: `x-agent-maestro-web-search-tool`
+- Parameter value: the original hosted web search tool from the incoming Responses request
+
+The patched Copilot bundle recognizes that marker, removes the marker function tool before the final server request, extracts the hosted `web_search*` declaration, and inserts that hosted tool into Copilot's final OpenAI Responses `tools` array.
+
+## Enable Flow
+
+Run `Agent Maestro: Enable Experimental GPT-5+ Web Search` from the Command Palette.
+
+The command:
+
+- Finds the currently loaded GitHub Copilot Chat bundle first, including Extension Development Host bundles.
+- Falls back to the current VS Code app bundle path when the loaded extension path is unavailable.
+- Creates a timestamped backup beside the target bundle before writing changes.
+- Applies the patch only when a supported Copilot Responses injection point is found.
+- Leaves an already patched bundle unchanged, so running the command multiple times does not duplicate the injected code.
+- Enables `agent-maestro.experimentalGpt5PlusWebSearchEnabled`.
+- Reloads VS Code after a successful patch.
+
+## Request Flow
+
+For `/v1/responses` requests:
+
+1. The client sends a Responses request with a hosted web search tool such as `web_search` or `web_search_preview`.
+2. Agent Maestro reads `agent-maestro.experimentalGpt5PlusWebSearchEnabled`.
+3. Agent Maestro only activates the marker path when the resolved model or Copilot family is GPT major version 5 or newer.
+4. Agent Maestro adds the internal marker function tool to the VS Code LM request options.
+5. The patched Copilot bundle removes the marker function tool and inserts the original hosted web search declaration into the final server-side `tools` array.
+6. The Copilot backend decides whether that model can use hosted web search and whether the current request needs it.
+
+Because hosted web search is handled by the model backend, a successful search may not produce a local VS Code tool call.
+
+## Restore Flow
+
+Run `Agent Maestro: Restore Experimental GPT-5+ Web Search Backup` from the Command Palette.
+
+The command:
+
+- Lists backups created for the currently resolved Copilot bundle.
+- Replaces the current bundle with the selected backup.
+- Sets `agent-maestro.experimentalGpt5PlusWebSearchEnabled` to `false`.
+- Reloads VS Code.
+
+VS Code or Copilot updates can overwrite the patched bundle. If that happens, run the enable command again only after confirming the feature is still needed.
+
+## Extension Development Host Notes
+
+When Agent Maestro is running in an Extension Development Host, the active Copilot Chat bundle may come from a local development checkout rather than `/Applications/Visual Studio Code*.app`. The enable command intentionally patches the loaded bundle first so it affects the VS Code window that is actually sending requests.
+
+If that development bundle is rebuilt or overwritten after reload, the patch can disappear. Re-run the enable command after the rebuild/reload if logs show the marker is no longer being injected.
+
+## Troubleshooting
+
+- Check Agent Maestro output for `Experimental GPT-5+ web search: ... injected=true`.
+- If the log says `injected=false`, verify the setting is enabled, the request includes a `web_search*` tool, and the selected model resolves to GPT major version 5 or newer.
+- If the model says it has no local `web_search` tool, that is not definitive. Hosted web search is inserted into the server-side Responses tool list, not exposed as a local function tool.
+- If the backend returns a 400 error, the hosted tool shape or selected model variant may not be accepted by that Copilot backend.
+- If a reload or rebuild happened after enabling, run the enable command again because the bundle may have been regenerated.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -20,7 +20,7 @@ pnpm run watch-tests
 | Test File                             | Tests | What It Covers                                            |
 | ------------------------------------- | ----- | --------------------------------------------------------- |
 | `extension.test.ts`                   | 13    | Extension activation, command registration, configuration |
-| `utils/copilotWebSearchPatch.test.ts` | 14    | Experimental Copilot web search bundle patching           |
+| `utils/copilotWebSearchPatch.test.ts` | 16    | Experimental Copilot web search bundle patching           |
 | `utils/config.test.ts`                | 5     | Configuration defaults and reading                        |
 | `utils/mimeTypes.test.ts`             | 12    | MIME type detection for file extensions                   |
 | `utils/rooSettingsFilter.test.ts`     | 5     | API key filtering from settings                           |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -17,20 +17,22 @@ pnpm run watch-tests
 
 ## Test Coverage Summary
 
-| Test File                         | Tests | What It Covers                                            |
-| --------------------------------- | ----- | --------------------------------------------------------- |
-| `extension.test.ts`               | 11    | Extension activation, command registration, configuration |
-| `utils/config.test.ts`            | 5     | Configuration defaults and reading                        |
-| `utils/mimeTypes.test.ts`         | 12    | MIME type detection for file extensions                   |
-| `utils/rooSettingsFilter.test.ts` | 5     | API key filtering from settings                           |
-| `utils/updateEnvFile.test.ts`     | 13    | .env file creation/update logic                           |
-| `schemas/cline.test.ts`           | 6     | Cline API request/response validation                     |
-| `schemas/roo.test.ts`             | 7     | Roo API request/response validation                       |
-| `schemas/common.test.ts`          | 7     | Common schemas (file ops, extension info, OS info)        |
-| `server/anthropic.test.ts`        | 23    | Anthropic → VS Code message conversion                    |
-| `server/openaiChat.test.ts`       | 15    | OpenAI → VS Code message conversion                       |
-| `server/openaiResponses.test.ts`  | 45    | OpenAI Responses → VS Code conversion                     |
-| `server/gemini.test.ts`           | 27    | Gemini → VS Code message conversion                       |
+| Test File                             | Tests | What It Covers                                            |
+| ------------------------------------- | ----- | --------------------------------------------------------- |
+| `extension.test.ts`                   | 13    | Extension activation, command registration, configuration |
+| `utils/copilotWebSearchPatch.test.ts` | 14    | Experimental Copilot web search bundle patching           |
+| `utils/config.test.ts`                | 5     | Configuration defaults and reading                        |
+| `utils/mimeTypes.test.ts`             | 12    | MIME type detection for file extensions                   |
+| `utils/rooSettingsFilter.test.ts`     | 5     | API key filtering from settings                           |
+| `utils/updateEnvFile.test.ts`         | 13    | .env file creation/update logic                           |
+| `schemas/cline.test.ts`               | 6     | Cline API request/response validation                     |
+| `schemas/roo.test.ts`                 | 7     | Roo API request/response validation                       |
+| `schemas/common.test.ts`              | 7     | Common schemas (file ops, extension info, OS info)        |
+| `server/anthropic.test.ts`            | 23    | Anthropic → VS Code message conversion                    |
+| `server/modelResolution.test.ts`      | 19    | Model matching and Copilot model configuration            |
+| `server/openaiChat.test.ts`           | 15    | OpenAI → VS Code message conversion                       |
+| `server/openaiResponses.test.ts`      | 54    | OpenAI Responses → VS Code conversion                     |
+| `server/gemini.test.ts`               | 27    | Gemini → VS Code message conversion                       |
 
 ## How Tests Prevent Regressions
 
@@ -81,6 +83,7 @@ src/test/
 │   ├── openaiChat.test.ts
 │   └── openaiResponses.test.ts
 └── utils/                     # Utility function tests
+    ├── copilotWebSearchPatch.test.ts
     ├── config.test.ts
     ├── mimeTypes.test.ts
     ├── rooSettingsFilter.test.ts

--- a/package.json
+++ b/package.json
@@ -84,6 +84,12 @@
           "default": false,
           "description": "Allow the extension to access files outside of the current workspace",
           "scope": "application"
+        },
+        "agent-maestro.experimentalGpt5PlusWebSearchEnabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable the experimental GPT-5+ web search Copilot bundle patch for OpenAI Responses requests. This is toggled by the Agent Maestro patch/restore commands.",
+          "scope": "application"
         }
       }
     },
@@ -146,6 +152,16 @@
       {
         "command": "agent-maestro.configureGeminiCli",
         "title": "Configure Gemini CLI Settings",
+        "category": "Agent Maestro"
+      },
+      {
+        "command": "agent-maestro.enableExperimentalGpt5PlusWebSearch",
+        "title": "Enable Experimental GPT-5+ Web Search",
+        "category": "Agent Maestro"
+      },
+      {
+        "command": "agent-maestro.restoreExperimentalGpt5PlusWebSearchBackup",
+        "title": "Restore Experimental GPT-5+ Web Search Backup",
         "category": "Agent Maestro"
       },
       {

--- a/src/commands/copilotWebSearchCommands.ts
+++ b/src/commands/copilotWebSearchCommands.ts
@@ -1,0 +1,144 @@
+import * as vscode from "vscode";
+
+import { CONFIG_KEYS } from "../utils/config";
+import {
+  getRunningCopilotBundlePath,
+  listCopilotWebSearchBackups,
+  patchCopilotWebSearchBundle,
+  restoreCopilotWebSearchBackup,
+} from "../utils/copilotWebSearchPatch";
+import { logger } from "../utils/logger";
+import { createCommandHandler } from "./commandHandler";
+
+export function registerCopilotWebSearchCommands(
+  context: vscode.ExtensionContext,
+) {
+  const patchDisposable = vscode.commands.registerCommand(
+    "agent-maestro.enableExperimentalGpt5PlusWebSearch",
+    createCommandHandler(async () => {
+      const bundlePath = getCurrentCopilotBundlePath();
+
+      const proceed = await vscode.window.showWarningMessage(
+        `This experimental command modifies the built-in GitHub Copilot bundle for the currently running VS Code app. A backup will be created before patching.\n\nTarget:\n${bundlePath}\n\nContinue?`,
+        { modal: true },
+        "Patch Bundle",
+      );
+
+      if (proceed !== "Patch Bundle") {
+        return;
+      }
+
+      await vscode.window.withProgress(
+        {
+          location: vscode.ProgressLocation.Notification,
+          title: "Enabling Experimental GPT-5+ Web Search",
+          cancellable: false,
+        },
+        async (progress) => {
+          progress.report({ message: "Patching Copilot bundle..." });
+
+          const result = patchCopilotWebSearchBundle(bundlePath);
+          logger.info(
+            `Copilot GPT-5+ web search patch status: ${result.status} (${result.bundlePath})`,
+          );
+
+          if (result.status === "already-patched") {
+            await setExperimentalWebSearchEnabled(true);
+            vscode.window.showInformationMessage(
+              "Experimental GPT-5+ web search patch is already applied. Reloading VS Code...",
+            );
+            await vscode.commands.executeCommand(
+              "workbench.action.reloadWindow",
+            );
+            return;
+          }
+
+          logger.info(`Copilot bundle backup created: ${result.backupPath}`);
+
+          await setExperimentalWebSearchEnabled(true);
+
+          vscode.window.showInformationMessage(
+            `Experimental GPT-5+ web search patch applied. Backup saved at:\n${result.backupPath}\n\nReloading VS Code...`,
+          );
+          await vscode.commands.executeCommand("workbench.action.reloadWindow");
+        },
+      );
+    }, "Failed to enable experimental GPT-5+ web search"),
+  );
+
+  const restoreDisposable = vscode.commands.registerCommand(
+    "agent-maestro.restoreExperimentalGpt5PlusWebSearchBackup",
+    createCommandHandler(async () => {
+      const bundlePath = getCurrentCopilotBundlePath();
+      const backups = listCopilotWebSearchBackups(bundlePath);
+
+      if (backups.length === 0) {
+        vscode.window.showErrorMessage(
+          `No Agent Maestro GPT-5+ web search backups found for:\n${bundlePath}`,
+        );
+        return;
+      }
+
+      const selectedBackup = await vscode.window.showQuickPick(
+        backups.map((backup) => ({
+          label: new Date(backup.createdAtMs).toLocaleString(),
+          description: backup.path,
+          backupPath: backup.path,
+        })),
+        {
+          title: "Restore Experimental GPT-5+ Web Search Backup",
+          placeHolder: "Choose a Copilot bundle backup to restore",
+        },
+      );
+
+      if (!selectedBackup) {
+        return;
+      }
+
+      const proceed = await vscode.window.showWarningMessage(
+        `This will replace the current Copilot bundle with the selected backup and reload VS Code.\n\nTarget:\n${bundlePath}\n\nBackup:\n${selectedBackup.backupPath}\n\nContinue?`,
+        { modal: true },
+        "Restore Backup",
+      );
+
+      if (proceed !== "Restore Backup") {
+        return;
+      }
+
+      restoreCopilotWebSearchBackup(bundlePath, selectedBackup.backupPath);
+      await setExperimentalWebSearchEnabled(false);
+      logger.info(
+        `Restored Copilot bundle from backup: ${selectedBackup.backupPath}`,
+      );
+
+      vscode.window.showInformationMessage(
+        "Experimental GPT-5+ web search backup restored. Reloading VS Code...",
+      );
+      await vscode.commands.executeCommand("workbench.action.reloadWindow");
+    }, "Failed to restore experimental GPT-5+ web search backup"),
+  );
+
+  context.subscriptions.push(patchDisposable, restoreDisposable);
+}
+
+function getCurrentCopilotBundlePath(): string {
+  const copilotChatExtension = vscode.extensions.getExtension(
+    "GitHub.copilot-chat",
+  );
+
+  return getRunningCopilotBundlePath({
+    appRoot: vscode.env.appRoot,
+    extensionPath: copilotChatExtension?.extensionPath,
+    extensionMain: copilotChatExtension?.packageJSON?.main,
+  });
+}
+
+async function setExperimentalWebSearchEnabled(enabled: boolean) {
+  await vscode.workspace
+    .getConfiguration()
+    .update(
+      CONFIG_KEYS.EXPERIMENTAL_GPT5_PLUS_WEB_SEARCH_ENABLED,
+      enabled,
+      vscode.ConfigurationTarget.Global,
+    );
+}

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -4,6 +4,7 @@ import { ExtensionController } from "../core/controller";
 import { McpServer } from "../server/McpServer";
 import { ProxyServer } from "../server/ProxyServer";
 import { registerConfiguratorCommands } from "./configuratorCommands";
+import { registerCopilotWebSearchCommands } from "./copilotWebSearchCommands";
 import { registerLlmApiKeyCommands } from "./llmApiKeyCommands";
 import { registerMcpCommands } from "./mcpCommands";
 import { registerProxyCommands } from "./proxyCommands";
@@ -18,6 +19,7 @@ export function registerAllCommands(
   registerProxyCommands(proxy, context);
   registerMcpCommands(mcpServer, context);
   registerConfiguratorCommands(proxy, context);
+  registerCopilotWebSearchCommands(context);
   registerStatusCommands(controller, context);
   registerLlmApiKeyCommands(proxy, context);
 }

--- a/src/server/routes/openai/openaiResponsesRoutes.ts
+++ b/src/server/routes/openai/openaiResponsesRoutes.ts
@@ -8,14 +8,21 @@ import * as vscode from "vscode";
 import {
   getChatModelClient,
   getCopilotModelConfiguration,
+  isGpt5PlusModel,
   withCopilotConfiguration,
 } from "../../../utils/chatModels";
+import { readConfiguration } from "../../../utils/config";
+import {
+  AGENT_MAESTRO_WEB_SEARCH_SENTINEL_PARAMETER,
+  AGENT_MAESTRO_WEB_SEARCH_SENTINEL_TOOL_NAME,
+} from "../../../utils/copilotWebSearchConstants";
 import { logger } from "../../../utils/logger";
 import { CommonResponseError } from "../../schemas/openai";
 import { handleErrorWithLogging } from "../../utils/errorDiagnostics";
 import { extractOpenAIResponsesUsage } from "../../utils/openai";
 import {
   OutputItem,
+  ResponseTool,
   ToolChoice,
   buildResponseOutput,
   closeMessageOutputItem,
@@ -26,6 +33,7 @@ import {
   generateMessageId,
   generateResponseId,
   getCurrentTimestamp,
+  getResponsesWebSearchTool,
 } from "../../utils/openaiResponses";
 
 type NonStreamingResponse = Omit<
@@ -49,7 +57,7 @@ const createResponseRoute = createRoute({
 
 Limitations:
 - Stateless: previous_response_id, conversation, item_reference not supported (send full history in input array)
-- Only function tools supported (file_search, web_search, code_interpreter, custom, etc. are ignored)
+- Only function tools supported by default; web_search tools can be passed through when the experimental GPT-5+ web search patch is enabled
 - Images: only base64 data URI supported (URL-based images fall back to JSON)
 - input_file: not supported (serialized as JSON text)
 - Annotations: always empty (VSCode LM doesn't provide annotations)
@@ -248,13 +256,48 @@ export function registerOpenaiResponsesRoutes(app: OpenAPIHono) {
       // 7. Build request options
       const shouldPassTools =
         tool_choice !== "none" && tools && tools.length > 0;
+      const effectiveTools = tools ? [...tools] : undefined;
+      const webSearchTool = getResponsesWebSearchTool(tools);
+      const experimentalWebSearchEnabled = webSearchTool
+        ? readConfiguration().experimentalGpt5PlusWebSearchEnabled
+        : false;
+      const gpt5Plus = webSearchTool ? isGpt5PlusModel(model, client) : false;
+      const shouldUseExperimentalWebSearch =
+        !!webSearchTool && experimentalWebSearchEnabled && gpt5Plus;
+
+      if (webSearchTool) {
+        logger.debug(
+          `Experimental GPT-5+ web search: enabled=${experimentalWebSearchEnabled}, gpt5Plus=${gpt5Plus}, toolType=${webSearchTool.type}, injected=${shouldUseExperimentalWebSearch}`,
+        );
+      }
+
+      if (shouldUseExperimentalWebSearch && effectiveTools) {
+        const sentinelTool: ResponseTool = {
+          type: "function",
+          name: AGENT_MAESTRO_WEB_SEARCH_SENTINEL_TOOL_NAME,
+          description:
+            "Internal Agent Maestro marker for Copilot bundle web search patching.",
+          strict: false,
+          parameters: {
+            type: "object",
+            properties: {
+              [AGENT_MAESTRO_WEB_SEARCH_SENTINEL_PARAMETER]: {
+                const: webSearchTool,
+              },
+            },
+          },
+        };
+        effectiveTools.push(sentinelTool);
+      }
 
       const lmRequestOptions: vscode.LanguageModelChatRequestOptions = {
         justification:
           "OpenAI Responses API endpoint using VS Code Language Model API",
         modelOptions,
         tools: shouldPassTools
-          ? convertResponsesToolsToVSCode(tools)
+          ? convertResponsesToolsToVSCode(effectiveTools, {
+              webSearchHandledByCopilotPatch: shouldUseExperimentalWebSearch,
+            })
           : undefined,
         toolMode: shouldPassTools
           ? convertToolChoice(tool_choice as ToolChoice)

--- a/src/server/utils/openaiResponses.ts
+++ b/src/server/utils/openaiResponses.ts
@@ -38,6 +38,8 @@ export type ToolChoice =
   | ToolChoiceApplyPatch
   | ToolChoiceShell;
 
+export type ResponseTool = Tool;
+
 /**
  * Output item types for Responses API (subset we generate)
  */
@@ -370,6 +372,7 @@ export const convertResponsesInputToVSCode = (
  */
 export const convertResponsesToolsToVSCode = (
   tools?: Tool[],
+  options: { webSearchHandledByCopilotPatch?: boolean } = {},
 ): vscode.LanguageModelChatTool[] => {
   if (!tools) {
     return [];
@@ -390,7 +393,9 @@ export const convertResponsesToolsToVSCode = (
         description: funcTool.description ?? "",
         inputSchema: funcTool.parameters ?? undefined,
       });
-    } else {
+    } else if (
+      !(options.webSearchHandledByCopilotPatch && isWebSearchTool(tool))
+    ) {
       // Known tool types are expected and frequent, so keep the log at debug.
       logger.debug(`Tool type "${tool.type}" not supported, skipping`);
     }
@@ -398,6 +403,14 @@ export const convertResponsesToolsToVSCode = (
 
   return vsCodeTools;
 };
+
+export function getResponsesWebSearchTool(tools?: Tool[]): Tool | undefined {
+  return tools?.find((tool) => !!tool && isWebSearchTool(tool));
+}
+
+function isWebSearchTool(tool: Tool): boolean {
+  return typeof tool.type === "string" && tool.type.startsWith("web_search");
+}
 
 /**
  * Convert tool choice to VSCode LM tool mode

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -82,6 +82,21 @@ suite("Extension Test Suite", () => {
       }
     });
 
+    test("experimental commands should be registered", async () => {
+      const commands = await vscode.commands.getCommands(true);
+
+      assert.ok(
+        commands.includes("agent-maestro.enableExperimentalGpt5PlusWebSearch"),
+        "enableExperimentalGpt5PlusWebSearch command should be registered",
+      );
+      assert.ok(
+        commands.includes(
+          "agent-maestro.restoreExperimentalGpt5PlusWebSearchBackup",
+        ),
+        "restoreExperimentalGpt5PlusWebSearchBackup command should be registered",
+      );
+    });
+
     test("status command should be registered", async () => {
       const commands = await vscode.commands.getCommands(true);
 
@@ -137,6 +152,18 @@ suite("Extension Test Suite", () => {
       assert.ok(
         typeof identifier === "string" && identifier.length > 0,
         "defaultRooIdentifier should be a non-empty string",
+      );
+    });
+
+    test("experimentalGpt5PlusWebSearchEnabled should be a boolean", () => {
+      const config = vscode.workspace.getConfiguration("agent-maestro");
+      const enabled = config.get<boolean>(
+        "experimentalGpt5PlusWebSearchEnabled",
+      );
+
+      assert.ok(
+        typeof enabled === "boolean",
+        "experimentalGpt5PlusWebSearchEnabled should be a boolean",
       );
     });
   });

--- a/src/test/server/modelResolution.test.ts
+++ b/src/test/server/modelResolution.test.ts
@@ -4,6 +4,7 @@ import * as vscode from "vscode";
 import {
   type CopilotModelConfiguration,
   getCopilotModelConfiguration,
+  isGpt5PlusModel,
   jaccardSimilarity,
   withCopilotConfiguration,
 } from "../../utils/chatModels";
@@ -185,6 +186,37 @@ suite("Model Resolution Test Suite", () => {
       assert.deepStrictEqual(
         getCopilotModelConfiguration({ reasoningEffort: 1 }),
         {},
+      );
+    });
+  });
+
+  suite("isGpt5PlusModel", () => {
+    test("matches GPT major version 5 from the requested model id", () => {
+      assert.strictEqual(isGpt5PlusModel("gpt-5", createMockModel({})), true);
+      assert.strictEqual(isGpt5PlusModel("gpt-5.5", createMockModel({})), true);
+    });
+
+    test("matches GPT major version 5 or newer from model metadata", () => {
+      assert.strictEqual(
+        isGpt5PlusModel(
+          "custom-alias",
+          createMockModel({ family: "gpt-5.5", name: "GPT-6 Preview" }),
+        ),
+        true,
+      );
+    });
+
+    test("does not match earlier GPT or non-GPT models", () => {
+      assert.strictEqual(
+        isGpt5PlusModel(
+          "gpt-4.1",
+          createMockModel({ id: "gpt-4.1", family: "gpt-4.1" }),
+        ),
+        false,
+      );
+      assert.strictEqual(
+        isGpt5PlusModel("claude-opus", createMockModel({})),
+        false,
       );
     });
   });

--- a/src/test/server/openaiResponses.test.ts
+++ b/src/test/server/openaiResponses.test.ts
@@ -12,6 +12,7 @@ import {
   generateFunctionCallId,
   generateMessageId,
   generateResponseId,
+  getResponsesWebSearchTool,
 } from "../../server/utils/openaiResponses";
 
 const encode = (value: unknown): Uint8Array =>
@@ -321,6 +322,41 @@ suite("OpenAI Responses Conversion Utils Test Suite", () => {
         { type: "web_search_preview" as const },
       ] as any[];
       const result = convertResponsesToolsToVSCode(tools);
+      assert.strictEqual(result.length, 1);
+      assert.strictEqual(result[0].name, "valid_function");
+    });
+
+    test("should return web search tools", () => {
+      const tools = [
+        { type: "function" as const, name: "valid_function" },
+        {
+          type: "web_search" as const,
+          external_web_access: true,
+          search_content_types: ["text", "image"],
+        },
+      ] as any[];
+
+      assert.deepStrictEqual(getResponsesWebSearchTool(tools), {
+        type: "web_search",
+        external_web_access: true,
+        search_content_types: ["text", "image"],
+      });
+      assert.strictEqual(
+        getResponsesWebSearchTool([{ type: "function", name: "fn" }] as any),
+        undefined,
+      );
+    });
+
+    test("should suppress web search skip log when handled by Copilot patch", () => {
+      const tools = [
+        { type: "function" as const, name: "valid_function" },
+        { type: "web_search" as const },
+      ] as any[];
+
+      const result = convertResponsesToolsToVSCode(tools, {
+        webSearchHandledByCopilotPatch: true,
+      });
+
       assert.strictEqual(result.length, 1);
       assert.strictEqual(result[0].name, "valid_function");
     });

--- a/src/test/utils/config.test.ts
+++ b/src/test/utils/config.test.ts
@@ -20,6 +20,10 @@ suite("Config Test Suite", () => {
       assert.strictEqual(DEFAULT_CONFIG.proxyServerPort, 23333);
       assert.strictEqual(DEFAULT_CONFIG.mcpServerPort, 23334);
       assert.strictEqual(DEFAULT_CONFIG.allowOutsideWorkspaceAccess, false);
+      assert.strictEqual(
+        DEFAULT_CONFIG.experimentalGpt5PlusWebSearchEnabled,
+        false,
+      );
     });
   });
 
@@ -72,6 +76,10 @@ suite("Config Test Suite", () => {
       assert.ok(
         typeof config.allowOutsideWorkspaceAccess === "boolean",
         "allowOutsideWorkspaceAccess should be a boolean",
+      );
+      assert.ok(
+        typeof config.experimentalGpt5PlusWebSearchEnabled === "boolean",
+        "experimentalGpt5PlusWebSearchEnabled should be a boolean",
       );
     });
 

--- a/src/test/utils/copilotWebSearchPatch.test.ts
+++ b/src/test/utils/copilotWebSearchPatch.test.ts
@@ -7,6 +7,7 @@ import {
   GPT5_PLUS_WEB_SEARCH_PATCH_SNIPPET,
   READABLE_GPT5_PLUS_WEB_SEARCH_PATCH_SNIPPET,
   getCopilotBundlePath,
+  getCopilotBundlePermissionMessage,
   getRunningCopilotBundlePath,
   listCopilotWebSearchBackups,
   patchCopilotWebSearchBundle,
@@ -286,5 +287,25 @@ ${legacyReadablePatch}  const contextManagementEnabled = true;
       () => patchCopilotWebSearchBundle(bundlePath),
       /Expected to find a supported Copilot Responses tool injection point/,
     );
+  });
+
+  test("should format Windows permission failures", () => {
+    const message = getCopilotBundlePermissionMessage("win32");
+
+    assert.ok(
+      message.includes("No write access to the VS Code Copilot bundle"),
+    );
+    assert.ok(message.includes("Run VS Code as Administrator"));
+    assert.ok(message.includes("VS Code User Installer"));
+  });
+
+  test("should format non-Windows permission failures", () => {
+    const message = getCopilotBundlePermissionMessage("darwin");
+
+    assert.ok(
+      message.includes("No write access to the VS Code Copilot bundle"),
+    );
+    assert.ok(message.includes("user-writable VS Code install"));
+    assert.ok(!message.includes("Administrator"));
   });
 });

--- a/src/test/utils/copilotWebSearchPatch.test.ts
+++ b/src/test/utils/copilotWebSearchPatch.test.ts
@@ -1,0 +1,290 @@
+import * as assert from "assert";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+import {
+  GPT5_PLUS_WEB_SEARCH_PATCH_SNIPPET,
+  READABLE_GPT5_PLUS_WEB_SEARCH_PATCH_SNIPPET,
+  getCopilotBundlePath,
+  getRunningCopilotBundlePath,
+  listCopilotWebSearchBackups,
+  patchCopilotWebSearchBundle,
+  restoreCopilotWebSearchBackup,
+} from "../../utils/copilotWebSearchPatch";
+
+suite("CopilotWebSearchPatch Test Suite", () => {
+  const testDir = path.join(os.tmpdir(), "copilot-web-search-patch-tests");
+  const bundlePath = path.join(testDir, "extension.js");
+  const toolSearchSnippet =
+    'let y=[...h];g&&y.unshift({type:"tool_search",execution:"client",description:"Search for relevant tools by describing what you need. Returns tool definitions for tools matching your query.",parameters:{type:"object",properties:{query:{type:"string",description:"Natural language description of what tool capability you are looking for."}},required:["query"]}});';
+  const toolMapSnippet =
+    "let v=e.requestOptions?.tools?new Map(e.requestOptions.tools.map(B=>[B.function.name,B])):void 0";
+
+  setup(() => {
+    fs.mkdirSync(testDir, { recursive: true });
+  });
+
+  teardown(() => {
+    fs.rmSync(testDir, { recursive: true, force: true });
+  });
+
+  test("should resolve the Copilot bundle path from app root", () => {
+    assert.strictEqual(
+      getCopilotBundlePath(
+        "/Applications/Visual Studio Code.app/Contents/Resources/app",
+      ),
+      "/Applications/Visual Studio Code.app/Contents/Resources/app/extensions/copilot/dist/extension.js",
+    );
+  });
+
+  test("should resolve a loaded Copilot extension bundle path", () => {
+    const extensionDir = path.join(testDir, "copilot-chat");
+    const extensionBundlePath = path.join(extensionDir, "dist", "extension.js");
+    fs.mkdirSync(path.dirname(extensionBundlePath), { recursive: true });
+    fs.writeFileSync(extensionBundlePath, "bundle");
+
+    assert.strictEqual(
+      getRunningCopilotBundlePath({
+        appRoot: "/Applications/Visual Studio Code.app/Contents/Resources/app",
+        extensionPath: extensionDir,
+        extensionMain: "./dist/extension",
+      }),
+      extensionBundlePath,
+    );
+  });
+
+  test("should reject empty app root", () => {
+    assert.throws(() => getCopilotBundlePath(""), /app root is unavailable/);
+  });
+
+  test("should patch bundle and create a backup", () => {
+    fs.writeFileSync(
+      bundlePath,
+      `prefix ${toolSearchSnippet}${toolMapSnippet} suffix`,
+    );
+
+    const result = patchCopilotWebSearchBundle(bundlePath);
+
+    assert.strictEqual(result.status, "patched");
+    assert.ok(result.backupPath, "backup path should be returned");
+    assert.ok(fs.existsSync(result.backupPath));
+
+    const patchedContent = fs.readFileSync(bundlePath, "utf8");
+    assert.ok(patchedContent.includes(GPT5_PLUS_WEB_SEARCH_PATCH_SNIPPET));
+    assert.strictEqual(
+      patchedContent.indexOf(GPT5_PLUS_WEB_SEARCH_PATCH_SNIPPET),
+      patchedContent.lastIndexOf(GPT5_PLUS_WEB_SEARCH_PATCH_SNIPPET),
+    );
+
+    const backupContent = fs.readFileSync(result.backupPath, "utf8");
+    assert.ok(!backupContent.includes(GPT5_PLUS_WEB_SEARCH_PATCH_SNIPPET));
+  });
+
+  test("should not patch an already patched bundle again", () => {
+    fs.writeFileSync(
+      bundlePath,
+      `${toolSearchSnippet}${GPT5_PLUS_WEB_SEARCH_PATCH_SNIPPET}${toolMapSnippet}`,
+    );
+
+    const result = patchCopilotWebSearchBundle(bundlePath);
+
+    assert.strictEqual(result.status, "already-patched");
+    assert.strictEqual(result.backupPath, undefined);
+  });
+
+  test("should migrate a legacy unconditional patch", () => {
+    const legacyPatchSnippet =
+      '((B=>{let Q=/^gpt-(\\d+)/.exec(String(B).toLowerCase().replace(/\\./g,"-"));return!!Q&&Number(Q[1])>=5})(t)||(B=>{let Q=/^gpt-(\\d+)/.exec(String(B).toLowerCase().replace(/\\./g,"-"));return!!Q&&Number(Q[1])>=5})(r.family))&&!y.some(B=>typeof B?.type=="string"&&B.type.startsWith("web_search"))&&y.unshift({type:"web_search_preview"});';
+    fs.writeFileSync(
+      bundlePath,
+      `${toolSearchSnippet}${legacyPatchSnippet}${toolMapSnippet}`,
+    );
+
+    const result = patchCopilotWebSearchBundle(bundlePath);
+
+    assert.strictEqual(result.status, "patched");
+    assert.ok(result.backupPath);
+
+    const patchedContent = fs.readFileSync(bundlePath, "utf8");
+    assert.ok(patchedContent.includes(GPT5_PLUS_WEB_SEARCH_PATCH_SNIPPET));
+    assert.ok(!patchedContent.includes(legacyPatchSnippet));
+  });
+
+  test("should migrate legacy patches with different local variable names", () => {
+    const legacyPatchSnippet =
+      '((X=>{let Y=/^gpt-(\\d+)/.exec(String(X).toLowerCase().replace(/\\./g,"-"));return!!Y&&Number(Y[1])>=5})(t)||(X=>{let Y=/^gpt-(\\d+)/.exec(String(X).toLowerCase().replace(/\\./g,"-"));return!!Y&&Number(Y[1])>=5})(r.family))&&!y.some(X=>typeof X?.type=="string"&&X.type.startsWith("web_search"))&&y.unshift({type:"web_search_preview"});';
+    fs.writeFileSync(
+      bundlePath,
+      `${toolSearchSnippet}${legacyPatchSnippet}${toolMapSnippet}`,
+    );
+
+    const result = patchCopilotWebSearchBundle(bundlePath);
+
+    assert.strictEqual(result.status, "patched");
+    const patchedContent = fs.readFileSync(bundlePath, "utf8");
+    assert.ok(patchedContent.includes(GPT5_PLUS_WEB_SEARCH_PATCH_SNIPPET));
+    assert.ok(!patchedContent.includes(legacyPatchSnippet));
+  });
+
+  test("should migrate marker patches that read nested modelOptions only", () => {
+    const legacyPatchSnippet =
+      '(()=>{let B=e.requestOptions?.modelOptions,Q=B?.agentMaestroWebSearchTool;if(Q&&typeof Q.type=="string"&&Q.type.startsWith("web_search")){delete B.agentMaestroWebSearchTool;((X=>{let ee=/^gpt-(\\d+)/.exec(String(X).toLowerCase().replace(/\\./g,"-"));return!!ee&&Number(ee[1])>=5})(t)||(X=>{let ee=/^gpt-(\\d+)/.exec(String(X).toLowerCase().replace(/\\./g,"-"));return!!ee&&Number(ee[1])>=5})(r.family))&&!y.some(X=>typeof X?.type=="string"&&X.type.startsWith("web_search"))&&y.unshift(Q)}})();';
+    fs.writeFileSync(
+      bundlePath,
+      `${toolSearchSnippet}${legacyPatchSnippet}${toolMapSnippet}`,
+    );
+
+    const result = patchCopilotWebSearchBundle(bundlePath);
+
+    assert.strictEqual(result.status, "patched");
+    const patchedContent = fs.readFileSync(bundlePath, "utf8");
+    assert.ok(patchedContent.includes(GPT5_PLUS_WEB_SEARCH_PATCH_SNIPPET));
+    assert.ok(!patchedContent.includes(legacyPatchSnippet));
+  });
+
+  test("should patch readable Copilot Chat development bundles", () => {
+    const readableSnippet = `function createResponsesRequestBody(accessor, options, model, endpoint) {
+  const body3 = {
+    model,
+    tools: options.requestOptions?.tools?.map((tool) => ({
+      ...tool.function,
+      type: "function",
+      strict: false,
+      parameters: tool.function.parameters || {}
+    })),
+    text: verbosity ? { verbosity } : void 0
+  };
+  const contextManagementEnabled = true;
+  return body3;
+}`;
+    fs.writeFileSync(bundlePath, readableSnippet);
+
+    const result = patchCopilotWebSearchBundle(bundlePath);
+
+    assert.strictEqual(result.status, "patched");
+    const patchedContent = fs.readFileSync(bundlePath, "utf8");
+    assert.ok(
+      patchedContent.includes(READABLE_GPT5_PLUS_WEB_SEARCH_PATCH_SNIPPET),
+    );
+    assert.strictEqual(
+      patchedContent.indexOf(READABLE_GPT5_PLUS_WEB_SEARCH_PATCH_SNIPPET),
+      patchedContent.lastIndexOf(READABLE_GPT5_PLUS_WEB_SEARCH_PATCH_SNIPPET),
+    );
+  });
+
+  test("should migrate legacy readable Copilot Chat development bundle patches", () => {
+    const legacyReadablePatch = `  (() => {
+    const sentinelToolIndex =
+      body3.tools?.findIndex(
+        (tool) => tool?.name === "__agent_maestro_web_search__",
+      ) ?? -1;
+    const sentinelTool =
+      sentinelToolIndex >= 0 ? body3.tools?.[sentinelToolIndex] : undefined;
+    const webSearchTool =
+      sentinelTool?.parameters?.properties?.[
+        "x-agent-maestro-web-search-tool"
+      ]?.const;
+    if (sentinelToolIndex >= 0) {
+      body3.tools?.splice(sentinelToolIndex, 1);
+    }
+    if (
+      webSearchTool &&
+      typeof webSearchTool.type === "string" &&
+      webSearchTool.type.startsWith("web_search")
+    ) {
+      const isAgentMaestroTargetModel = (value) => {
+        const match = /^gpt-(\\d+)/.exec(
+          String(value).toLowerCase().replace(/\\./g, "-"),
+        );
+        return !!match && Number(match[1]) >= 5;
+      };
+      if (
+        (isAgentMaestroTargetModel(model) ||
+          isAgentMaestroTargetModel(endpoint.family)) &&
+        !body3.tools?.some(
+          (tool) =>
+            typeof tool?.type === "string" &&
+            tool.type.startsWith("web_search"),
+        )
+      ) {
+        body3.tools = [webSearchTool, ...(body3.tools ?? [])];
+      }
+    }
+  })();
+`;
+    fs.writeFileSync(
+      bundlePath,
+      `function createResponsesRequestBody() {
+  const body3 = {
+    text: verbosity ? { verbosity } : void 0
+  };
+${legacyReadablePatch}  const contextManagementEnabled = true;
+  return body3;
+}`,
+    );
+
+    const result = patchCopilotWebSearchBundle(bundlePath);
+
+    assert.strictEqual(result.status, "patched");
+    const patchedContent = fs.readFileSync(bundlePath, "utf8");
+    assert.ok(
+      patchedContent.includes(READABLE_GPT5_PLUS_WEB_SEARCH_PATCH_SNIPPET),
+    );
+    assert.ok(!patchedContent.includes(legacyReadablePatch));
+  });
+
+  test("should target GPT major version 5 and newer", () => {
+    const isTargetModel = (model: string) => {
+      const match = /^gpt-(\d+)/.exec(model.toLowerCase().replace(/\./g, "-"));
+      return !!match && Number(match[1]) >= 5;
+    };
+
+    assert.strictEqual(isTargetModel("claude-opus-4.1"), false);
+    assert.strictEqual(isTargetModel("gpt"), false);
+    assert.strictEqual(isTargetModel("gpt-4.1"), false);
+    assert.strictEqual(isTargetModel("gpt-5"), true);
+    assert.strictEqual(isTargetModel("gpt-5.5"), true);
+    assert.strictEqual(isTargetModel("GPT-6"), true);
+    assert.strictEqual(isTargetModel("gpt-10-preview"), true);
+  });
+
+  test("should list backups newest first", () => {
+    const olderBackup = `${bundlePath}.agent-maestro-web-search-2026-01-01T00-00-00-000Z.bak`;
+    const newerBackup = `${bundlePath}.agent-maestro-web-search-2026-01-02T00-00-00-000Z.bak`;
+    fs.writeFileSync(bundlePath, "current");
+    fs.writeFileSync(olderBackup, "older");
+    fs.writeFileSync(newerBackup, "newer");
+
+    const olderDate = new Date("2026-01-01T00:00:00.000Z");
+    const newerDate = new Date("2026-01-02T00:00:00.000Z");
+    fs.utimesSync(olderBackup, olderDate, olderDate);
+    fs.utimesSync(newerBackup, newerDate, newerDate);
+
+    const backups = listCopilotWebSearchBackups(bundlePath);
+
+    assert.deepStrictEqual(
+      backups.map((backup) => backup.path),
+      [newerBackup, olderBackup],
+    );
+  });
+
+  test("should restore a selected backup", () => {
+    const backupPath = `${bundlePath}.agent-maestro-web-search-2026-01-01T00-00-00-000Z.bak`;
+    fs.writeFileSync(bundlePath, "patched");
+    fs.writeFileSync(backupPath, "original");
+
+    restoreCopilotWebSearchBackup(bundlePath, backupPath);
+
+    assert.strictEqual(fs.readFileSync(bundlePath, "utf8"), "original");
+  });
+
+  test("should fail when the Copilot injection point changes", () => {
+    fs.writeFileSync(bundlePath, "let y=[...h];let v=changed");
+
+    assert.throws(
+      () => patchCopilotWebSearchBundle(bundlePath),
+      /Expected to find a supported Copilot Responses tool injection point/,
+    );
+  });
+});

--- a/src/utils/chatModels.ts
+++ b/src/utils/chatModels.ts
@@ -249,6 +249,20 @@ export function getCopilotModelConfiguration({
   return configuration;
 }
 
+export function isGpt5PlusModel(
+  requestedModelId: string,
+  model: vscode.LanguageModelChat,
+): boolean {
+  return [requestedModelId, model.id, model.family, model.name].some(
+    (value) => {
+      const match = /^gpt-(\d+)/.exec(
+        String(value).toLowerCase().replace(/\./g, "-"),
+      );
+      return !!match && Number(match[1]) >= 5;
+    },
+  );
+}
+
 /**
  * VS Code stores provider-specific model configuration separately from public
  * `modelOptions`. Copilot reads this bag for settings like context size and

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -6,6 +6,7 @@ export interface AgentMaestroConfiguration {
   proxyServerPort: number;
   mcpServerPort: number;
   allowOutsideWorkspaceAccess: boolean;
+  experimentalGpt5PlusWebSearchEnabled: boolean;
 }
 
 /**
@@ -17,6 +18,8 @@ export const CONFIG_KEYS = {
   PROXY_SERVER_PORT: "agent-maestro.proxyServerPort",
   MCP_SERVER_PORT: "agent-maestro.mcpServerPort",
   ALLOW_OUTSIDE_WORKSPACE_ACCESS: "agent-maestro.allowOutsideWorkspaceAccess",
+  EXPERIMENTAL_GPT5_PLUS_WEB_SEARCH_ENABLED:
+    "agent-maestro.experimentalGpt5PlusWebSearchEnabled",
 } as const;
 
 /**
@@ -28,6 +31,7 @@ export const DEFAULT_CONFIG: AgentMaestroConfiguration = {
   proxyServerPort: 23333,
   mcpServerPort: 23334,
   allowOutsideWorkspaceAccess: false,
+  experimentalGpt5PlusWebSearchEnabled: false,
 };
 
 /**
@@ -56,6 +60,10 @@ export const readConfiguration = (): AgentMaestroConfiguration => {
     allowOutsideWorkspaceAccess: config.get<boolean>(
       CONFIG_KEYS.ALLOW_OUTSIDE_WORKSPACE_ACCESS,
       DEFAULT_CONFIG.allowOutsideWorkspaceAccess,
+    ),
+    experimentalGpt5PlusWebSearchEnabled: config.get<boolean>(
+      CONFIG_KEYS.EXPERIMENTAL_GPT5_PLUS_WEB_SEARCH_ENABLED,
+      DEFAULT_CONFIG.experimentalGpt5PlusWebSearchEnabled,
     ),
   };
 };

--- a/src/utils/copilotWebSearchConstants.ts
+++ b/src/utils/copilotWebSearchConstants.ts
@@ -1,0 +1,5 @@
+export const AGENT_MAESTRO_WEB_SEARCH_SENTINEL_TOOL_NAME =
+  "__agent_maestro_web_search__";
+
+export const AGENT_MAESTRO_WEB_SEARCH_SENTINEL_PARAMETER =
+  "x-agent-maestro-web-search-tool";

--- a/src/utils/copilotWebSearchPatch.ts
+++ b/src/utils/copilotWebSearchPatch.ts
@@ -138,8 +138,14 @@ export function patchCopilotWebSearchBundle(
     patchReadableResponsesBundle(content);
 
   if (patchedContent) {
-    const backupPath = createBundleBackup(bundlePath);
-    fs.writeFileSync(bundlePath, patchedContent);
+    let backupPath: string;
+
+    try {
+      backupPath = createBundleBackup(bundlePath);
+      fs.writeFileSync(bundlePath, patchedContent);
+    } catch (error) {
+      throwCopilotBundleWriteError(error);
+    }
 
     return {
       status: "patched",
@@ -272,7 +278,39 @@ export function restoreCopilotWebSearchBackup(
     throw new Error(`Backup not found: ${backupPath}`);
   }
 
-  fs.copyFileSync(backupPath, bundlePath);
+  try {
+    fs.copyFileSync(backupPath, bundlePath);
+  } catch (error) {
+    throwCopilotBundleWriteError(error);
+  }
+}
+
+function throwCopilotBundleWriteError(error: unknown): never {
+  if (isPermissionError(error)) {
+    throw new Error(getCopilotBundlePermissionMessage());
+  }
+
+  throw error;
+}
+
+function isPermissionError(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+
+  const code = (error as { code?: unknown }).code;
+  return code === "EACCES" || code === "EPERM";
+}
+
+export function getCopilotBundlePermissionMessage(
+  platform: NodeJS.Platform = process.platform,
+): string {
+  const permissionHint =
+    platform === "win32"
+      ? "Run VS Code as Administrator or use the VS Code User Installer, then try again."
+      : "Restart VS Code with write access to the app bundle, or use a user-writable VS Code install.";
+
+  return `No write access to the VS Code Copilot bundle. ${permissionHint}`;
 }
 
 function createBundleBackup(bundlePath: string): string {

--- a/src/utils/copilotWebSearchPatch.ts
+++ b/src/utils/copilotWebSearchPatch.ts
@@ -1,0 +1,301 @@
+import * as fs from "fs";
+import * as path from "path";
+
+import {
+  AGENT_MAESTRO_WEB_SEARCH_SENTINEL_PARAMETER,
+  AGENT_MAESTRO_WEB_SEARCH_SENTINEL_TOOL_NAME,
+} from "./copilotWebSearchConstants";
+
+const COPILOT_BUNDLE_RELATIVE_PATH = path.join(
+  "extensions",
+  "copilot",
+  "dist",
+  "extension.js",
+);
+
+const TOOL_SEARCH_SNIPPET =
+  'let y=[...h];g&&y.unshift({type:"tool_search",execution:"client",description:"Search for relevant tools by describing what you need. Returns tool definitions for tools matching your query.",parameters:{type:"object",properties:{query:{type:"string",description:"Natural language description of what tool capability you are looking for."}},required:["query"]}});';
+
+const TOOL_MAP_SNIPPET =
+  "let v=e.requestOptions?.tools?new Map(e.requestOptions.tools.map(B=>[B.function.name,B])):void 0";
+
+export const GPT5_PLUS_WEB_SEARCH_PATCH_SNIPPET = `(()=>{let B=y.findIndex(ee=>ee?.name==="${AGENT_MAESTRO_WEB_SEARCH_SENTINEL_TOOL_NAME}"),X=B>=0?y[B]:void 0,Q=X?.parameters?.properties?.["${AGENT_MAESTRO_WEB_SEARCH_SENTINEL_PARAMETER}"]?.const;B>=0&&y.splice(B,1);if(Q&&typeof Q.type=="string"&&Q.type.startsWith("web_search")){e.postOptions?.tool_choice?.function?.name==="${AGENT_MAESTRO_WEB_SEARCH_SENTINEL_TOOL_NAME}"&&(e.postOptions.tool_choice="required");((ee=>{let te=/^gpt-(\\d+)/.exec(String(ee).toLowerCase().replace(/\\./g,"-"));return!!te&&Number(te[1])>=5})(t)||(ee=>{let te=/^gpt-(\\d+)/.exec(String(ee).toLowerCase().replace(/\\./g,"-"));return!!te&&Number(te[1])>=5})(r.family))&&!y.some(ee=>typeof ee?.type=="string"&&ee.type.startsWith("web_search"))&&y.unshift(Q)}})();`;
+
+const READABLE_RESPONSES_BODY_SNIPPET = `    text: verbosity ? { verbosity } : void 0
+  };
+  const contextManagementEnabled =`;
+
+const READABLE_RESPONSES_BODY_END_SNIPPET = `    text: verbosity ? { verbosity } : void 0
+  };
+`;
+
+const READABLE_CONTEXT_MANAGEMENT_SNIPPET =
+  "  const contextManagementEnabled =";
+
+export const READABLE_GPT5_PLUS_WEB_SEARCH_PATCH_SNIPPET = `  (() => {
+    const sentinelToolIndex =
+      body3.tools?.findIndex(
+        (tool) => tool?.name === "${AGENT_MAESTRO_WEB_SEARCH_SENTINEL_TOOL_NAME}",
+      ) ?? -1;
+    const sentinelTool =
+      sentinelToolIndex >= 0 ? body3.tools?.[sentinelToolIndex] : undefined;
+    const webSearchTool =
+      sentinelTool?.parameters?.properties?.[
+        "${AGENT_MAESTRO_WEB_SEARCH_SENTINEL_PARAMETER}"
+      ]?.const;
+    if (sentinelToolIndex >= 0) {
+      body3.tools?.splice(sentinelToolIndex, 1);
+    }
+    if (body3.tool_choice?.name === "${AGENT_MAESTRO_WEB_SEARCH_SENTINEL_TOOL_NAME}") {
+      body3.tool_choice = "required";
+    }
+    if (
+      webSearchTool &&
+      typeof webSearchTool.type === "string" &&
+      webSearchTool.type.startsWith("web_search")
+    ) {
+      const isAgentMaestroTargetModel = (value) => {
+        const match = /^gpt-(\\d+)/.exec(
+          String(value).toLowerCase().replace(/\\./g, "-"),
+        );
+        return !!match && Number(match[1]) >= 5;
+      };
+      if (
+        (isAgentMaestroTargetModel(model) ||
+          isAgentMaestroTargetModel(endpoint.family)) &&
+        !body3.tools?.some(
+          (tool) =>
+            typeof tool?.type === "string" &&
+            tool.type.startsWith("web_search"),
+        )
+      ) {
+        body3.tools = [webSearchTool, ...(body3.tools ?? [])];
+      }
+    }
+  })();
+`;
+
+export interface CopilotBundlePathOptions {
+  appRoot: string;
+  extensionPath?: string;
+  extensionMain?: string;
+}
+
+export interface CopilotWebSearchPatchResult {
+  status: "patched" | "already-patched";
+  bundlePath: string;
+  backupPath?: string;
+}
+
+export interface CopilotWebSearchBackupInfo {
+  path: string;
+  createdAtMs: number;
+}
+
+export function getCopilotBundlePath(appRoot: string): string {
+  if (!appRoot) {
+    throw new Error(
+      "VS Code app root is unavailable. This command only works in desktop VS Code.",
+    );
+  }
+
+  return path.join(appRoot, COPILOT_BUNDLE_RELATIVE_PATH);
+}
+
+export function getRunningCopilotBundlePath({
+  appRoot,
+  extensionPath,
+  extensionMain,
+}: CopilotBundlePathOptions): string {
+  const loadedExtensionBundlePath = getLoadedExtensionBundlePath(
+    extensionPath,
+    extensionMain,
+  );
+  return loadedExtensionBundlePath ?? getCopilotBundlePath(appRoot);
+}
+
+export function patchCopilotWebSearchBundle(
+  bundlePath: string,
+): CopilotWebSearchPatchResult {
+  if (!fs.existsSync(bundlePath)) {
+    throw new Error(`Copilot bundle not found: ${bundlePath}`);
+  }
+
+  const content = fs.readFileSync(bundlePath, "utf8");
+
+  if (
+    content.includes(GPT5_PLUS_WEB_SEARCH_PATCH_SNIPPET) ||
+    content.includes(READABLE_GPT5_PLUS_WEB_SEARCH_PATCH_SNIPPET)
+  ) {
+    return {
+      status: "already-patched",
+      bundlePath,
+    };
+  }
+
+  const patchedContent =
+    patchMinifiedResponsesBundle(content) ??
+    patchReadableResponsesBundle(content);
+
+  if (patchedContent) {
+    const backupPath = createBundleBackup(bundlePath);
+    fs.writeFileSync(bundlePath, patchedContent);
+
+    return {
+      status: "patched",
+      bundlePath,
+      backupPath,
+    };
+  }
+
+  throw new Error(
+    "Expected to find a supported Copilot Responses tool injection point. VS Code may have updated its Copilot bundle.",
+  );
+}
+
+function patchMinifiedResponsesBundle(content: string): string | undefined {
+  const targetSnippet = `${TOOL_SEARCH_SNIPPET}${TOOL_MAP_SNIPPET}`;
+  const replacement = `${TOOL_SEARCH_SNIPPET}${GPT5_PLUS_WEB_SEARCH_PATCH_SNIPPET}${TOOL_MAP_SNIPPET}`;
+  const matchCount = content.split(targetSnippet).length - 1;
+
+  if (matchCount === 1) {
+    return content.replace(targetSnippet, replacement);
+  }
+
+  const legacyPatchResult = replaceLegacyPatch(content);
+  if (legacyPatchResult) {
+    return legacyPatchResult;
+  }
+
+  return undefined;
+}
+
+function patchReadableResponsesBundle(content: string): string | undefined {
+  const replacement = `${READABLE_RESPONSES_BODY_SNIPPET.replace(
+    "  const contextManagementEnabled =",
+    "",
+  )}${READABLE_GPT5_PLUS_WEB_SEARCH_PATCH_SNIPPET}  const contextManagementEnabled =`;
+  const matchCount = content.split(READABLE_RESPONSES_BODY_SNIPPET).length - 1;
+
+  if (matchCount === 1) {
+    return content.replace(READABLE_RESPONSES_BODY_SNIPPET, replacement);
+  }
+
+  return replaceReadableLegacyPatch(content);
+}
+
+function replaceReadableLegacyPatch(content: string): string | undefined {
+  const bodyEndIndex = content.indexOf(READABLE_RESPONSES_BODY_END_SNIPPET);
+  if (bodyEndIndex < 0) {
+    return undefined;
+  }
+
+  const legacyPatchStart =
+    bodyEndIndex + READABLE_RESPONSES_BODY_END_SNIPPET.length;
+  const contextManagementIndex = content.indexOf(
+    READABLE_CONTEXT_MANAGEMENT_SNIPPET,
+    legacyPatchStart,
+  );
+  if (contextManagementIndex < 0) {
+    return undefined;
+  }
+
+  const legacyPatch = content.slice(legacyPatchStart, contextManagementIndex);
+  if (!isLegacyWebSearchPatch(legacyPatch)) {
+    return undefined;
+  }
+
+  return `${content.slice(0, legacyPatchStart)}${READABLE_GPT5_PLUS_WEB_SEARCH_PATCH_SNIPPET}${content.slice(contextManagementIndex)}`;
+}
+
+function replaceLegacyPatch(content: string): string | undefined {
+  const toolSearchIndex = content.indexOf(TOOL_SEARCH_SNIPPET);
+  if (toolSearchIndex < 0) {
+    return undefined;
+  }
+
+  const legacyPatchStart = toolSearchIndex + TOOL_SEARCH_SNIPPET.length;
+  const toolMapIndex = content.indexOf(TOOL_MAP_SNIPPET, legacyPatchStart);
+  if (toolMapIndex < 0) {
+    return undefined;
+  }
+
+  const legacyPatch = content.slice(legacyPatchStart, toolMapIndex);
+  if (!isLegacyWebSearchPatch(legacyPatch)) {
+    return undefined;
+  }
+
+  return `${content.slice(0, legacyPatchStart)}${GPT5_PLUS_WEB_SEARCH_PATCH_SNIPPET}${content.slice(toolMapIndex)}`;
+}
+
+function isLegacyWebSearchPatch(snippet: string): boolean {
+  if (!snippet.includes('type.startsWith("web_search")')) {
+    return false;
+  }
+
+  return (
+    snippet.includes('y.unshift({type:"web_search_preview"})') ||
+    snippet.includes("agentMaestroWebSearchTool") ||
+    snippet.includes(AGENT_MAESTRO_WEB_SEARCH_SENTINEL_TOOL_NAME)
+  );
+}
+
+export function listCopilotWebSearchBackups(
+  bundlePath: string,
+): CopilotWebSearchBackupInfo[] {
+  const bundleDir = path.dirname(bundlePath);
+  const bundleBaseName = path.basename(bundlePath);
+  const backupPrefix = `${bundleBaseName}.agent-maestro-web-search-`;
+
+  if (!fs.existsSync(bundleDir)) {
+    return [];
+  }
+
+  return fs
+    .readdirSync(bundleDir)
+    .filter((entry) => entry.startsWith(backupPrefix) && entry.endsWith(".bak"))
+    .map((entry) => {
+      const backupPath = path.join(bundleDir, entry);
+      return {
+        path: backupPath,
+        createdAtMs: fs.statSync(backupPath).mtimeMs,
+      };
+    })
+    .sort((a, b) => b.createdAtMs - a.createdAtMs);
+}
+
+export function restoreCopilotWebSearchBackup(
+  bundlePath: string,
+  backupPath: string,
+): void {
+  if (!fs.existsSync(backupPath)) {
+    throw new Error(`Backup not found: ${backupPath}`);
+  }
+
+  fs.copyFileSync(backupPath, bundlePath);
+}
+
+function createBundleBackup(bundlePath: string): string {
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const backupPath = `${bundlePath}.agent-maestro-web-search-${timestamp}.bak`;
+  fs.copyFileSync(bundlePath, backupPath);
+  return backupPath;
+}
+
+function getLoadedExtensionBundlePath(
+  extensionPath?: string,
+  extensionMain?: string,
+): string | undefined {
+  if (!extensionPath || !extensionMain) {
+    return undefined;
+  }
+
+  const mainPath = path.isAbsolute(extensionMain)
+    ? extensionMain
+    : path.resolve(extensionPath, extensionMain);
+  const candidates = path.extname(mainPath)
+    ? [mainPath]
+    : [`${mainPath}.js`, `${mainPath}.cjs`, `${mainPath}.mjs`, mainPath];
+
+  return candidates.find((candidate) => fs.existsSync(candidate));
+}


### PR DESCRIPTION
## Summary
- Add experimental commands to enable and restore a local Copilot bundle patch for GPT-5+ hosted web search.
- Pass OpenAI Responses `web_search*` tools through VS Code LM by wrapping the hosted tool in an internal sentinel function tool, then letting the patched Copilot bundle unwrap it into the final server-side Responses `tools` array.
- Gate the marker path behind `agent-maestro.experimentalGpt5PlusWebSearchEnabled` and GPT major version 5 or newer model detection.
- Document the implementation, recovery path, limitations, and troubleshooting notes.

## Why
VS Code LM request tools are function-oriented, while OpenAI Responses hosted web search is a server-side tool declaration. Without the patch, Responses requests that include `web_search` cannot reach Copilot as hosted web search. This feature is intentionally experimental and only injects the hosted tool declaration; actual search availability and behavior still depend on the active Copilot backend model.

## Safety and restore
- The enable command targets the currently loaded `GitHub.copilot-chat` bundle first, including Extension Development Host bundles.
- A timestamped backup is created before writing the bundle.
- Re-running enable is idempotent and does not duplicate the injected snippet.
- The restore command replaces the bundle from a selected backup, disables the setting, and reloads VS Code.
- VS Code or Copilot updates may overwrite the patch.

## Test plan
- [x] `pnpm run check-types`
- [x] `pnpm run lint`
- [x] `pnpm run build`
- [x] `git diff --check`

Just did web search on server side, no local tool call invoked.
<img width="1550" height="438" alt="image" src="https://github.com/user-attachments/assets/cd5d1fc9-023d-4dd7-86cd-8e24be3f3d6c" />
