### PR TITLE
chore(release): v2.10.0

### DIFF
--- a/.changeset/additional-tools-support.md
+++ b/.changeset/additional-tools-support.md
@@ -1,5 +1,0 @@
----
-"agent-maestro": minor
----
-
-Support OpenAI Responses API `additional_tools`, `custom`, and `namespace` tool types (used by Codex/GPT-5.6). Custom tools round-trip as `custom_tool_call` items with raw string input, and namespaced tools preserve their `namespace` field across the VSCode LM boundary via an encoded-name mapping table. `tool_choice: { type: "custom" }` is now enforced as required.

--- a/.changeset/remove-copilot-fix-command.md
+++ b/.changeset/remove-copilot-fix-command.md
@@ -1,5 +1,0 @@
----
-"agent-maestro": patch
----
-
-Remove the GitHub Copilot Chat header fixer command because current VS Code builds ship Copilot Chat as a built-in extension, making the old user-extension patch path obsolete.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.10.0 - 2026.07.10
+
+- Add support for OpenAI Responses API `additional_tools`, `custom`, and `namespace` tools, enabling GPT-5.6 and Codex tool calling through Agent Maestro. Custom tool calls now preserve raw string input, and named `tool_choice` requests are enforced.
+- Remove the GitHub Copilot Chat header fixer command because current VS Code builds ship Copilot Chat as a built-in extension, making the old user-extension patch path obsolete.
+
 ## v2.9.7 - 2026.07.04
 
 - Fix Anthropic tool-result images being rejected as a media-type mismatch when large JPEG/GIF/WebP bytes were relabeled as PNG. Top-level image parts still keep the VS Code resize workaround, while nested tool-result images now preserve their declared media type.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "agent-maestro",
   "displayName": "Agent Maestro",
   "description": "Turn VS Code into your compliant AI playground! With Agent Maestro, spin up Cline or Roo on demand and plug Claude Code or Codex straight in through an OpenAI/Anthropic-compatible API.",
-  "version": "2.9.7",
+  "version": "2.10.0",
   "icon": "assets/icons/icon.png",
   "publisher": "Joouis",
   "repository": "https://github.com/Joouis/agent-maestro",


### PR DESCRIPTION
## Summary

- Bump Agent Maestro to v2.10.0.
- Regenerate the changelog for the merged Responses API tool support and Copilot Chat command removal.
- Consume the included changesets.

## Test plan

- [x] Pre-commit ESLint and Prettier checks
- [x] Lockfile supply-chain policy check
- [x] Reviewed generated version and changelog changes