### PR TITLE
feat(openai): support additional_tools, custom & namespace tool types

### DIFF
--- a/.changeset/additional-tools-support.md
+++ b/.changeset/additional-tools-support.md
@@ -1,0 +1,5 @@
+---
+"agent-maestro": minor
+---
+
+Support OpenAI Responses API `additional_tools`, `custom`, and `namespace` tool types (used by Codex/GPT-5.6). Custom tools round-trip as `custom_tool_call` items with raw string input, and namespaced tools preserve their `namespace` field across the VSCode LM boundary via an encoded-name mapping table. `tool_choice: { type: "custom" }` is now enforced as required.

--- a/docs/openai-responses-api-design.md
+++ b/docs/openai-responses-api-design.md
@@ -99,9 +99,18 @@ Agent Maestro is stateless and doesn't persist responses between requests.
 
 **Error Response**: Return 400 with clear explanation directing users to send full history.
 
+### Supported Tools
+
+| Tool Type          | Handling                                                                                                                                                                                                                                                                      |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `function`         | Passed through with its JSON Schema parameters.                                                                                                                                                                                                                               |
+| `custom`           | Registered as a schema-less tool; the model's call is serialized back as a `custom_tool_call` (raw string input) instead of a `function_call`.                                                                                                                                |
+| `namespace`        | Nested `function`/`custom` tools are flattened. Since VSCode LM's tool-call shape has no namespace slot, each nested tool is registered under an encoded name `<namespace>__<name>` and decoded back into a separate `namespace` + bare `name` on output via a mapping table. |
+| `additional_tools` | Developer-injected tools carried on input items; merged with request-level tools before dispatch.                                                                                                                                                                             |
+
 ### Unsupported Tools
 
-Only `function` type tools are supported. Other tools are filtered out with a warning log.
+Other tool types are filtered out with a debug log.
 
 | Tool Type              | Reason                                        |
 | ---------------------- | --------------------------------------------- |
@@ -112,7 +121,6 @@ Only `function` type tools are supported. Other tools are filtered out with a wa
 | `image_gen`            | No VSCode LM equivalent                       |
 | `local_shell`          | Security concerns                             |
 | `mcp`                  | Would require separate MCP server integration |
-| `custom`               | No VSCode LM equivalent for custom tool input |
 | `shell`                | No VSCode LM equivalent                       |
 | `apply_patch`          | No VSCode LM equivalent                       |
 

--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
     "fastmcp": "^3.5.0",
     "hono": "^4.8.9",
     "image-size": "^2.0.2",
-    "openai": "^6.38.0",
+    "openai": "^6.46.0",
     "smol-toml": "^1.6.0",
     "uuid": "^11.1.0",
     "zod": "^4.0.10"
@@ -180,7 +180,7 @@
     "@trivago/prettier-plugin-sort-imports": "^5.2.2",
     "@types/mocha": "^10.0.10",
     "@types/node": "20.x",
-    "@types/vscode": "^1.120.0",
+    "@types/vscode": "^1.125.0",
     "@typescript-eslint/eslint-plugin": "^8.31.1",
     "@typescript-eslint/parser": "^8.31.1",
     "@vscode/test-cli": "^0.0.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,7 +32,7 @@ importers:
         version: 1.39.3
       fastmcp:
         specifier: ^3.5.0
-        version: 3.5.0
+        version: 3.5.0(supports-color@8.1.1)
       hono:
         specifier: ^4.8.9
         version: 4.8.9
@@ -40,8 +40,8 @@ importers:
         specifier: ^2.0.2
         version: 2.0.2
       openai:
-        specifier: ^6.38.0
-        version: 6.38.0(ws@8.18.3)(zod@4.0.10)
+        specifier: ^6.46.0
+        version: 6.46.0(ws@8.18.3)(zod@4.0.10)
       smol-toml:
         specifier: ^1.6.0
         version: 1.6.0
@@ -57,7 +57,7 @@ importers:
         version: 2.29.4
       "@trivago/prettier-plugin-sort-imports":
         specifier: ^5.2.2
-        version: 5.2.2(prettier@3.5.3)
+        version: 5.2.2(prettier@3.5.3)(supports-color@8.1.1)
       "@types/mocha":
         specifier: ^10.0.10
         version: 10.0.10
@@ -65,35 +65,35 @@ importers:
         specifier: 20.x
         version: 20.17.57
       "@types/vscode":
-        specifier: ^1.120.0
-        version: 1.120.0
+        specifier: ^1.125.0
+        version: 1.125.0
       "@typescript-eslint/eslint-plugin":
         specifier: ^8.31.1
-        version: 8.33.0(@typescript-eslint/parser@8.33.0(eslint@9.28.0)(typescript@5.8.3))(eslint@9.28.0)(typescript@5.8.3)
+        version: 8.33.0(@typescript-eslint/parser@8.33.0(eslint@9.28.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.8.3))(eslint@9.28.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.8.3)
       "@typescript-eslint/parser":
         specifier: ^8.31.1
-        version: 8.33.0(eslint@9.28.0)(typescript@5.8.3)
+        version: 8.33.0(eslint@9.28.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.8.3)
       "@vscode/test-cli":
         specifier: ^0.0.10
         version: 0.0.10
       "@vscode/test-electron":
         specifier: ^2.5.2
-        version: 2.5.2
+        version: 2.5.2(supports-color@8.1.1)
       "@vscode/vsce":
         specifier: ^3.7.0
-        version: 3.7.0
+        version: 3.7.0(supports-color@8.1.1)
       esbuild:
         specifier: ^0.25.3
         version: 0.25.5
       eslint:
         specifier: ^9.25.1
-        version: 9.28.0
+        version: 9.28.0(supports-color@8.1.1)
       husky:
         specifier: ^9.1.7
         version: 9.1.7
       lint-staged:
         specifier: ^16.1.0
-        version: 16.1.0
+        version: 16.1.0(supports-color@8.1.1)
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
@@ -1258,10 +1258,10 @@ packages:
         integrity: sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==,
       }
 
-  "@types/vscode@1.120.0":
+  "@types/vscode@1.125.0":
     resolution:
       {
-        integrity: sha512-feaT4Rst+FkTch5zz/ZbNCxoIvo55YU80Be2kiL7OJcod4+CUYf2lUBPdIJzozNnSEMq1VRTGrWEcCGFB3fBmA==,
+        integrity: sha512-0icm/ZQAaism87P0ekHqi4/Ju9du+Tm0RUW+y7vqRsxY2cY0FNRX1nAnaW7nT6npPt2tfHiheZ55Zm9UhqonFA==,
       }
 
   "@typescript-eslint/eslint-plugin@8.33.0":
@@ -2920,6 +2920,7 @@ packages:
       {
         integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==,
       }
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@11.0.2:
@@ -2928,6 +2929,7 @@ packages:
         integrity: sha512-YT7U7Vye+t5fZ/QMkBFrTJ7ZQxInIUjwyAjVj84CYXqgBdv30MFUPGnBR6sQaVq6Is15wYJUsnzTuWaGRBhBAQ==,
       }
     engines: { node: 20 || >=22 }
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@7.2.3:
@@ -2935,7 +2937,7 @@ packages:
       {
         integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==,
       }
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@8.1.0:
     resolution:
@@ -2943,7 +2945,7 @@ packages:
         integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==,
       }
     engines: { node: ">=12" }
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globals@14.0.0:
     resolution:
@@ -4316,16 +4318,24 @@ packages:
       }
     engines: { node: ">=18" }
 
-  openai@6.38.0:
+  openai@6.46.0:
     resolution:
       {
-        integrity: sha512-AoMplt2UalrpgUDMh3L09QWjNRlgJPipclQvA6sYAaeF6nHNBMgmikAZGmcYLn8on4d9sQY9Q8bOLfrBS7Lc8g==,
+        integrity: sha512-DFg6jEPT2RO+oAyXtddeUJU8zkGy1OQ1AjGzNIJUMQG03TTqvCpy9tBpQ+2VVVnvrl3E56F8GEin2JYtWpITtA==,
       }
-    hasBin: true
     peerDependencies:
+      "@aws-sdk/credential-provider-node": ">=3.972.0 <4"
+      "@smithy/hash-node": ">=4.3.0 <5"
+      "@smithy/signature-v4": ">=5.4.0 <6"
       ws: ^8.18.0
       zod: ^3.25 || ^4.0
     peerDependenciesMeta:
+      "@aws-sdk/credential-provider-node":
+        optional: true
+      "@smithy/hash-node":
+        optional: true
+      "@smithy/signature-v4":
+        optional: true
       ws:
         optional: true
       zod:
@@ -4677,6 +4687,7 @@ packages:
         integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==,
       }
     engines: { node: ">=10" }
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
 
   prelude-ls@1.2.1:
@@ -5743,6 +5754,7 @@ packages:
       {
         integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==,
       }
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-to-istanbul@9.3.0:
@@ -5785,6 +5797,7 @@ packages:
         integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==,
       }
     engines: { node: ">=18" }
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-mimetype@4.0.0:
     resolution:
@@ -6188,7 +6201,7 @@ snapshots:
       "@babel/parser": 7.28.3
       "@babel/types": 7.28.2
 
-  "@babel/traverse@7.28.3":
+  "@babel/traverse@7.28.3(supports-color@8.1.1)":
     dependencies:
       "@babel/code-frame": 7.27.1
       "@babel/generator": 7.28.3
@@ -6440,14 +6453,14 @@ snapshots:
   "@esbuild/win32-x64@0.25.5":
     optional: true
 
-  "@eslint-community/eslint-utils@4.7.0(eslint@9.28.0)":
+  "@eslint-community/eslint-utils@4.7.0(eslint@9.28.0(supports-color@8.1.1))":
     dependencies:
-      eslint: 9.28.0
+      eslint: 9.28.0(supports-color@8.1.1)
       eslint-visitor-keys: 3.4.3
 
   "@eslint-community/regexpp@4.12.1": {}
 
-  "@eslint/config-array@0.20.0":
+  "@eslint/config-array@0.20.0(supports-color@8.1.1)":
     dependencies:
       "@eslint/object-schema": 2.1.6
       debug: 4.4.1(supports-color@8.1.1)
@@ -6461,7 +6474,7 @@ snapshots:
     dependencies:
       "@types/json-schema": 7.0.15
 
-  "@eslint/eslintrc@3.3.1":
+  "@eslint/eslintrc@3.3.1(supports-color@8.1.1)":
     dependencies:
       ajv: 6.12.6
       debug: 4.4.1(supports-color@8.1.1)
@@ -6569,15 +6582,15 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  "@modelcontextprotocol/sdk@1.13.0":
+  "@modelcontextprotocol/sdk@1.13.0(supports-color@8.1.1)":
     dependencies:
       ajv: 6.12.6
       content-type: 1.0.5
       cors: 2.8.5
       cross-spawn: 7.0.6
       eventsource: 3.0.7
-      express: 5.1.0
-      express-rate-limit: 7.5.1(express@5.1.0)
+      express: 5.1.0(supports-color@8.1.1)
+      express-rate-limit: 7.5.1(express@5.1.0(supports-color@8.1.1))
       pkce-challenge: 5.0.0
       raw-body: 3.0.0
       zod: 3.25.76
@@ -6785,7 +6798,7 @@ snapshots:
     dependencies:
       "@textlint/ast-node-types": 15.3.0
 
-  "@tokenizer/inflate@0.2.7":
+  "@tokenizer/inflate@0.2.7(supports-color@8.1.1)":
     dependencies:
       debug: 4.4.1(supports-color@8.1.1)
       fflate: 0.8.2
@@ -6795,11 +6808,11 @@ snapshots:
 
   "@tokenizer/token@0.3.0": {}
 
-  "@trivago/prettier-plugin-sort-imports@5.2.2(prettier@3.5.3)":
+  "@trivago/prettier-plugin-sort-imports@5.2.2(prettier@3.5.3)(supports-color@8.1.1)":
     dependencies:
       "@babel/generator": 7.28.3
       "@babel/parser": 7.28.3
-      "@babel/traverse": 7.28.3
+      "@babel/traverse": 7.28.3(supports-color@8.1.1)
       "@babel/types": 7.28.2
       javascript-natural-sort: 0.7.1
       lodash: 4.17.21
@@ -6830,17 +6843,17 @@ snapshots:
 
   "@types/sarif@2.1.7": {}
 
-  "@types/vscode@1.120.0": {}
+  "@types/vscode@1.125.0": {}
 
-  "@typescript-eslint/eslint-plugin@8.33.0(@typescript-eslint/parser@8.33.0(eslint@9.28.0)(typescript@5.8.3))(eslint@9.28.0)(typescript@5.8.3)":
+  "@typescript-eslint/eslint-plugin@8.33.0(@typescript-eslint/parser@8.33.0(eslint@9.28.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.8.3))(eslint@9.28.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.8.3)":
     dependencies:
       "@eslint-community/regexpp": 4.12.1
-      "@typescript-eslint/parser": 8.33.0(eslint@9.28.0)(typescript@5.8.3)
+      "@typescript-eslint/parser": 8.33.0(eslint@9.28.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.8.3)
       "@typescript-eslint/scope-manager": 8.33.0
-      "@typescript-eslint/type-utils": 8.33.0(eslint@9.28.0)(typescript@5.8.3)
-      "@typescript-eslint/utils": 8.33.0(eslint@9.28.0)(typescript@5.8.3)
+      "@typescript-eslint/type-utils": 8.33.0(eslint@9.28.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.8.3)
+      "@typescript-eslint/utils": 8.33.0(eslint@9.28.0(supports-color@8.1.1))(typescript@5.8.3)
       "@typescript-eslint/visitor-keys": 8.33.0
-      eslint: 9.28.0
+      eslint: 9.28.0(supports-color@8.1.1)
       graphemer: 1.4.0
       ignore: 7.0.5
       natural-compare: 1.4.0
@@ -6849,19 +6862,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/parser@8.33.0(eslint@9.28.0)(typescript@5.8.3)":
+  "@typescript-eslint/parser@8.33.0(eslint@9.28.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.8.3)":
     dependencies:
       "@typescript-eslint/scope-manager": 8.33.0
       "@typescript-eslint/types": 8.33.0
-      "@typescript-eslint/typescript-estree": 8.33.0(typescript@5.8.3)
+      "@typescript-eslint/typescript-estree": 8.33.0(supports-color@8.1.1)(typescript@5.8.3)
       "@typescript-eslint/visitor-keys": 8.33.0
       debug: 4.4.1(supports-color@8.1.1)
-      eslint: 9.28.0
+      eslint: 9.28.0(supports-color@8.1.1)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/project-service@8.33.0(typescript@5.8.3)":
+  "@typescript-eslint/project-service@8.33.0(supports-color@8.1.1)(typescript@5.8.3)":
     dependencies:
       "@typescript-eslint/tsconfig-utils": 8.33.0(typescript@5.8.3)
       "@typescript-eslint/types": 8.33.0
@@ -6879,12 +6892,12 @@ snapshots:
     dependencies:
       typescript: 5.8.3
 
-  "@typescript-eslint/type-utils@8.33.0(eslint@9.28.0)(typescript@5.8.3)":
+  "@typescript-eslint/type-utils@8.33.0(eslint@9.28.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.8.3)":
     dependencies:
-      "@typescript-eslint/typescript-estree": 8.33.0(typescript@5.8.3)
-      "@typescript-eslint/utils": 8.33.0(eslint@9.28.0)(typescript@5.8.3)
+      "@typescript-eslint/typescript-estree": 8.33.0(supports-color@8.1.1)(typescript@5.8.3)
+      "@typescript-eslint/utils": 8.33.0(eslint@9.28.0(supports-color@8.1.1))(typescript@5.8.3)
       debug: 4.4.1(supports-color@8.1.1)
-      eslint: 9.28.0
+      eslint: 9.28.0(supports-color@8.1.1)
       ts-api-utils: 2.1.0(typescript@5.8.3)
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -6892,9 +6905,9 @@ snapshots:
 
   "@typescript-eslint/types@8.33.0": {}
 
-  "@typescript-eslint/typescript-estree@8.33.0(typescript@5.8.3)":
+  "@typescript-eslint/typescript-estree@8.33.0(supports-color@8.1.1)(typescript@5.8.3)":
     dependencies:
-      "@typescript-eslint/project-service": 8.33.0(typescript@5.8.3)
+      "@typescript-eslint/project-service": 8.33.0(supports-color@8.1.1)(typescript@5.8.3)
       "@typescript-eslint/tsconfig-utils": 8.33.0(typescript@5.8.3)
       "@typescript-eslint/types": 8.33.0
       "@typescript-eslint/visitor-keys": 8.33.0
@@ -6908,13 +6921,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/utils@8.33.0(eslint@9.28.0)(typescript@5.8.3)":
+  "@typescript-eslint/utils@8.33.0(eslint@9.28.0(supports-color@8.1.1))(typescript@5.8.3)":
     dependencies:
-      "@eslint-community/eslint-utils": 4.7.0(eslint@9.28.0)
+      "@eslint-community/eslint-utils": 4.7.0(eslint@9.28.0(supports-color@8.1.1))
       "@typescript-eslint/scope-manager": 8.33.0
       "@typescript-eslint/types": 8.33.0
-      "@typescript-eslint/typescript-estree": 8.33.0(typescript@5.8.3)
-      eslint: 9.28.0
+      "@typescript-eslint/typescript-estree": 8.33.0(supports-color@8.1.1)(typescript@5.8.3)
+      eslint: 9.28.0(supports-color@8.1.1)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
@@ -6926,8 +6939,8 @@ snapshots:
 
   "@typespec/ts-http-runtime@0.2.3":
     dependencies:
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      http-proxy-agent: 7.0.2(supports-color@8.1.1)
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -6944,10 +6957,10 @@ snapshots:
       supports-color: 9.4.0
       yargs: 17.7.2
 
-  "@vscode/test-electron@2.5.2":
+  "@vscode/test-electron@2.5.2(supports-color@8.1.1)":
     dependencies:
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      http-proxy-agent: 7.0.2(supports-color@8.1.1)
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
       jszip: 3.10.1
       ora: 8.2.0
       semver: 7.7.2
@@ -6993,7 +7006,7 @@ snapshots:
       "@vscode/vsce-sign-win32-arm64": 2.0.5
       "@vscode/vsce-sign-win32-x64": 2.0.5
 
-  "@vscode/vsce@3.7.0":
+  "@vscode/vsce@3.7.0(supports-color@8.1.1)":
     dependencies:
       "@azure/identity": 4.10.1
       "@secretlint/node": 10.2.2
@@ -7016,7 +7029,7 @@ snapshots:
       minimatch: 3.1.2
       parse-semver: 1.1.1
       read: 1.0.7
-      secretlint: 10.2.2
+      secretlint: 10.2.2(supports-color@8.1.1)
       semver: 7.7.2
       tmp: 0.2.3
       typed-rest-client: 1.8.11
@@ -7150,7 +7163,7 @@ snapshots:
       readable-stream: 3.6.2
     optional: true
 
-  body-parser@2.2.0:
+  body-parser@2.2.0(supports-color@8.1.1):
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
@@ -7668,14 +7681,14 @@ snapshots:
 
   eslint-visitor-keys@4.2.0: {}
 
-  eslint@9.28.0:
+  eslint@9.28.0(supports-color@8.1.1):
     dependencies:
-      "@eslint-community/eslint-utils": 4.7.0(eslint@9.28.0)
+      "@eslint-community/eslint-utils": 4.7.0(eslint@9.28.0(supports-color@8.1.1))
       "@eslint-community/regexpp": 4.12.1
-      "@eslint/config-array": 0.20.0
+      "@eslint/config-array": 0.20.0(supports-color@8.1.1)
       "@eslint/config-helpers": 0.2.2
       "@eslint/core": 0.14.0
-      "@eslint/eslintrc": 3.3.1
+      "@eslint/eslintrc": 3.3.1(supports-color@8.1.1)
       "@eslint/js": 9.28.0
       "@eslint/plugin-kit": 0.3.1
       "@humanfs/node": 0.16.6
@@ -7760,14 +7773,14 @@ snapshots:
   expand-template@2.0.3:
     optional: true
 
-  express-rate-limit@7.5.1(express@5.1.0):
+  express-rate-limit@7.5.1(express@5.1.0(supports-color@8.1.1)):
     dependencies:
-      express: 5.1.0
+      express: 5.1.0(supports-color@8.1.1)
 
-  express@5.1.0:
+  express@5.1.0(supports-color@8.1.1):
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.2.0
+      body-parser: 2.2.0(supports-color@8.1.1)
       content-disposition: 1.0.0
       content-type: 1.0.5
       cookie: 0.7.2
@@ -7776,7 +7789,7 @@ snapshots:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 2.1.0
+      finalhandler: 2.1.0(supports-color@8.1.1)
       fresh: 2.0.0
       http-errors: 2.0.0
       merge-descriptors: 2.0.0
@@ -7787,8 +7800,8 @@ snapshots:
       proxy-addr: 2.0.7
       qs: 6.14.0
       range-parser: 1.2.1
-      router: 2.2.0
-      send: 1.2.0
+      router: 2.2.0(supports-color@8.1.1)
+      send: 1.2.0(supports-color@8.1.1)
       serve-static: 2.2.0
       statuses: 2.0.2
       type-is: 2.0.1
@@ -7824,12 +7837,12 @@ snapshots:
 
   fast-uri@3.0.6: {}
 
-  fastmcp@3.5.0:
+  fastmcp@3.5.0(supports-color@8.1.1):
     dependencies:
-      "@modelcontextprotocol/sdk": 1.13.0
+      "@modelcontextprotocol/sdk": 1.13.0(supports-color@8.1.1)
       "@standard-schema/spec": 1.0.0
       execa: 9.6.0
-      file-type: 21.0.0
+      file-type: 21.0.0(supports-color@8.1.1)
       fuse.js: 7.1.0
       mcp-proxy: 5.1.1
       strict-event-emitter-types: 2.0.0
@@ -7869,9 +7882,9 @@ snapshots:
     dependencies:
       flat-cache: 4.0.1
 
-  file-type@21.0.0:
+  file-type@21.0.0(supports-color@8.1.1):
     dependencies:
-      "@tokenizer/inflate": 0.2.7
+      "@tokenizer/inflate": 0.2.7(supports-color@8.1.1)
       strtok3: 10.3.1
       token-types: 6.0.0
       uint8array-extras: 1.4.0
@@ -7882,7 +7895,7 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  finalhandler@2.1.0:
+  finalhandler@2.1.0(supports-color@8.1.1):
     dependencies:
       debug: 4.4.1(supports-color@8.1.1)
       encodeurl: 2.0.0
@@ -7982,7 +7995,7 @@ snapshots:
   gaxios@7.1.3:
     dependencies:
       extend: 3.0.2
-      https-proxy-agent: 7.0.6
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
       node-fetch: 3.3.2
       rimraf: 5.0.10
     transitivePeerDependencies:
@@ -8182,14 +8195,14 @@ snapshots:
       statuses: 2.0.1
       toidentifier: 1.0.1
 
-  http-proxy-agent@7.0.2:
+  http-proxy-agent@7.0.2(supports-color@8.1.1):
     dependencies:
       agent-base: 7.1.3
       debug: 4.4.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@7.0.6:
+  https-proxy-agent@7.0.6(supports-color@8.1.1):
     dependencies:
       agent-base: 7.1.3
       debug: 4.4.1(supports-color@8.1.1)
@@ -8561,7 +8574,7 @@ snapshots:
     dependencies:
       uc.micro: 2.1.0
 
-  lint-staged@16.1.0:
+  lint-staged@16.1.0(supports-color@8.1.1):
     dependencies:
       chalk: 5.4.1
       commander: 14.0.0
@@ -8665,7 +8678,7 @@ snapshots:
 
   mcp-proxy@5.1.1:
     dependencies:
-      "@modelcontextprotocol/sdk": 1.13.0
+      "@modelcontextprotocol/sdk": 1.13.0(supports-color@8.1.1)
       eventsource: 4.0.0
       yargs: 18.0.0
     transitivePeerDependencies:
@@ -8860,7 +8873,7 @@ snapshots:
       is-inside-container: 1.0.0
       is-wsl: 3.1.0
 
-  openai@6.38.0(ws@8.18.3)(zod@4.0.10):
+  openai@6.46.0(ws@8.18.3)(zod@4.0.10):
     optionalDependencies:
       ws: 8.18.3
       zod: 4.0.10
@@ -8896,7 +8909,7 @@ snapshots:
 
   ovsx@0.10.4:
     dependencies:
-      "@vscode/vsce": 3.7.0
+      "@vscode/vsce": 3.7.0(supports-color@8.1.1)
       commander: 6.2.1
       follow-redirects: 1.15.9
       is-ci: 2.0.0
@@ -9219,7 +9232,7 @@ snapshots:
       glob: 11.0.2
       package-json-from-dist: 1.0.1
 
-  router@2.2.0:
+  router@2.2.0(supports-color@8.1.1):
     dependencies:
       debug: 4.4.1(supports-color@8.1.1)
       depd: 2.0.0
@@ -9262,7 +9275,7 @@ snapshots:
 
   sax@1.4.1: {}
 
-  secretlint@10.2.2:
+  secretlint@10.2.2(supports-color@8.1.1):
     dependencies:
       "@secretlint/config-creator": 10.2.2
       "@secretlint/formatter": 10.2.2
@@ -9278,7 +9291,7 @@ snapshots:
 
   semver@7.7.2: {}
 
-  send@1.2.0:
+  send@1.2.0(supports-color@8.1.1):
     dependencies:
       debug: 4.4.1(supports-color@8.1.1)
       encodeurl: 2.0.0
@@ -9303,7 +9316,7 @@ snapshots:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 1.2.0
+      send: 1.2.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,9 @@ allowBuilds:
   esbuild: true
   keytar: true
 
+minimumReleaseAgeExclude:
+  - openai@6.46.0
+
 packageExtensions:
   "@roo-code/types":
     dependencies:

--- a/src/server/routes/openai/openaiResponsesRoutes.ts
+++ b/src/server/routes/openai/openaiResponsesRoutes.ts
@@ -22,10 +22,14 @@ import {
   convertResponsesInputToVSCode,
   convertResponsesToolsToVSCode,
   convertToolChoice,
+  customToolCallInput,
+  extractAdditionalTools,
+  generateCustomToolCallId,
   generateFunctionCallId,
   generateMessageId,
   generateResponseId,
   getCurrentTimestamp,
+  narrowToolsForChoice,
 } from "../../utils/openaiResponses";
 
 type NonStreamingResponse = Omit<
@@ -49,7 +53,7 @@ const createResponseRoute = createRoute({
 
 Limitations:
 - Stateless: previous_response_id, conversation, item_reference not supported (send full history in input array)
-- Only function tools supported (file_search, web_search, code_interpreter, custom, etc. are ignored)
+- Tools: function, custom, namespace, and additional_tools are supported; file_search, web_search, code_interpreter, mcp, etc. are ignored
 - Images: only base64 data URI supported (URL-based images fall back to JSON)
 - input_file: not supported (serialized as JSON text)
 - Annotations: always empty (VSCode LM doesn't provide annotations)
@@ -246,16 +250,51 @@ export function registerOpenaiResponsesRoutes(app: OpenAPIHono) {
       lmChatMessages = vsCodeMessages;
 
       // 7. Build request options
+      // Tools may arrive both at the top level and as `additional_tools`
+      // items injected mid-conversation; merge both sources.
+      const effectiveTools = [
+        ...(tools ?? []),
+        ...extractAdditionalTools(input),
+      ];
+      const { tools: vsCodeTools, toolMap } =
+        convertResponsesToolsToVSCode(effectiveTools);
       const shouldPassTools =
-        tool_choice !== "none" && tools && tools.length > 0;
+        tool_choice !== "none" && effectiveTools.length > 0;
+
+      let narrowedTools = vsCodeTools;
+      if (shouldPassTools) {
+        const narrowed = narrowToolsForChoice(
+          tool_choice as ToolChoice,
+          vsCodeTools,
+          toolMap,
+        );
+        if (!narrowed.ok) {
+          return c.json(
+            {
+              error: {
+                type: "invalid_request_error",
+                message:
+                  `tool_choice named "${narrowed.targetName}" matched ` +
+                  `${narrowed.matchCount} tools. A named tool_choice must ` +
+                  "resolve to exactly one available tool.",
+                param: "tool_choice",
+                code:
+                  narrowed.matchCount === 0
+                    ? "tool_not_found"
+                    : "ambiguous_tool_choice",
+              },
+            },
+            400,
+          );
+        }
+        narrowedTools = narrowed.tools;
+      }
 
       const lmRequestOptions: vscode.LanguageModelChatRequestOptions = {
         justification:
           "OpenAI Responses API endpoint using VS Code Language Model API",
         modelOptions,
-        tools: shouldPassTools
-          ? convertResponsesToolsToVSCode(tools)
-          : undefined,
+        tools: shouldPassTools ? narrowedTools : undefined,
         toolMode: shouldPassTools
           ? convertToolChoice(tool_choice as ToolChoice)
           : undefined,
@@ -297,7 +336,7 @@ export function registerOpenaiResponsesRoutes(app: OpenAPIHono) {
         }
 
         // Build output
-        const output = buildResponseOutput(accumulatedText, toolCalls);
+        const output = buildResponseOutput(accumulatedText, toolCalls, toolMap);
 
         if (!responseUsage) {
           const [fallbackInputTokens, outputTokens] = await Promise.all([
@@ -310,7 +349,7 @@ export function registerOpenaiResponsesRoutes(app: OpenAPIHono) {
           inputTokens = fallbackInputTokens;
           responseUsage = {
             input_tokens: fallbackInputTokens,
-            input_tokens_details: { cached_tokens: 0 },
+            input_tokens_details: { cached_tokens: 0, cache_write_tokens: 0 },
             output_tokens: outputTokens,
             output_tokens_details: { reasoning_tokens: 0 },
             total_tokens: fallbackInputTokens + outputTokens,
@@ -334,7 +373,7 @@ export function registerOpenaiResponsesRoutes(app: OpenAPIHono) {
         logger.debug("/v1/responses response:");
         logger.debug(JSON.stringify(responseObj, null, 2));
         logger.info(
-          `← /v1/responses | input: ${responseUsage.input_tokens} | cache_read: ${responseUsage.input_tokens_details.cached_tokens} | output: ${responseUsage.output_tokens}`,
+          `← /v1/responses | input: ${responseUsage?.input_tokens} | cache_read: ${responseUsage?.input_tokens_details?.cached_tokens} | output: ${responseUsage?.output_tokens}`,
         );
 
         cancellationTokenSource.dispose();
@@ -475,11 +514,84 @@ export function registerOpenaiResponsesRoutes(app: OpenAPIHono) {
                 accumulatedText = "";
               }
 
+              totalOutputText += JSON.stringify(chunk);
+
+              const toolInfo = toolMap.get(chunk.name);
+              const toolName = toolInfo?.name ?? chunk.name;
+              const toolNamespace = toolInfo?.namespace;
+
+              if (toolInfo?.isCustom) {
+                // Emit custom tool call events (raw string input, no JSON args)
+                const ctcId = generateCustomToolCallId();
+                const callId = chunk.callId;
+                const inputStr = customToolCallInput(chunk.input);
+
+                await sseStream.writeSSE({
+                  event: "response.output_item.added",
+                  data: JSON.stringify({
+                    type: "response.output_item.added",
+                    output_index: outputIndex,
+                    item: {
+                      type: "custom_tool_call",
+                      id: ctcId,
+                      call_id: callId,
+                      name: toolName,
+                      input: "",
+                      ...(toolNamespace ? { namespace: toolNamespace } : {}),
+                    },
+                    sequence_number: sequenceNumberRef.value++,
+                  }),
+                });
+
+                await sseStream.writeSSE({
+                  event: "response.custom_tool_call_input.delta",
+                  data: JSON.stringify({
+                    type: "response.custom_tool_call_input.delta",
+                    item_id: ctcId,
+                    output_index: outputIndex,
+                    delta: inputStr,
+                    sequence_number: sequenceNumberRef.value++,
+                  }),
+                });
+
+                await sseStream.writeSSE({
+                  event: "response.custom_tool_call_input.done",
+                  data: JSON.stringify({
+                    type: "response.custom_tool_call_input.done",
+                    item_id: ctcId,
+                    output_index: outputIndex,
+                    input: inputStr,
+                    sequence_number: sequenceNumberRef.value++,
+                  }),
+                });
+
+                output.push({
+                  type: "custom_tool_call",
+                  id: ctcId,
+                  call_id: callId,
+                  name: toolName,
+                  input: inputStr,
+                  ...(toolNamespace ? { namespace: toolNamespace } : {}),
+                });
+
+                await sseStream.writeSSE({
+                  event: "response.output_item.done",
+                  data: JSON.stringify({
+                    type: "response.output_item.done",
+                    output_index: outputIndex,
+                    item: output[outputIndex],
+                    sequence_number: sequenceNumberRef.value++,
+                  }),
+                });
+
+                outputIndex++;
+                continue;
+              }
+
               // Emit function call events
               const fcId = generateFunctionCallId();
               const callId = chunk.callId;
               const argsStr = JSON.stringify(chunk.input ?? {});
-              totalOutputText += JSON.stringify(chunk);
 
               await sseStream.writeSSE({
                 event: "response.output_item.added",
@@ -490,9 +602,10 @@ export function registerOpenaiResponsesRoutes(app: OpenAPIHono) {
                     type: "function_call",
                     id: fcId,
                     call_id: callId,
-                    name: chunk.name,
+                    name: toolName,
                     arguments: "",
                     status: "in_progress",
+                    ...(toolNamespace ? { namespace: toolNamespace } : {}),
                   },
                   sequence_number: sequenceNumberRef.value++,
                 }),
@@ -524,9 +637,10 @@ export function registerOpenaiResponsesRoutes(app: OpenAPIHono) {
                 type: "function_call",
                 id: fcId,
                 call_id: callId,
-                name: chunk.name,
+                name: toolName,
                 arguments: argsStr,
                 status: "completed",
+                ...(toolNamespace ? { namespace: toolNamespace } : {}),
               });
 
               await sseStream.writeSSE({
@@ -571,7 +685,7 @@ export function registerOpenaiResponsesRoutes(app: OpenAPIHono) {
             inputTokens = fallbackInputTokens;
             responseUsage = {
               input_tokens: fallbackInputTokens,
-              input_tokens_details: { cached_tokens: 0 },
+              input_tokens_details: { cached_tokens: 0, cache_write_tokens: 0 },
               output_tokens: outputTokens,
               output_tokens_details: { reasoning_tokens: 0 },
               total_tokens: fallbackInputTokens + outputTokens,
@@ -594,7 +708,7 @@ export function registerOpenaiResponsesRoutes(app: OpenAPIHono) {
           });
 
           logger.info(
-            `← /v1/responses (stream) | input: ${responseUsage.input_tokens} | cache_read: ${responseUsage.input_tokens_details.cached_tokens} | output: ${responseUsage.output_tokens}`,
+            `← /v1/responses (stream) | input: ${responseUsage?.input_tokens} | cache_read: ${responseUsage?.input_tokens_details?.cached_tokens} | cache_write: ${responseUsage?.input_tokens_details?.cache_write_tokens} | output: ${responseUsage?.output_tokens}`,
           );
           cancellationTokenSource?.dispose();
         },

--- a/src/server/utils/openai.ts
+++ b/src/server/utils/openai.ts
@@ -67,6 +67,8 @@ export function extractOpenAIResponsesUsage(chunk: {
       cached_tokens: nonNegativeNumberOrZero(
         usage.prompt_tokens_details?.cached_tokens,
       ),
+      // TODO: Add cache_write_tokens if available to CopilotUsagePayload and extract it here
+      cache_write_tokens: 0,
     },
     output_tokens: usage.completion_tokens,
     output_tokens_details: {

--- a/src/server/utils/openaiResponses.ts
+++ b/src/server/utils/openaiResponses.ts
@@ -401,7 +401,6 @@ export const convertResponsesItemToVSCode = (
   }
 
   logger.warn("Unknown input item type, skipping:", typedItem.type);
-  logger.debug(JSON.stringify(typedItem, null, 2));
   return null;
 };
 
@@ -499,6 +498,12 @@ export const convertResponsesToolsToVSCode = (
     description?: string | null,
     parameters?: unknown,
   ) => {
+    if (toolMap.has(encodedName)) {
+      logger.warn(
+        `Duplicate tool definition for \"${encodedName}\"; keeping the first definition`,
+      );
+      return;
+    }
     vsCodeTools.push({
       name: encodedName,
       description: description ?? "",
@@ -714,5 +719,5 @@ export const customToolCallInput = (input: unknown): string => {
   ) {
     return (input as { input: string }).input;
   }
-  return JSON.stringify(input ?? "");
+  return input === null || input === undefined ? "" : JSON.stringify(input);
 };

--- a/src/server/utils/openaiResponses.ts
+++ b/src/server/utils/openaiResponses.ts
@@ -3,6 +3,9 @@ import { SSEStreamingApi } from "hono/streaming";
 import {
   EasyInputMessage,
   FunctionTool,
+  NamespaceTool,
+  ResponseCustomToolCall,
+  ResponseCustomToolCallOutput,
   ResponseFunctionToolCall,
   ResponseInput,
   ResponseInputContent,
@@ -41,7 +44,10 @@ export type ToolChoice =
 /**
  * Output item types for Responses API (subset we generate)
  */
-export type OutputItem = ResponseOutputMessage | ResponseFunctionToolCall;
+export type OutputItem =
+  | ResponseOutputMessage
+  | ResponseFunctionToolCall
+  | ResponseCustomToolCall;
 
 /**
  * Generate random string for IDs using crypto
@@ -71,6 +77,12 @@ export const generateMessageId = (): string => `msg_AM-${randomString(12)}`;
  * Generate unique function call ID
  */
 export const generateFunctionCallId = (): string => `fc_AM-${randomString(12)}`;
+
+/**
+ * Generate unique custom tool call ID
+ */
+export const generateCustomToolCallId = (): string =>
+  `ctc_AM-${randomString(12)}`;
 
 /**
  * Get current Unix timestamp in seconds
@@ -178,6 +190,14 @@ const convertInputImageToVSCodePart = (
 export const convertInputContentToVSCodePart = (
   content: ResponseInputContent | ResponseOutputText,
 ): vscode.LanguageModelTextPart | vscode.LanguageModelDataPart => {
+  // `encrypted_content` is an opaque encrypted reasoning blob (Codex/OpenAI
+  // round-trips it back to the provider). It's not in the SDK content union.
+  // VSCode LM can't decrypt or use it, and dumping the ciphertext into the
+  // prompt is harmful, so drop it.
+  if ((content as { type?: string }).type === "encrypted_content") {
+    logger.debug("Dropping encrypted_content part (not usable by VSCode LM)");
+    return new vscode.LanguageModelTextPart("");
+  }
   switch (content.type) {
     case "input_text":
       return new vscode.LanguageModelTextPart(content.text ?? "");
@@ -283,8 +303,13 @@ export const convertResponsesItemToVSCode = (
     } catch (e) {
       logger.warn("Failed to parse function_call arguments:", e);
     }
+    // Namespaced tools are registered under an encoded name; re-encode so the
+    // replayed call matches a tool the model can still see (see toolMap).
+    const name = fc.namespace
+      ? encodeNamespacedName(fc.namespace, fc.name)
+      : fc.name;
     return vscode.LanguageModelChatMessage.Assistant([
-      new vscode.LanguageModelToolCallPart(fc.call_id, fc.name, input),
+      new vscode.LanguageModelToolCallPart(fc.call_id, name, input),
     ]);
   }
 
@@ -298,6 +323,62 @@ export const convertResponsesItemToVSCode = (
       new vscode.LanguageModelToolResultPart(fco.call_id, [
         new vscode.LanguageModelTextPart(outputText),
       ]),
+    ]);
+  }
+
+  // Handle custom_tool_call (assistant call to a `custom` tool). Its `input`
+  // is a raw string, not JSON. VSCode's tool call part requires an object
+  // input, so wrap it; downstream consumers read the raw string back out.
+  if (typedItem.type === "custom_tool_call") {
+    const ctc = item as unknown as ResponseCustomToolCall;
+    const name = ctc.namespace
+      ? encodeNamespacedName(ctc.namespace, ctc.name)
+      : ctc.name;
+    return vscode.LanguageModelChatMessage.Assistant([
+      new vscode.LanguageModelToolCallPart(ctc.call_id, name, {
+        input: ctc.input,
+      }),
+    ]);
+  }
+
+  // Handle custom_tool_call_output (result of a `custom` tool execution).
+  if (typedItem.type === "custom_tool_call_output") {
+    const ctco = item as unknown as ResponseCustomToolCallOutput;
+    const outputText =
+      typeof ctco.output === "string"
+        ? ctco.output
+        : JSON.stringify(ctco.output);
+    return vscode.LanguageModelChatMessage.User([
+      new vscode.LanguageModelToolResultPart(ctco.call_id, [
+        new vscode.LanguageModelTextPart(outputText),
+      ]),
+    ]);
+  }
+
+  // Handle additional_tools (tools injected mid-conversation).
+  // These carry no message content; their tools are merged separately via
+  // extractAdditionalTools, so there is nothing to convert into a message.
+  if (typedItem.type === "additional_tools") {
+    return null;
+  }
+
+  // Handle agent_message (Codex sub-agent/collaboration inter-agent message).
+  // Not part of the OpenAI SDK; its `content` is an array of input_* parts.
+  // Surface it as a User message so the model sees the exchanged text, tagging
+  // the author/recipient so provenance survives the flattening.
+  if (typedItem.type === "agent_message") {
+    const am = item as unknown as {
+      author?: string;
+      recipient?: string;
+      content?: ResponseInputContent[];
+    };
+    const parts = (am.content ?? []).map(convertInputContentToVSCodePart);
+    const header = `[agent_message${am.author ? ` from ${am.author}` : ""}${
+      am.recipient ? ` to ${am.recipient}` : ""
+    }]`;
+    return vscode.LanguageModelChatMessage.User([
+      new vscode.LanguageModelTextPart(header),
+      ...parts,
     ]);
   }
 
@@ -320,6 +401,7 @@ export const convertResponsesItemToVSCode = (
   }
 
   logger.warn("Unknown input item type, skipping:", typedItem.type);
+  logger.debug(JSON.stringify(typedItem, null, 2));
   return null;
 };
 
@@ -366,16 +448,66 @@ export const convertResponsesInputToVSCode = (
 };
 
 /**
- * Convert Responses API tools to VSCode LM tools (filter unsupported)
+ * Convert Responses API tools to VSCode LM tools.
+ *
+ * VSCode's LanguageModelChatTool only models flat function-style tools
+ * (name/description/inputSchema). Codex injects richer tool shapes via
+ * `additional_tools`, so we flatten them here:
+ *  - `function`: passed through directly.
+ *  - `custom`: exposed as a schema-less tool (freeform/grammar input the model
+ *    supplies as a raw string). The grammar/format hint cannot be represented
+ *    in VSCode LM and is dropped, but the tool stays callable by name.
+ *  - `namespace`: expanded into its nested function/custom tools. VSCode LM's
+ *    tool-call shape has no namespace slot, so each nested tool is registered
+ *    under an *encoded* name `<namespace>__<name>` to keep it unique across
+ *    namespaces. The returned `toolMap` records how to decode that back into a
+ *    separate `namespace` + bare `name` when serializing the model's tool call.
+ * Other tool types (file_search, web_search, etc.) are not executable via
+ * VSCode LM and are skipped.
  */
+export const NAMESPACE_SEPARATOR = "__";
+
+export const encodeNamespacedName = (namespace: string, name: string): string =>
+  `${namespace}${NAMESPACE_SEPARATOR}${name}`;
+
+export type ToolCallInfo = {
+  namespace?: string;
+  name: string;
+  isCustom: boolean;
+};
+
+export type ToolMap = Map<string, ToolCallInfo>;
+
+export type ConvertedTools = {
+  tools: vscode.LanguageModelChatTool[];
+  toolMap: ToolMap;
+};
+
 export const convertResponsesToolsToVSCode = (
   tools?: Tool[],
-): vscode.LanguageModelChatTool[] => {
+): ConvertedTools => {
+  const vsCodeTools: vscode.LanguageModelChatTool[] = [];
+  const toolMap: ToolMap = new Map();
+
   if (!tools) {
-    return [];
+    return { tools: vsCodeTools, toolMap };
   }
 
-  const vsCodeTools: vscode.LanguageModelChatTool[] = [];
+  const push = (
+    encodedName: string,
+    info: ToolCallInfo,
+    description?: string | null,
+    parameters?: unknown,
+  ) => {
+    vsCodeTools.push({
+      name: encodedName,
+      description: description ?? "",
+      inputSchema: info.isCustom
+        ? undefined
+        : ((parameters as object) ?? undefined),
+    });
+    toolMap.set(encodedName, info);
+  };
 
   for (const tool of tools) {
     if (!tool || typeof tool !== "object") {
@@ -384,19 +516,69 @@ export const convertResponsesToolsToVSCode = (
 
     if (tool.type === "function") {
       const funcTool = tool as FunctionTool;
-
-      vsCodeTools.push({
-        name: funcTool.name,
-        description: funcTool.description ?? "",
-        inputSchema: funcTool.parameters ?? undefined,
-      });
+      push(
+        funcTool.name,
+        { name: funcTool.name, isCustom: false },
+        funcTool.description,
+        funcTool.parameters,
+      );
+    } else if (tool.type === "custom") {
+      push(tool.name, { name: tool.name, isCustom: true }, tool.description);
+    } else if (tool.type === "namespace") {
+      const ns = tool as NamespaceTool;
+      for (const nested of ns.tools ?? []) {
+        const encoded = encodeNamespacedName(ns.name, nested.name);
+        if (nested.type === "custom") {
+          push(
+            encoded,
+            { namespace: ns.name, name: nested.name, isCustom: true },
+            nested.description,
+          );
+        } else {
+          push(
+            encoded,
+            { namespace: ns.name, name: nested.name, isCustom: false },
+            nested.description,
+            nested.parameters,
+          );
+        }
+      }
     } else {
       // Known tool types are expected and frequent, so keep the log at debug.
       logger.debug(`Tool type "${tool.type}" not supported, skipping`);
     }
   }
 
-  return vsCodeTools;
+  return { tools: vsCodeTools, toolMap };
+};
+
+/**
+ * Extract tools carried by `additional_tools` items in the input array.
+ * These are tools the developer injects mid-conversation; they must be merged
+ * with the request-level tools before being handed to the VSCode LM.
+ */
+export const extractAdditionalTools = (
+  input: string | ResponseInput | undefined,
+): Tool[] => {
+  if (!Array.isArray(input)) {
+    return [];
+  }
+
+  const tools: Tool[] = [];
+  for (const item of input) {
+    if (
+      item &&
+      typeof item === "object" &&
+      (item as { type?: string }).type === "additional_tools"
+    ) {
+      const additional = item as ResponseInputItem.AdditionalTools;
+      if (Array.isArray(additional.tools)) {
+        tools.push(...additional.tools);
+      }
+    }
+  }
+
+  return tools;
 };
 
 /**
@@ -410,11 +592,59 @@ export const convertToolChoice = (
   }
   if (
     toolChoice === "required" ||
-    (typeof toolChoice === "object" && toolChoice.type === "function")
+    (typeof toolChoice === "object" &&
+      (toolChoice.type === "function" || toolChoice.type === "custom"))
   ) {
     return vscode.LanguageModelChatToolMode.Required;
   }
   return vscode.LanguageModelChatToolMode.Auto; // Default for "auto"
+};
+
+/**
+ * When `tool_choice` names a single tool (`{ type: "function" | "custom", name }`),
+ * VSCode LM's `Required` mode can only force *some* tool call, not a *specific*
+ * one. To honor the choice we narrow the exposed tool list to just that tool.
+ *
+ * `tool_choice` carries no namespace, so we match by the tool's bare name via
+ * the `toolMap`, and additionally require the chosen `type` to agree with the
+ * tool's kind (`function` ↔ non-custom, `custom` ↔ custom) so a named choice
+ * can't select a tool of the wrong kind. Exactly one match narrows to it
+ * (`ok: true`). Zero or multiple matches cannot be represented safely —
+ * exposing every tool under `Required` would let the model call a *different*
+ * tool than requested — so we report `ok: false` and let the caller reject.
+ */
+export type NarrowToolsResult =
+  | { ok: true; tools: vscode.LanguageModelChatTool[] }
+  | { ok: false; targetName: string; matchCount: number };
+
+export const narrowToolsForChoice = (
+  toolChoice: ToolChoice | undefined,
+  vsCodeTools: vscode.LanguageModelChatTool[],
+  toolMap: ToolMap,
+): NarrowToolsResult => {
+  if (
+    !toolChoice ||
+    typeof toolChoice !== "object" ||
+    (toolChoice.type !== "function" && toolChoice.type !== "custom") ||
+    !toolChoice.name
+  ) {
+    return { ok: true, tools: vsCodeTools };
+  }
+
+  const targetName = toolChoice.name;
+  const wantCustom = toolChoice.type === "custom";
+  const matches = vsCodeTools.filter((t) => {
+    const info = toolMap.get(t.name);
+    const name = info?.name ?? t.name;
+    const isCustom = info?.isCustom ?? false;
+    return name === targetName && isCustom === wantCustom;
+  });
+
+  if (matches.length === 1) {
+    return { ok: true, tools: matches };
+  }
+
+  return { ok: false, targetName, matchCount: matches.length };
 };
 
 /**
@@ -424,6 +654,7 @@ export const convertToolChoice = (
 export const buildResponseOutput = (
   accumulatedText: string,
   toolCalls: { callId: string; name: string; input: unknown }[],
+  toolMap?: ToolMap,
 ): OutputItem[] => {
   const output: OutputItem[] = [];
 
@@ -440,15 +671,48 @@ export const buildResponseOutput = (
   }
 
   for (const tc of toolCalls) {
-    output.push({
-      type: "function_call",
-      id: generateFunctionCallId(),
-      call_id: tc.callId,
-      name: tc.name,
-      arguments: JSON.stringify(tc.input ?? {}),
-      status: "completed",
-    } as ResponseFunctionToolCall);
+    const info = toolMap?.get(tc.name);
+    const name = info?.name ?? tc.name;
+    if (info?.isCustom) {
+      output.push({
+        type: "custom_tool_call",
+        id: generateCustomToolCallId(),
+        call_id: tc.callId,
+        name,
+        input: customToolCallInput(tc.input),
+        ...(info.namespace ? { namespace: info.namespace } : {}),
+      } as ResponseCustomToolCall);
+    } else {
+      output.push({
+        type: "function_call",
+        id: generateFunctionCallId(),
+        call_id: tc.callId,
+        name,
+        arguments: JSON.stringify(tc.input ?? {}),
+        status: "completed",
+        ...(info?.namespace ? { namespace: info.namespace } : {}),
+      } as ResponseFunctionToolCall);
+    }
   }
 
   return output;
+};
+
+/**
+ * A `custom` tool's input is a raw string. We wrap it as `{ input: <string> }`
+ * when replaying history into VSCode LM, so unwrap that shape on the way out;
+ * fall back to JSON for anything else.
+ */
+export const customToolCallInput = (input: unknown): string => {
+  if (typeof input === "string") {
+    return input;
+  }
+  if (
+    input &&
+    typeof input === "object" &&
+    typeof (input as { input?: unknown }).input === "string"
+  ) {
+    return (input as { input: string }).input;
+  }
+  return JSON.stringify(input ?? "");
 };

--- a/src/test/server/openaiResponses.test.ts
+++ b/src/test/server/openaiResponses.test.ts
@@ -503,6 +503,35 @@ suite("OpenAI Responses Conversion Utils Test Suite", () => {
       });
     });
 
+    test("should keep the first duplicate tool definition", () => {
+      const tools = [
+        {
+          type: "function" as const,
+          name: "wait",
+          description: "Original definition",
+          parameters: { type: "object", properties: {} },
+        },
+        {
+          type: "function" as const,
+          name: "wait",
+          description: "Duplicate definition",
+          parameters: {
+            type: "object",
+            properties: { ms: { type: "number" } },
+          },
+        },
+      ];
+      const { tools: result, toolMap } = convertResponsesToolsToVSCode(
+        tools as any,
+      );
+      assert.strictEqual(result.length, 1);
+      assert.strictEqual(result[0].description, "Original definition");
+      assert.deepStrictEqual(toolMap.get("wait"), {
+        name: "wait",
+        isCustom: false,
+      });
+    });
+
     test("should skip non-function tools", () => {
       const tools = [
         { type: "function" as const, name: "valid_function" },
@@ -811,8 +840,8 @@ suite("OpenAI Responses Conversion Utils Test Suite", () => {
     });
 
     test("should stringify null/undefined to empty string", () => {
-      assert.strictEqual(customToolCallInput(null), '""');
-      assert.strictEqual(customToolCallInput(undefined), '""');
+      assert.strictEqual(customToolCallInput(null), "");
+      assert.strictEqual(customToolCallInput(undefined), "");
     });
   });
 

--- a/src/test/server/openaiResponses.test.ts
+++ b/src/test/server/openaiResponses.test.ts
@@ -9,9 +9,12 @@ import {
   convertResponsesItemToVSCode,
   convertResponsesToolsToVSCode,
   convertToolChoice,
+  customToolCallInput,
+  extractAdditionalTools,
   generateFunctionCallId,
   generateMessageId,
   generateResponseId,
+  narrowToolsForChoice,
 } from "../../server/utils/openaiResponses";
 
 const encode = (value: unknown): Uint8Array =>
@@ -85,6 +88,16 @@ suite("OpenAI Responses Conversion Utils Test Suite", () => {
       };
       const result = convertInputContentToVSCodePart(content);
       assert.ok(result instanceof vscode.LanguageModelTextPart);
+    });
+
+    test("should drop encrypted_content to an empty text part", () => {
+      const content = {
+        type: "encrypted_content",
+        data: "gAAAAABm..ciphertext..",
+      } as any;
+      const result = convertInputContentToVSCodePart(content);
+      assert.ok(result instanceof vscode.LanguageModelTextPart);
+      assert.strictEqual((result as vscode.LanguageModelTextPart).value, "");
     });
 
     test("should handle unknown content type by falling back to JSON", () => {
@@ -192,6 +205,21 @@ suite("OpenAI Responses Conversion Utils Test Suite", () => {
       assert.ok(result);
     });
 
+    test("should re-encode namespaced function_call name on replay", () => {
+      const item = {
+        type: "function_call" as const,
+        id: "fc_123",
+        call_id: "call_1",
+        namespace: "collaboration",
+        name: "spawn_agent",
+        arguments: "{}",
+        status: "completed" as const,
+      };
+      const result = convertResponsesItemToVSCode(item as any);
+      const part = (result!.content as any[])[0];
+      assert.strictEqual(part.name, "collaboration__spawn_agent");
+    });
+
     test("should convert function_call_output item", () => {
       const item = {
         type: "function_call_output" as const,
@@ -199,6 +227,114 @@ suite("OpenAI Responses Conversion Utils Test Suite", () => {
         output: '{"temperature": 72}',
       };
       const result = convertResponsesItemToVSCode(item);
+      assert.ok(result);
+      assert.strictEqual(
+        result!.role,
+        vscode.LanguageModelChatMessageRole.User,
+      );
+    });
+
+    test("should convert custom_tool_call item", () => {
+      const item = {
+        type: "custom_tool_call" as const,
+        id: "ctc_123",
+        call_id: "call_exec_1",
+        name: "exec",
+        input: "await tools.exec_command({ cmd: 'pwd' })",
+      };
+      const result = convertResponsesItemToVSCode(item);
+      assert.ok(result);
+      assert.strictEqual(
+        result!.role,
+        vscode.LanguageModelChatMessageRole.Assistant,
+      );
+      const part = (result!.content as any[])[0];
+      assert.strictEqual(part.callId, "call_exec_1");
+      assert.strictEqual(part.name, "exec");
+      // Raw string input is wrapped so VSCode's object-typed input is satisfied.
+      assert.deepStrictEqual(part.input, {
+        input: "await tools.exec_command({ cmd: 'pwd' })",
+      });
+    });
+
+    test("should re-encode namespaced custom_tool_call name on replay", () => {
+      const item = {
+        type: "custom_tool_call" as const,
+        id: "ctc_123",
+        call_id: "call_1",
+        namespace: "collaboration",
+        name: "raw_helper",
+        input: "raw",
+      };
+      const result = convertResponsesItemToVSCode(item as any);
+      const part = (result!.content as any[])[0];
+      assert.strictEqual(part.name, "collaboration__raw_helper");
+    });
+
+    test("should convert custom_tool_call_output item (string output)", () => {
+      const item = {
+        type: "custom_tool_call_output" as const,
+        call_id: "call_exec_1",
+        output: "/home/user/project",
+      };
+      const result = convertResponsesItemToVSCode(item);
+      assert.ok(result);
+      assert.strictEqual(
+        result!.role,
+        vscode.LanguageModelChatMessageRole.User,
+      );
+      const part = (result!.content as any[])[0];
+      assert.strictEqual(part.callId, "call_exec_1");
+    });
+
+    test("should convert custom_tool_call_output item (array output)", () => {
+      const item = {
+        type: "custom_tool_call_output" as const,
+        call_id: "call_exec_1",
+        output: [{ type: "input_text" as const, text: "done" }],
+      };
+      const result = convertResponsesItemToVSCode(item);
+      assert.ok(result);
+      assert.strictEqual(
+        result!.role,
+        vscode.LanguageModelChatMessageRole.User,
+      );
+    });
+
+    test("should return null for additional_tools item", () => {
+      const item = {
+        type: "additional_tools" as const,
+        role: "developer" as const,
+        tools: [{ type: "custom" as const, name: "exec" }],
+      };
+      const result = convertResponsesItemToVSCode(item as any);
+      assert.strictEqual(result, null);
+    });
+
+    test("should convert agent_message into a tagged User message", () => {
+      const item = {
+        type: "agent_message" as const,
+        author: "/root/second_review",
+        recipient: "/root",
+        content: [{ type: "input_text" as const, text: "review done" }],
+      };
+      const result = convertResponsesItemToVSCode(item as any);
+      assert.ok(result);
+      assert.strictEqual(
+        result!.role,
+        vscode.LanguageModelChatMessageRole.User,
+      );
+      const parts = result!.content as vscode.LanguageModelTextPart[];
+      assert.ok(
+        parts[0].value.includes("/root/second_review") &&
+          parts[0].value.includes("/root"),
+      );
+      assert.strictEqual(parts[1].value, "review done");
+    });
+
+    test("should handle agent_message without content", () => {
+      const item = { type: "agent_message" as const, author: "/root" };
+      const result = convertResponsesItemToVSCode(item as any);
       assert.ok(result);
       assert.strictEqual(
         result!.role,
@@ -293,7 +429,7 @@ suite("OpenAI Responses Conversion Utils Test Suite", () => {
           strict: false,
         },
       ];
-      const result = convertResponsesToolsToVSCode(tools);
+      const { tools: result } = convertResponsesToolsToVSCode(tools);
       assert.strictEqual(result.length, 1);
       assert.strictEqual(result[0].name, "get_weather");
       assert.strictEqual(result[0].description, "Get the weather");
@@ -308,10 +444,63 @@ suite("OpenAI Responses Conversion Utils Test Suite", () => {
           strict: false,
         },
       ];
-      const result = convertResponsesToolsToVSCode(tools);
+      const { tools: result } = convertResponsesToolsToVSCode(tools);
       assert.strictEqual(result.length, 1);
       assert.strictEqual(result[0].name, "simple_function");
       assert.strictEqual(result[0].description, "");
+    });
+
+    test("should convert custom tool to a schema-less tool", () => {
+      const tools = [
+        {
+          type: "custom" as const,
+          name: "exec",
+          description: "Run JavaScript",
+          format: { type: "grammar" as const, syntax: "lark", definition: "" },
+        },
+      ];
+      const { tools: result } = convertResponsesToolsToVSCode(tools as any);
+      assert.strictEqual(result.length, 1);
+      assert.strictEqual(result[0].name, "exec");
+      assert.strictEqual(result[0].description, "Run JavaScript");
+      assert.strictEqual(result[0].inputSchema, undefined);
+    });
+
+    test("should encode namespace tools as <ns>__<name> with a toolMap", () => {
+      const tools = [
+        {
+          type: "namespace" as const,
+          name: "collaboration",
+          description: "Sub-agent tools",
+          tools: [
+            {
+              type: "function" as const,
+              name: "spawn_agent",
+              description: "Spawn",
+              parameters: { type: "object", properties: {} },
+            },
+            { type: "custom" as const, name: "raw_helper", description: "Raw" },
+          ],
+        },
+      ];
+      const { tools: result, toolMap } = convertResponsesToolsToVSCode(
+        tools as any,
+      );
+      assert.strictEqual(result.length, 2);
+      assert.deepStrictEqual(
+        result.map((t) => t.name),
+        ["collaboration__spawn_agent", "collaboration__raw_helper"],
+      );
+      assert.deepStrictEqual(toolMap.get("collaboration__spawn_agent"), {
+        namespace: "collaboration",
+        name: "spawn_agent",
+        isCustom: false,
+      });
+      assert.deepStrictEqual(toolMap.get("collaboration__raw_helper"), {
+        namespace: "collaboration",
+        name: "raw_helper",
+        isCustom: true,
+      });
     });
 
     test("should skip non-function tools", () => {
@@ -320,18 +509,18 @@ suite("OpenAI Responses Conversion Utils Test Suite", () => {
         { type: "file_search" as const, vector_store_ids: ["vs_123"] },
         { type: "web_search_preview" as const },
       ] as any[];
-      const result = convertResponsesToolsToVSCode(tools);
+      const { tools: result } = convertResponsesToolsToVSCode(tools);
       assert.strictEqual(result.length, 1);
       assert.strictEqual(result[0].name, "valid_function");
     });
 
     test("should handle undefined tools", () => {
-      const result = convertResponsesToolsToVSCode(undefined);
+      const { tools: result } = convertResponsesToolsToVSCode(undefined);
       assert.strictEqual(result.length, 0);
     });
 
     test("should handle empty tools array", () => {
-      const result = convertResponsesToolsToVSCode([]);
+      const { tools: result } = convertResponsesToolsToVSCode([]);
       assert.strictEqual(result.length, 0);
     });
 
@@ -341,8 +530,91 @@ suite("OpenAI Responses Conversion Utils Test Suite", () => {
         { type: "function" as const, name: "valid" },
         undefined,
       ];
-      const result = convertResponsesToolsToVSCode(tools as any);
+      const { tools: result } = convertResponsesToolsToVSCode(tools as any);
       assert.strictEqual(result.length, 1);
+    });
+  });
+
+  suite("narrowToolsForChoice", () => {
+    const vsTools = [
+      { name: "exec", description: "", inputSchema: undefined },
+      { name: "wait", description: "", inputSchema: undefined },
+      {
+        name: "collaboration__spawn_agent",
+        description: "",
+        inputSchema: undefined,
+      },
+    ];
+    const toolMap = new Map<string, any>([
+      ["exec", { name: "exec", isCustom: true }],
+      ["wait", { name: "wait", isCustom: false }],
+      [
+        "collaboration__spawn_agent",
+        { namespace: "collaboration", name: "spawn_agent", isCustom: false },
+      ],
+    ]);
+
+    test("should narrow to the single named tool", () => {
+      const result = narrowToolsForChoice(
+        { type: "custom", name: "exec" } as any,
+        vsTools,
+        toolMap,
+      );
+      assert.strictEqual(result.ok, true);
+      assert.ok(result.ok && result.tools.length === 1);
+      assert.strictEqual(result.ok && result.tools[0].name, "exec");
+    });
+
+    test("should narrow to a namespaced tool by its bare name", () => {
+      const result = narrowToolsForChoice(
+        { type: "function", name: "spawn_agent" } as any,
+        vsTools,
+        toolMap,
+      );
+      assert.ok(result.ok && result.tools.length === 1);
+      assert.strictEqual(
+        result.ok && result.tools[0].name,
+        "collaboration__spawn_agent",
+      );
+    });
+
+    test("should fail when the named tool matches nothing", () => {
+      const result = narrowToolsForChoice(
+        { type: "function", name: "missing" } as any,
+        vsTools,
+        toolMap,
+      );
+      assert.strictEqual(result.ok, false);
+      assert.strictEqual(!result.ok && result.matchCount, 0);
+      assert.strictEqual(!result.ok && result.targetName, "missing");
+    });
+
+    test("should fail when the chosen type disagrees with the tool kind", () => {
+      // `exec` is a custom tool; asking for it as `function` must not match.
+      const result = narrowToolsForChoice(
+        { type: "function", name: "exec" } as any,
+        vsTools,
+        toolMap,
+      );
+      assert.strictEqual(result.ok, false);
+      assert.strictEqual(!result.ok && result.matchCount, 0);
+    });
+
+    test("should match a custom tool only for a custom choice", () => {
+      const result = narrowToolsForChoice(
+        { type: "custom", name: "exec" } as any,
+        vsTools,
+        toolMap,
+      );
+      assert.ok(result.ok && result.tools.length === 1);
+      assert.strictEqual(result.ok && result.tools[0].name, "exec");
+    });
+
+    test("should keep all tools for non-named choices", () => {
+      const req = narrowToolsForChoice("required" as any, vsTools, toolMap);
+      assert.ok(req.ok && req.tools.length === 3);
+      const none = narrowToolsForChoice(undefined, vsTools, toolMap);
+      assert.ok(none.ok && none.tools.length === 3);
     });
   });
 
@@ -372,6 +644,14 @@ suite("OpenAI Responses Conversion Utils Test Suite", () => {
         type: "function" as const,
         name: "get_weather",
       });
+      assert.strictEqual(result, vscode.LanguageModelChatToolMode.Required);
+    });
+
+    test("should return Required for custom type object", () => {
+      const result = convertToolChoice({
+        type: "custom" as const,
+        name: "exec",
+      } as any);
       assert.strictEqual(result, vscode.LanguageModelChatToolMode.Required);
     });
 
@@ -429,6 +709,111 @@ suite("OpenAI Responses Conversion Utils Test Suite", () => {
       const fc = output[0] as any;
       assert.strictEqual(fc.arguments, "{}");
     });
+
+    test("should emit custom_tool_call for custom tools via toolMap", () => {
+      const toolCalls = [
+        { callId: "call_1", name: "get_weather", input: { city: "NYC" } },
+        { callId: "call_2", name: "exec", input: { input: "pwd" } },
+      ];
+      const toolMap = new Map([
+        ["get_weather", { name: "get_weather", isCustom: false }],
+        ["exec", { name: "exec", isCustom: true }],
+      ]);
+      const output = buildResponseOutput("", toolCalls, toolMap as any);
+      assert.strictEqual(output.length, 2);
+      assert.strictEqual(output[0].type, "function_call");
+      assert.strictEqual(output[1].type, "custom_tool_call");
+      const ctc = output[1] as any;
+      assert.strictEqual(ctc.name, "exec");
+      assert.strictEqual(ctc.call_id, "call_2");
+      // Wrapped raw-string input is unwrapped back to the raw string.
+      assert.strictEqual(ctc.input, "pwd");
+    });
+
+    test("should decode namespaced names and restore namespace field", () => {
+      const toolCalls = [
+        {
+          callId: "call_1",
+          name: "collaboration__spawn_agent",
+          input: { task: "x" },
+        },
+        {
+          callId: "call_2",
+          name: "collaboration__raw_helper",
+          input: { input: "raw" },
+        },
+      ];
+      const toolMap = new Map([
+        [
+          "collaboration__spawn_agent",
+          { namespace: "collaboration", name: "spawn_agent", isCustom: false },
+        ],
+        [
+          "collaboration__raw_helper",
+          { namespace: "collaboration", name: "raw_helper", isCustom: true },
+        ],
+      ]);
+      const output = buildResponseOutput("", toolCalls, toolMap as any);
+      const fc = output[0] as any;
+      assert.strictEqual(fc.type, "function_call");
+      assert.strictEqual(fc.name, "spawn_agent");
+      assert.strictEqual(fc.namespace, "collaboration");
+      const ctc = output[1] as any;
+      assert.strictEqual(ctc.type, "custom_tool_call");
+      assert.strictEqual(ctc.name, "raw_helper");
+      assert.strictEqual(ctc.namespace, "collaboration");
+      assert.strictEqual(ctc.input, "raw");
+    });
+  });
+
+  suite("extractAdditionalTools", () => {
+    test("should extract tools from additional_tools items", () => {
+      const input = [
+        { role: "user" as const, content: "hi" },
+        {
+          type: "additional_tools" as const,
+          role: "developer" as const,
+          tools: [
+            { type: "custom" as const, name: "exec" },
+            { type: "function" as const, name: "wait" },
+          ],
+        },
+      ];
+      const tools = extractAdditionalTools(input as any);
+      assert.strictEqual(tools.length, 2);
+      assert.deepStrictEqual(
+        tools.map((t: any) => t.name),
+        ["exec", "wait"],
+      );
+    });
+
+    test("should return empty array for string input", () => {
+      assert.strictEqual(extractAdditionalTools("hello").length, 0);
+    });
+
+    test("should return empty array when no additional_tools present", () => {
+      const input = [{ role: "user" as const, content: "hi" }];
+      assert.strictEqual(extractAdditionalTools(input as any).length, 0);
+    });
+  });
+
+  suite("customToolCallInput", () => {
+    test("should pass through a raw string", () => {
+      assert.strictEqual(customToolCallInput("pwd"), "pwd");
+    });
+
+    test("should unwrap the { input } wrapper", () => {
+      assert.strictEqual(customToolCallInput({ input: "ls -la" }), "ls -la");
+    });
+
+    test("should JSON-stringify other object shapes", () => {
+      assert.strictEqual(customToolCallInput({ a: 1 }), '{"a":1}');
+    });
+
+    test("should stringify null/undefined to empty string", () => {
+      assert.strictEqual(customToolCallInput(null), '""');
+      assert.strictEqual(customToolCallInput(undefined), '""');
+    });
   });
 
   suite("extractOpenAIResponsesUsage", () => {
@@ -446,7 +831,7 @@ suite("OpenAI Responses Conversion Utils Test Suite", () => {
 
       assert.deepStrictEqual(result, {
         input_tokens: 10445,
-        input_tokens_details: { cached_tokens: 25 },
+        input_tokens_details: { cached_tokens: 25, cache_write_tokens: 0 },
         output_tokens: 88,
         output_tokens_details: { reasoning_tokens: 80 },
         total_tokens: 10533,


### PR DESCRIPTION
## Summary

Adds support for OpenAI Responses API `additional_tools`, `custom`, and `namespace` tool types (introduced with Codex/GPT-5.6) to the `/v1/responses` proxy, plus a few related input-item handlers surfaced during testing.

- **`custom` tools** round-trip as `custom_tool_call` items with raw string input (instead of `function_call` with JSON arguments).
- **`namespace` tools** are flattened and encoded as `<namespace>__<name>` across the VSCode LM boundary (which has no namespace slot), then decoded back into separate `namespace` + bare `name` on output via a mapping table. Historical `function_call`/`custom_tool_call` items re-encode on replay so multi-turn namespaced calls stay stable.
- **Named `tool_choice`** (`{ type, name }`) narrows the exposed tool list to the single tool matching both name **and** kind (`function` ↔ non-custom, `custom` ↔ custom). Zero / multiple / type-mismatch returns a **400** instead of silently exposing all tools under `Required` (which would let the model call a different tool than requested).
- **`additional_tools`** input items are extracted and merged with request-level tools.
- **`agent_message`** input items (Codex sub-agent collaboration) surface as tagged User messages.
- **`encrypted_content`** parts are dropped rather than dumped into the prompt as ciphertext.

Bumps `openai` to 6.46.0 and `@types/vscode` to 1.125.0 for the new SDK types.

## Test plan

- [x] `pnpm check-types`
- [x] `pnpm lint`
- [x] Unit tests — 366 passing (new coverage for namespace encode/decode, replay re-encoding, `narrowToolsForChoice` name+type matching, `agent_message`, `encrypted_content`)
- [x] Manual end-to-end with Codex/GPT-5.6 (custom tool exec, namespace `collaboration.*` multi-turn)

🤖 Generated with [Claude Code](https://claude.com/claude-code)