### PR TITLE
fix(build): align vscode type version

### DIFF
--- a/package.json
+++ b/package.json
@@ -180,7 +180,7 @@
     "@trivago/prettier-plugin-sort-imports": "^5.2.2",
     "@types/mocha": "^10.0.10",
     "@types/node": "20.x",
-    "@types/vscode": "^1.125.0",
+    "@types/vscode": "^1.120.0",
     "@typescript-eslint/eslint-plugin": "^8.31.1",
     "@typescript-eslint/parser": "^8.31.1",
     "@vscode/test-cli": "^0.0.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,7 +66,7 @@ importers:
         version: 20.17.57
       "@types/vscode":
         specifier: ^1.120.0
-        version: 1.125.0
+        version: 1.120.0
       "@typescript-eslint/eslint-plugin":
         specifier: ^8.31.1
         version: 8.33.0(@typescript-eslint/parser@8.33.0(eslint@9.28.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.8.3))(eslint@9.28.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.8.3)
@@ -1258,10 +1258,10 @@ packages:
         integrity: sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==,
       }
 
-  "@types/vscode@1.125.0":
+  "@types/vscode@1.120.0":
     resolution:
       {
-        integrity: sha512-0icm/ZQAaism87P0ekHqi4/Ju9du+Tm0RUW+y7vqRsxY2cY0FNRX1nAnaW7nT6npPt2tfHiheZ55Zm9UhqonFA==,
+        integrity: sha512-feaT4Rst+FkTch5zz/ZbNCxoIvo55YU80Be2kiL7OJcod4+CUYf2lUBPdIJzozNnSEMq1VRTGrWEcCGFB3fBmA==,
       }
 
   "@typescript-eslint/eslint-plugin@8.33.0":
@@ -6843,7 +6843,7 @@ snapshots:
 
   "@types/sarif@2.1.7": {}
 
-  "@types/vscode@1.125.0": {}
+  "@types/vscode@1.120.0": {}
 
   "@typescript-eslint/eslint-plugin@8.33.0(@typescript-eslint/parser@8.33.0(eslint@9.28.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.8.3))(eslint@9.28.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.8.3)":
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,7 +65,7 @@ importers:
         specifier: 20.x
         version: 20.17.57
       "@types/vscode":
-        specifier: ^1.125.0
+        specifier: ^1.120.0
         version: 1.125.0
       "@typescript-eslint/eslint-plugin":
         specifier: ^8.31.1


### PR DESCRIPTION
## Summary

- Align the declared @types/vscode range with engines.vscode.
- Restore successful VSIX packaging with VSCE.

## Test plan

- [x] pnpm run vscode:package
- [x] pnpm run check-types
- [x] pnpm run lint