### PR TITLE
fix(proxy): cancel stalled language model requests

### DIFF
--- a/.changeset/quiet-pandas-wait.md
+++ b/.changeset/quiet-pandas-wait.md
@@ -1,0 +1,5 @@
+---
+"agent-maestro": patch
+---
+
+fix(proxy): cancel stalled Anthropic and OpenAI language model requests after ten minutes or when clients disconnect

--- a/README.md
+++ b/README.md
@@ -271,6 +271,8 @@ Perfect for Codex and OpenAI model integration:
 - **`POST /api/openai/v1/chat/completions`** - OpenAI Chat Completions API compatibility using VS Code's Language Model API
 - **`POST /api/openai/v1/responses`** - OpenAI Responses API compatibility using VS Code's Language Model API
 
+Anthropic Messages and both OpenAI endpoints cancel the upstream language model request when the client disconnects or when the request remains unfinished for 10 minutes. Non-streaming timeouts return HTTP 504; streaming timeouts use each protocol's error event instead of a successful completion event.
+
 ### Gemini-Compatible Endpoints
 
 Perfect for Gemini CLI integration:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -17,22 +17,23 @@ pnpm run watch-tests
 
 ## Test Coverage Summary
 
-| Test File                             | Tests | What It Covers                                            |
-| ------------------------------------- | ----- | --------------------------------------------------------- |
-| `extension.test.ts`                   | 13    | Extension activation, command registration, configuration |
-| `utils/copilotWebSearchPatch.test.ts` | 16    | Experimental Copilot web search bundle patching           |
-| `utils/config.test.ts`                | 5     | Configuration defaults and reading                        |
-| `utils/mimeTypes.test.ts`             | 12    | MIME type detection for file extensions                   |
-| `utils/rooSettingsFilter.test.ts`     | 5     | API key filtering from settings                           |
-| `utils/updateEnvFile.test.ts`         | 13    | .env file creation/update logic                           |
-| `schemas/cline.test.ts`               | 6     | Cline API request/response validation                     |
-| `schemas/roo.test.ts`                 | 7     | Roo API request/response validation                       |
-| `schemas/common.test.ts`              | 7     | Common schemas (file ops, extension info, OS info)        |
-| `server/anthropic.test.ts`            | 23    | Anthropic → VS Code message conversion                    |
-| `server/modelResolution.test.ts`      | 19    | Model matching and Copilot model configuration            |
-| `server/openaiChat.test.ts`           | 15    | OpenAI → VS Code message conversion                       |
-| `server/openaiResponses.test.ts`      | 54    | OpenAI Responses → VS Code conversion                     |
-| `server/gemini.test.ts`               | 27    | Gemini → VS Code message conversion                       |
+| Test File                                      | Tests | What It Covers                                            |
+| ---------------------------------------------- | ----- | --------------------------------------------------------- |
+| `extension.test.ts`                            | 13    | Extension activation, command registration, configuration |
+| `utils/copilotWebSearchPatch.test.ts`          | 16    | Experimental Copilot web search bundle patching           |
+| `utils/config.test.ts`                         | 5     | Configuration defaults and reading                        |
+| `utils/mimeTypes.test.ts`                      | 12    | MIME type detection for file extensions                   |
+| `utils/rooSettingsFilter.test.ts`              | 5     | API key filtering from settings                           |
+| `utils/updateEnvFile.test.ts`                  | 13    | .env file creation/update logic                           |
+| `schemas/cline.test.ts`                        | 6     | Cline API request/response validation                     |
+| `schemas/roo.test.ts`                          | 7     | Roo API request/response validation                       |
+| `schemas/common.test.ts`                       | 7     | Common schemas (file ops, extension info, OS info)        |
+| `server/anthropic.test.ts`                     | 23    | Anthropic → VS Code message conversion                    |
+| `server/languageModelRequestLifecycle.test.ts` | 14    | LM request timeout and disconnect cancellation            |
+| `server/modelResolution.test.ts`               | 19    | Model matching and Copilot model configuration            |
+| `server/openaiChat.test.ts`                    | 15    | OpenAI → VS Code message conversion                       |
+| `server/openaiResponses.test.ts`               | 54    | OpenAI Responses → VS Code conversion                     |
+| `server/gemini.test.ts`                        | 27    | Gemini → VS Code message conversion                       |
 
 ## How Tests Prevent Regressions
 

--- a/src/server/routes/anthropicRoutes.ts
+++ b/src/server/routes/anthropicRoutes.ts
@@ -26,6 +26,13 @@ import {
 } from "../utils/anthropicModels";
 import { handleErrorWithLogging } from "../utils/errorDiagnostics";
 import { isResponseTooLongError } from "../utils/languageModelErrors";
+import {
+  LANGUAGE_MODEL_REQUEST_TIMEOUT_MS,
+  LanguageModelClientDisconnectedError,
+  LanguageModelRequestLifecycle,
+  LanguageModelRequestTimeoutError,
+  interruptibleLanguageModelStream,
+} from "../utils/languageModelRequestLifecycle";
 
 const prepareAnthropicMessages = async ({
   requestBody,
@@ -112,6 +119,15 @@ const messagesRoute = createRoute({
         },
       },
       description: "Internal server error",
+    },
+    504: {
+      content: {
+        "application/json": {
+          schema: AnthropicErrorResponseSchema,
+        },
+      },
+      description:
+        "Gateway timeout - language model request exceeded 10 minutes",
     },
   },
 });
@@ -256,7 +272,19 @@ const modelRoute = createRoute({
   },
 });
 
-export function registerAnthropicRoutes(app: OpenAPIHono) {
+export interface AnthropicRoutesOptions {
+  requestTimeoutMs?: number;
+  resolveChatModelClient?: typeof getChatModelClient;
+}
+
+export function registerAnthropicRoutes(
+  app: OpenAPIHono,
+  options: AnthropicRoutesOptions = {},
+) {
+  const requestTimeoutMs =
+    options.requestTimeoutMs ?? LANGUAGE_MODEL_REQUEST_TIMEOUT_MS;
+  const resolveChatModelClient =
+    options.resolveChatModelClient ?? getChatModelClient;
   // GET /v1/models - Anthropic-compatible models endpoint
   app.openapi(modelsRoute, async (c) => {
     try {
@@ -322,7 +350,7 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
     let effectiveModelId = "";
     let rawRequestBody;
     let lmChatMessages: vscode.LanguageModelChatMessage[] | undefined;
-    let cancellationTokenSource: vscode.CancellationTokenSource | undefined;
+    let requestLifecycle: LanguageModelRequestLifecycle | undefined;
 
     try {
       // Parse request body
@@ -340,7 +368,7 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
       } = requestBody;
       // 1. Get chat model client (handles model mapping internally)
       const { client: initialClient, error: clientError } =
-        await getChatModelClient(model);
+        await resolveChatModelClient(model);
 
       if (initialClient) {
         effectiveModelId = initialClient.id;
@@ -357,8 +385,11 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
         requestBody,
       });
       lmChatMessages = vsCodeLmMessages;
-      cancellationTokenSource = new vscode.CancellationTokenSource();
-      const cancellationToken = cancellationTokenSource.token;
+      requestLifecycle = new LanguageModelRequestLifecycle(
+        c.req.raw.signal,
+        requestTimeoutMs,
+      );
+      const cancellationToken = requestLifecycle.token;
       logger.info(
         `→ /v1/messages | model: ${
           model === effectiveModelId ? model : `${model} → ${effectiveModelId}`
@@ -381,25 +412,28 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
       });
 
       // 5. Send request to the VS Code LM API
-      const response = await client.sendRequest(
-        vsCodeLmMessages,
-        withCopilotConfiguration(
-          client,
-          lmRequestOptions,
-          copilotConfiguration,
+      const response = await requestLifecycle.waitFor(
+        client.sendRequest(
+          vsCodeLmMessages,
+          withCopilotConfiguration(
+            client,
+            lmRequestOptions,
+            copilotConfiguration,
+          ),
+          cancellationToken,
         ),
-        cancellationToken,
       );
 
       const getFallbackUsage = async (
         accumulatedText: string,
       ): Promise<AnthropicTokenUsage> => {
-        const inputTokenCount = await client.countTokens(
-          JSON.stringify(requestBody),
-          cancellationToken,
+        const inputTokenCount = await requestLifecycle!.waitFor(
+          client.countTokens(JSON.stringify(requestBody), cancellationToken),
         );
         const outputTokenCount = accumulatedText
-          ? await client.countTokens(accumulatedText, cancellationToken)
+          ? await requestLifecycle!.waitFor(
+              client.countTokens(accumulatedText, cancellationToken),
+            )
           : 1;
 
         return {
@@ -418,7 +452,10 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
         let stopReason: Anthropic.Messages.StopReason = "end_turn";
 
         try {
-          for await (const chunk of response.stream) {
+          for await (const chunk of interruptibleLanguageModelStream(
+            response.stream,
+            requestLifecycle,
+          )) {
             if (chunk instanceof vscode.LanguageModelTextPart) {
               let lastBlock = content.at(-1);
               if (!lastBlock || lastBlock.type !== "text") {
@@ -490,7 +527,7 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
           `← /v1/messages | input: ${usage.input_tokens} | cache_read: ${usage.cache_read_input_tokens} | cache_creation: ${usage.cache_creation_input_tokens} | output: ${usage.output_tokens}`,
         );
 
-        cancellationTokenSource.dispose();
+        requestLifecycle.dispose();
         return c.json(resp);
       }
 
@@ -501,10 +538,12 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
           const writeSSE = async (
             message: Anthropic.Messages.RawMessageStreamEvent,
           ) => {
-            await stream.writeSSE({
-              event: message.type,
-              data: JSON.stringify(message),
-            });
+            await requestLifecycle!.waitFor(
+              stream.writeSSE({
+                event: message.type,
+                data: JSON.stringify(message),
+              }),
+            );
           };
 
           await writeSSE({
@@ -538,7 +577,10 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
           let stopReason: Anthropic.Messages.StopReason = "end_turn";
 
           try {
-            for await (const chunk of response.stream) {
+            for await (const chunk of interruptibleLanguageModelStream(
+              response.stream,
+              requestLifecycle!,
+            )) {
               const lastBlock = contentBlocks.at(-1);
               if (chunk instanceof vscode.LanguageModelTextPart) {
                 // Stop last non-text block if it exists
@@ -668,15 +710,62 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
           logger.info(
             `← /v1/messages (stream) | input: ${usage.input_tokens} | cache_read: ${usage.cache_read_input_tokens} | cache_creation: ${usage.cache_creation_input_tokens} | output: ${usage.output_tokens}`,
           );
-          cancellationTokenSource?.dispose();
+          requestLifecycle?.dispose();
         },
-        async (error, _stream) => {
+        async (error, stream) => {
+          if (error instanceof LanguageModelClientDisconnectedError) {
+            logger.info("/v1/messages | client disconnected");
+            requestLifecycle?.dispose();
+            await stream.close();
+            return;
+          }
+
+          if (error instanceof LanguageModelRequestTimeoutError) {
+            logger.error("✕ /v1/messages |", error);
+            try {
+              await stream.writeSSE({
+                event: "error",
+                data: JSON.stringify({
+                  type: "error",
+                  error: {
+                    type: "timeout_error",
+                    message: error.message,
+                  },
+                  request_id: null,
+                }),
+              });
+            } finally {
+              requestLifecycle?.dispose();
+              await stream.close();
+            }
+            return;
+          }
+
           logger.error("✕ /v1/messages |", error);
-          cancellationTokenSource?.dispose();
+          requestLifecycle?.dispose();
         },
       );
     } catch (error) {
-      cancellationTokenSource?.dispose();
+      requestLifecycle?.dispose();
+
+      if (error instanceof LanguageModelRequestTimeoutError) {
+        logger.error("✕ /v1/messages |", error);
+        return c.json(
+          {
+            error: {
+              message: error.message,
+              type: "timeout_error",
+            },
+          },
+          504,
+        );
+      }
+
+      if (error instanceof LanguageModelClientDisconnectedError) {
+        logger.info("/v1/messages | client disconnected");
+        return new Response(null, { status: 499 });
+      }
+
       logger.error("✕ /v1/messages |", error);
 
       const logFilePath = await handleErrorWithLogging({
@@ -721,7 +810,7 @@ export function registerAnthropicRoutes(app: OpenAPIHono) {
     try {
       const requestBody =
         (await c.req.json()) as Anthropic.Messages.MessageCreateParams;
-      const { client, error: clientError } = await getChatModelClient(
+      const { client, error: clientError } = await resolveChatModelClient(
         requestBody.model,
       );
 

--- a/src/server/routes/openai/openaiChatRoutes.ts
+++ b/src/server/routes/openai/openaiChatRoutes.ts
@@ -12,6 +12,12 @@ import {
 import { logger } from "../../../utils/logger";
 import { CommonResponseError } from "../../schemas/openai";
 import { handleErrorWithLogging } from "../../utils/errorDiagnostics";
+import {
+  LanguageModelClientDisconnectedError,
+  LanguageModelRequestLifecycle,
+  LanguageModelRequestTimeoutError,
+  interruptibleLanguageModelStream,
+} from "../../utils/languageModelRequestLifecycle";
 import { extractOpenAIChatUsage } from "../../utils/openai";
 import {
   convertOpenAIChatCompletionToolToVSCode,
@@ -87,17 +93,36 @@ const chatCompletionsRoute = createRoute({
       },
       description: "Internal server error",
     },
+    504: {
+      content: {
+        "application/json": {
+          schema: CommonResponseError,
+        },
+      },
+      description:
+        "Gateway timeout - language model request exceeded 10 minutes",
+    },
   },
 });
 
-export function registerOpenaiChatRoutes(app: OpenAPIHono) {
+export interface OpenaiChatRoutesOptions {
+  requestTimeoutMs?: number;
+  resolveChatModelClient?: typeof getChatModelClient;
+}
+
+export function registerOpenaiChatRoutes(
+  app: OpenAPIHono,
+  options: OpenaiChatRoutesOptions = {},
+) {
+  const resolveChatModelClient =
+    options.resolveChatModelClient ?? getChatModelClient;
   // POST /v1/chat/completions - OpenAI-compatible chat completions endpoint
   app.openapi(chatCompletionsRoute, async (c: Context): Promise<Response> => {
     let rawRequestBody: OpenAI.ChatCompletionCreateParams | undefined;
     let lmChatMessages: vscode.LanguageModelChatMessage[] | undefined;
     let requestedModelId = "";
     let inputTokens = 0;
-    let cancellationTokenSource: vscode.CancellationTokenSource | undefined;
+    let requestLifecycle: LanguageModelRequestLifecycle | undefined;
 
     try {
       // Parse and validate request body
@@ -124,7 +149,8 @@ export function registerOpenaiChatRoutes(app: OpenAPIHono) {
       requestedModelId = modelId;
 
       // 1. Get chat model client
-      const { client, error: clientError } = await getChatModelClient(modelId);
+      const { client, error: clientError } =
+        await resolveChatModelClient(modelId);
 
       if (clientError) {
         return c.json(clientError, 404);
@@ -132,8 +158,11 @@ export function registerOpenaiChatRoutes(app: OpenAPIHono) {
 
       logger.debug("/v1/chat/completions payload:");
       logger.debug(JSON.stringify(requestBody, null, 2));
-      cancellationTokenSource = new vscode.CancellationTokenSource();
-      const cancellationToken = cancellationTokenSource.token;
+      requestLifecycle = new LanguageModelRequestLifecycle(
+        c.req.raw.signal,
+        options.requestTimeoutMs,
+      );
+      const cancellationToken = requestLifecycle.token;
 
       logger.info(
         `→ /v1/chat/completions | model: ${
@@ -160,14 +189,16 @@ export function registerOpenaiChatRoutes(app: OpenAPIHono) {
       };
 
       // 4. Send request to VSCode LM API
-      const response = await client.sendRequest(
-        vsCodeLmMessages,
-        withCopilotConfiguration(
-          client,
-          lmRequestOptions,
-          copilotConfiguration,
+      const response = await requestLifecycle.waitFor(
+        client.sendRequest(
+          vsCodeLmMessages,
+          withCopilotConfiguration(
+            client,
+            lmRequestOptions,
+            copilotConfiguration,
+          ),
+          cancellationToken,
         ),
-        cancellationToken,
       );
 
       // 5. Handle non-streaming response
@@ -176,7 +207,10 @@ export function registerOpenaiChatRoutes(app: OpenAPIHono) {
         let toolCalls: OpenAI.ChatCompletionMessageToolCall[] = [];
         let accumulatedText = "";
         let completionUsage: OpenAI.CompletionUsage | undefined;
-        for await (const chunk of response.stream) {
+        for await (const chunk of interruptibleLanguageModelStream(
+          response.stream,
+          requestLifecycle,
+        )) {
           if (chunk instanceof vscode.LanguageModelTextPart) {
             content += chunk.value;
           } else if (chunk instanceof vscode.LanguageModelToolCallPart) {
@@ -195,10 +229,16 @@ export function registerOpenaiChatRoutes(app: OpenAPIHono) {
         }
 
         if (!completionUsage) {
-          const [promptTokens, completionTokens] = await Promise.all([
-            client.countTokens(JSON.stringify(requestBody), cancellationToken),
-            client.countTokens(accumulatedText, cancellationToken),
-          ]);
+          const [promptTokens, completionTokens] =
+            await requestLifecycle.waitFor(
+              Promise.all([
+                client.countTokens(
+                  JSON.stringify(requestBody),
+                  cancellationToken,
+                ),
+                client.countTokens(accumulatedText, cancellationToken),
+              ]),
+            );
           inputTokens = promptTokens;
           completionUsage = {
             prompt_tokens: promptTokens,
@@ -236,7 +276,7 @@ export function registerOpenaiChatRoutes(app: OpenAPIHono) {
           `← /v1/chat/completions | input: ${completionUsage.prompt_tokens} | cache_read: ${completionUsage.prompt_tokens_details?.cached_tokens ?? 0} | output: ${completionUsage.completion_tokens}`,
         );
 
-        cancellationTokenSource.dispose();
+        requestLifecycle.dispose();
         return c.json(openaiResponse);
       }
 
@@ -265,15 +305,19 @@ export function registerOpenaiChatRoutes(app: OpenAPIHono) {
               },
             ],
           };
-          await stream.writeSSE({
-            data: JSON.stringify(initialChunk),
-          });
+          const writeSSE = (data: string) =>
+            requestLifecycle!.waitFor(stream.writeSSE({ data }));
+
+          await writeSSE(JSON.stringify(initialChunk));
 
           // Process streaming response
           let accumulatedText = "";
           let toolCalls: vscode.LanguageModelToolCallPart[] = [];
           let completionUsage: OpenAI.CompletionUsage | undefined;
-          for await (const chunk of response.stream) {
+          for await (const chunk of interruptibleLanguageModelStream(
+            response.stream,
+            requestLifecycle!,
+          )) {
             if (chunk instanceof vscode.LanguageModelTextPart) {
               const contentChunk: OpenAI.ChatCompletionChunk = {
                 id: chatCompletionId,
@@ -292,9 +336,7 @@ export function registerOpenaiChatRoutes(app: OpenAPIHono) {
                   },
                 ],
               };
-              await stream.writeSSE({
-                data: JSON.stringify(contentChunk),
-              });
+              await writeSSE(JSON.stringify(contentChunk));
             } else if (chunk instanceof vscode.LanguageModelToolCallPart) {
               toolCalls.push(chunk);
               const toolCallChunk: OpenAI.ChatCompletionChunk = {
@@ -324,9 +366,7 @@ export function registerOpenaiChatRoutes(app: OpenAPIHono) {
                   },
                 ],
               };
-              await stream.writeSSE({
-                data: JSON.stringify(toolCallChunk),
-              });
+              await writeSSE(JSON.stringify(toolCallChunk));
             } else if (chunk instanceof vscode.LanguageModelDataPart) {
               completionUsage =
                 extractOpenAIChatUsage(chunk) ?? completionUsage;
@@ -335,13 +375,16 @@ export function registerOpenaiChatRoutes(app: OpenAPIHono) {
           }
 
           if (!completionUsage) {
-            const [promptTokens, completionTokens] = await Promise.all([
-              client.countTokens(
-                JSON.stringify(requestBody),
-                cancellationToken,
-              ),
-              client.countTokens(accumulatedText, cancellationToken),
-            ]);
+            const [promptTokens, completionTokens] =
+              await requestLifecycle!.waitFor(
+                Promise.all([
+                  client.countTokens(
+                    JSON.stringify(requestBody),
+                    cancellationToken,
+                  ),
+                  client.countTokens(accumulatedText, cancellationToken),
+                ]),
+              );
             inputTokens = promptTokens;
 
             completionUsage = {
@@ -370,50 +413,70 @@ export function registerOpenaiChatRoutes(app: OpenAPIHono) {
               ? completionUsage
               : undefined,
           };
-          await stream.writeSSE({
-            data: JSON.stringify(finalChunk),
-          });
+          await writeSSE(JSON.stringify(finalChunk));
 
           // Send [DONE] signal
-          await stream.writeSSE({
-            data: "[DONE]",
-          });
+          await writeSSE("[DONE]");
 
           logger.info(
             `← /v1/chat/completions (stream) | input: ${completionUsage.prompt_tokens} | cache_read: ${completionUsage.prompt_tokens_details?.cached_tokens ?? 0} | output: ${completionUsage.completion_tokens}`,
           );
-          cancellationTokenSource?.dispose();
+          requestLifecycle?.dispose();
         },
         async (error, stream) => {
-          logger.error("✕ /v1/chat/completions (stream) |", error);
-          cancellationTokenSource?.dispose();
+          if (error instanceof LanguageModelClientDisconnectedError) {
+            logger.info("/v1/chat/completions | client disconnected");
+            requestLifecycle?.dispose();
+            await stream.close();
+            return;
+          }
 
-          // Send error chunk to client before closing
+          logger.error("✕ /v1/chat/completions (stream) |", error);
+          requestLifecycle?.dispose();
+
           const errorMessage =
             error instanceof Error ? error.message : String(error);
-          const errorChunk: OpenAI.ChatCompletionChunk = {
-            id: `AM-${Date.now()}`,
-            object: "chat.completion.chunk",
-            created: Math.floor(Date.now() / 1000),
-            model: modelId,
-            choices: [
-              {
-                index: 0,
-                delta: {
-                  content: `\n\n[Error: ${errorMessage}]`,
-                },
-                finish_reason: "stop",
-                logprobs: null,
-              },
-            ],
-          };
           await stream.writeSSE({
-            data: JSON.stringify(errorChunk),
+            event: "error",
+            data: JSON.stringify({
+              error: {
+                message: errorMessage,
+                type:
+                  error instanceof LanguageModelRequestTimeoutError
+                    ? "timeout_error"
+                    : "server_error",
+                code:
+                  error instanceof LanguageModelRequestTimeoutError
+                    ? "request_timeout"
+                    : "server_error",
+              },
+            }),
           });
+          await stream.close();
         },
       );
     } catch (error) {
-      cancellationTokenSource?.dispose();
+      requestLifecycle?.dispose();
+
+      if (error instanceof LanguageModelRequestTimeoutError) {
+        logger.error("✕ /v1/chat/completions |", error);
+        return c.json(
+          {
+            error: {
+              message: error.message,
+              type: "timeout_error",
+              code: "request_timeout",
+            },
+          },
+          504,
+        );
+      }
+
+      if (error instanceof LanguageModelClientDisconnectedError) {
+        logger.info("/v1/chat/completions | client disconnected");
+        return new Response(null, { status: 499 });
+      }
+
       logger.error("✕ /v1/chat/completions |", error);
 
       const logFilePath = await handleErrorWithLogging({

--- a/src/server/routes/openai/openaiChatRoutes.ts
+++ b/src/server/routes/openai/openaiChatRoutes.ts
@@ -426,33 +426,39 @@ export function registerOpenaiChatRoutes(
         async (error, stream) => {
           if (error instanceof LanguageModelClientDisconnectedError) {
             logger.info("/v1/chat/completions | client disconnected");
-            requestLifecycle?.dispose();
-            await stream.close();
+            try {
+              await stream.close();
+            } finally {
+              requestLifecycle?.dispose();
+            }
             return;
           }
 
           logger.error("✕ /v1/chat/completions (stream) |", error);
-          requestLifecycle?.dispose();
 
           const errorMessage =
             error instanceof Error ? error.message : String(error);
-          await stream.writeSSE({
-            event: "error",
-            data: JSON.stringify({
-              error: {
-                message: errorMessage,
-                type:
-                  error instanceof LanguageModelRequestTimeoutError
-                    ? "timeout_error"
-                    : "server_error",
-                code:
-                  error instanceof LanguageModelRequestTimeoutError
-                    ? "request_timeout"
-                    : "server_error",
-              },
-            }),
-          });
-          await stream.close();
+          try {
+            await stream.writeSSE({
+              event: "error",
+              data: JSON.stringify({
+                error: {
+                  message: errorMessage,
+                  type:
+                    error instanceof LanguageModelRequestTimeoutError
+                      ? "timeout_error"
+                      : "server_error",
+                  code:
+                    error instanceof LanguageModelRequestTimeoutError
+                      ? "request_timeout"
+                      : "server_error",
+                },
+              }),
+            });
+          } finally {
+            requestLifecycle?.dispose();
+            await stream.close();
+          }
         },
       );
     } catch (error) {
@@ -465,6 +471,7 @@ export function registerOpenaiChatRoutes(
             error: {
               message: error.message,
               type: "timeout_error",
+              param: null,
               code: "request_timeout",
             },
           },

--- a/src/server/routes/openai/openaiResponsesRoutes.ts
+++ b/src/server/routes/openai/openaiResponsesRoutes.ts
@@ -19,6 +19,12 @@ import {
 import { logger } from "../../../utils/logger";
 import { CommonResponseError } from "../../schemas/openai";
 import { handleErrorWithLogging } from "../../utils/errorDiagnostics";
+import {
+  LanguageModelClientDisconnectedError,
+  LanguageModelRequestLifecycle,
+  LanguageModelRequestTimeoutError,
+  interruptibleLanguageModelStream,
+} from "../../utils/languageModelRequestLifecycle";
 import { extractOpenAIResponsesUsage } from "../../utils/openai";
 import {
   OutputItem,
@@ -123,16 +129,35 @@ Limitations:
       },
       description: "Internal server error",
     },
+    504: {
+      content: {
+        "application/json": {
+          schema: CommonResponseError,
+        },
+      },
+      description:
+        "Gateway timeout - language model request exceeded 10 minutes",
+    },
   },
 });
 
-export function registerOpenaiResponsesRoutes(app: OpenAPIHono) {
+export interface OpenaiResponsesRoutesOptions {
+  requestTimeoutMs?: number;
+  resolveChatModelClient?: typeof getChatModelClient;
+}
+
+export function registerOpenaiResponsesRoutes(
+  app: OpenAPIHono,
+  options: OpenaiResponsesRoutesOptions = {},
+) {
+  const resolveChatModelClient =
+    options.resolveChatModelClient ?? getChatModelClient;
   app.openapi(createResponseRoute, async (c: Context): Promise<Response> => {
     let rawRequestBody: Responses.ResponseCreateParams | undefined;
     let lmChatMessages: vscode.LanguageModelChatMessage[] | undefined;
     let requestedModelId = "";
     let inputTokens = 0;
-    let cancellationTokenSource: vscode.CancellationTokenSource | undefined;
+    let requestLifecycle: LanguageModelRequestLifecycle | undefined;
 
     try {
       // 1. Parse request and extract fields
@@ -236,7 +261,8 @@ export function registerOpenaiResponsesRoutes(app: OpenAPIHono) {
       }
 
       // 4. Get chat model client
-      const { client, error: clientError } = await getChatModelClient(model);
+      const { client, error: clientError } =
+        await resolveChatModelClient(model);
 
       if (clientError) {
         return c.json(clientError, 404);
@@ -244,8 +270,11 @@ export function registerOpenaiResponsesRoutes(app: OpenAPIHono) {
 
       logger.debug("/v1/responses payload:");
       logger.debug(JSON.stringify(requestBody, null, 2));
-      cancellationTokenSource = new vscode.CancellationTokenSource();
-      const cancellationToken = cancellationTokenSource.token;
+      requestLifecycle = new LanguageModelRequestLifecycle(
+        c.req.raw.signal,
+        options.requestTimeoutMs,
+      );
+      const cancellationToken = requestLifecycle.token;
 
       logger.info(
         `→ /v1/responses | model: ${
@@ -349,14 +378,16 @@ export function registerOpenaiResponsesRoutes(app: OpenAPIHono) {
       });
 
       // 8. Send request to VSCode LM
-      const response = await client.sendRequest(
-        vsCodeMessages,
-        withCopilotConfiguration(
-          client,
-          lmRequestOptions,
-          copilotConfiguration,
+      const response = await requestLifecycle.waitFor(
+        client.sendRequest(
+          vsCodeMessages,
+          withCopilotConfiguration(
+            client,
+            lmRequestOptions,
+            copilotConfiguration,
+          ),
+          cancellationToken,
         ),
-        cancellationToken,
       );
 
       // 9. Handle non-streaming response
@@ -366,7 +397,10 @@ export function registerOpenaiResponsesRoutes(app: OpenAPIHono) {
           [];
         let responseUsage: ResponseUsage | undefined;
 
-        for await (const chunk of response.stream) {
+        for await (const chunk of interruptibleLanguageModelStream(
+          response.stream,
+          requestLifecycle,
+        )) {
           if (chunk instanceof vscode.LanguageModelTextPart) {
             accumulatedText += chunk.value;
           } else if (chunk instanceof vscode.LanguageModelToolCallPart) {
@@ -384,13 +418,19 @@ export function registerOpenaiResponsesRoutes(app: OpenAPIHono) {
         const output = buildResponseOutput(accumulatedText, toolCalls, toolMap);
 
         if (!responseUsage) {
-          const [fallbackInputTokens, outputTokens] = await Promise.all([
-            client.countTokens(JSON.stringify(requestBody), cancellationToken),
-            client.countTokens(
-              accumulatedText + JSON.stringify(toolCalls),
-              cancellationToken,
-            ),
-          ]);
+          const [fallbackInputTokens, outputTokens] =
+            await requestLifecycle.waitFor(
+              Promise.all([
+                client.countTokens(
+                  JSON.stringify(requestBody),
+                  cancellationToken,
+                ),
+                client.countTokens(
+                  accumulatedText + JSON.stringify(toolCalls),
+                  cancellationToken,
+                ),
+              ]),
+            );
           inputTokens = fallbackInputTokens;
           responseUsage = {
             input_tokens: fallbackInputTokens,
@@ -421,7 +461,7 @@ export function registerOpenaiResponsesRoutes(app: OpenAPIHono) {
           `← /v1/responses | input: ${responseUsage?.input_tokens} | cache_read: ${responseUsage?.input_tokens_details?.cached_tokens} | output: ${responseUsage?.output_tokens}`,
         );
 
-        cancellationTokenSource.dispose();
+        requestLifecycle.dispose();
         return c.json(responseObj);
       }
 
@@ -432,6 +472,9 @@ export function registerOpenaiResponsesRoutes(app: OpenAPIHono) {
           const responseId = generateResponseId();
           const createdAt = getCurrentTimestamp();
           const sequenceNumberRef = { value: 0 };
+          const writeSSE = (
+            message: Parameters<typeof sseStream.writeSSE>[0],
+          ) => requestLifecycle!.waitFor(sseStream.writeSSE(message));
 
           // Build base response object
           const baseResponse = {
@@ -464,7 +507,7 @@ export function registerOpenaiResponsesRoutes(app: OpenAPIHono) {
           });
 
           // Emit response.created
-          await sseStream.writeSSE({
+          await writeSSE({
             event: "response.created",
             data: JSON.stringify({
               type: "response.created",
@@ -474,7 +517,7 @@ export function registerOpenaiResponsesRoutes(app: OpenAPIHono) {
           });
 
           // Emit response.in_progress
-          await sseStream.writeSSE({
+          await writeSSE({
             event: "response.in_progress",
             data: JSON.stringify({
               type: "response.in_progress",
@@ -492,14 +535,17 @@ export function registerOpenaiResponsesRoutes(app: OpenAPIHono) {
           let totalOutputText = ""; // Track all output for token counting
           let responseUsage: ResponseUsage | undefined;
 
-          for await (const chunk of response.stream) {
+          for await (const chunk of interruptibleLanguageModelStream(
+            response.stream,
+            requestLifecycle!,
+          )) {
             if (chunk instanceof vscode.LanguageModelTextPart) {
               if (!currentMessageId) {
                 // Start new message output item
                 currentMessageId = generateMessageId();
                 contentIndex = 0;
 
-                await sseStream.writeSSE({
+                await writeSSE({
                   event: "response.output_item.added",
                   data: JSON.stringify({
                     type: "response.output_item.added",
@@ -515,7 +561,7 @@ export function registerOpenaiResponsesRoutes(app: OpenAPIHono) {
                   }),
                 });
 
-                await sseStream.writeSSE({
+                await writeSSE({
                   event: "response.content_part.added",
                   data: JSON.stringify({
                     type: "response.content_part.added",
@@ -531,7 +577,7 @@ export function registerOpenaiResponsesRoutes(app: OpenAPIHono) {
               // Emit text delta
               accumulatedText += chunk.value;
               totalOutputText += chunk.value;
-              await sseStream.writeSSE({
+              await writeSSE({
                 event: "response.output_text.delta",
                 data: JSON.stringify({
                   type: "response.output_text.delta",
@@ -546,7 +592,7 @@ export function registerOpenaiResponsesRoutes(app: OpenAPIHono) {
               // Close current message if open
               if (currentMessageId) {
                 const outputItem = await closeMessageOutputItem(
-                  sseStream,
+                  writeSSE,
                   currentMessageId,
                   outputIndex,
                   contentIndex,
@@ -571,7 +617,7 @@ export function registerOpenaiResponsesRoutes(app: OpenAPIHono) {
                 const callId = chunk.callId;
                 const inputStr = customToolCallInput(chunk.input);
 
-                await sseStream.writeSSE({
+                await writeSSE({
                   event: "response.output_item.added",
                   data: JSON.stringify({
                     type: "response.output_item.added",
@@ -588,7 +634,7 @@ export function registerOpenaiResponsesRoutes(app: OpenAPIHono) {
                   }),
                 });
 
-                await sseStream.writeSSE({
+                await writeSSE({
                   event: "response.custom_tool_call_input.delta",
                   data: JSON.stringify({
                     type: "response.custom_tool_call_input.delta",
@@ -599,7 +645,7 @@ export function registerOpenaiResponsesRoutes(app: OpenAPIHono) {
                   }),
                 });
 
-                await sseStream.writeSSE({
+                await writeSSE({
                   event: "response.custom_tool_call_input.done",
                   data: JSON.stringify({
                     type: "response.custom_tool_call_input.done",
@@ -619,7 +665,7 @@ export function registerOpenaiResponsesRoutes(app: OpenAPIHono) {
                   ...(toolNamespace ? { namespace: toolNamespace } : {}),
                 });
 
-                await sseStream.writeSSE({
+                await writeSSE({
                   event: "response.output_item.done",
                   data: JSON.stringify({
                     type: "response.output_item.done",
@@ -638,7 +684,7 @@ export function registerOpenaiResponsesRoutes(app: OpenAPIHono) {
               const callId = chunk.callId;
               const argsStr = JSON.stringify(chunk.input ?? {});
 
-              await sseStream.writeSSE({
+              await writeSSE({
                 event: "response.output_item.added",
                 data: JSON.stringify({
                   type: "response.output_item.added",
@@ -656,7 +702,7 @@ export function registerOpenaiResponsesRoutes(app: OpenAPIHono) {
                 }),
               });
 
-              await sseStream.writeSSE({
+              await writeSSE({
                 event: "response.function_call_arguments.delta",
                 data: JSON.stringify({
                   type: "response.function_call_arguments.delta",
@@ -667,7 +713,7 @@ export function registerOpenaiResponsesRoutes(app: OpenAPIHono) {
                 }),
               });
 
-              await sseStream.writeSSE({
+              await writeSSE({
                 event: "response.function_call_arguments.done",
                 data: JSON.stringify({
                   type: "response.function_call_arguments.done",
@@ -688,7 +734,7 @@ export function registerOpenaiResponsesRoutes(app: OpenAPIHono) {
                 ...(toolNamespace ? { namespace: toolNamespace } : {}),
               });
 
-              await sseStream.writeSSE({
+              await writeSSE({
                 event: "response.output_item.done",
                 data: JSON.stringify({
                   type: "response.output_item.done",
@@ -708,7 +754,7 @@ export function registerOpenaiResponsesRoutes(app: OpenAPIHono) {
           // Close any remaining message
           if (currentMessageId) {
             const outputItem = await closeMessageOutputItem(
-              sseStream,
+              writeSSE,
               currentMessageId,
               outputIndex,
               contentIndex,
@@ -720,13 +766,16 @@ export function registerOpenaiResponsesRoutes(app: OpenAPIHono) {
           }
 
           if (!responseUsage) {
-            const [fallbackInputTokens, outputTokens] = await Promise.all([
-              client.countTokens(
-                JSON.stringify(requestBody),
-                cancellationToken,
-              ),
-              client.countTokens(totalOutputText, cancellationToken),
-            ]);
+            const [fallbackInputTokens, outputTokens] =
+              await requestLifecycle!.waitFor(
+                Promise.all([
+                  client.countTokens(
+                    JSON.stringify(requestBody),
+                    cancellationToken,
+                  ),
+                  client.countTokens(totalOutputText, cancellationToken),
+                ]),
+              );
             inputTokens = fallbackInputTokens;
             responseUsage = {
               input_tokens: fallbackInputTokens,
@@ -738,7 +787,7 @@ export function registerOpenaiResponsesRoutes(app: OpenAPIHono) {
           }
 
           // Emit response.completed
-          await sseStream.writeSSE({
+          await writeSSE({
             event: "response.completed",
             data: JSON.stringify({
               type: "response.completed",
@@ -755,41 +804,76 @@ export function registerOpenaiResponsesRoutes(app: OpenAPIHono) {
           logger.info(
             `← /v1/responses (stream) | input: ${responseUsage?.input_tokens} | cache_read: ${responseUsage?.input_tokens_details?.cached_tokens} | cache_write: ${responseUsage?.input_tokens_details?.cache_write_tokens} | output: ${responseUsage?.output_tokens}`,
           );
-          cancellationTokenSource?.dispose();
+          requestLifecycle?.dispose();
         },
         async (error, sseStream) => {
+          if (error instanceof LanguageModelClientDisconnectedError) {
+            logger.info("/v1/responses | client disconnected");
+            requestLifecycle?.dispose();
+            await sseStream.close();
+            return;
+          }
+
           logger.error("✕ /v1/responses (stream) |", error);
-          cancellationTokenSource?.dispose();
 
           const responseId = generateResponseId();
           const createdAt = getCurrentTimestamp();
 
-          await sseStream.writeSSE({
-            event: "response.failed",
-            data: JSON.stringify({
-              type: "response.failed",
-              response: {
-                id: responseId,
-                object: "response",
-                status: "failed",
-                created_at: createdAt,
-                model: model,
-                output: [],
-                error: {
-                  code: "server_error",
-                  message:
-                    error instanceof Error ? error.message : String(error),
+          try {
+            await sseStream.writeSSE({
+              event: "response.failed",
+              data: JSON.stringify({
+                type: "response.failed",
+                response: {
+                  id: responseId,
+                  object: "response",
+                  status: "failed",
+                  created_at: createdAt,
+                  model: model,
+                  output: [],
+                  error: {
+                    code:
+                      error instanceof LanguageModelRequestTimeoutError
+                        ? "request_timeout"
+                        : "server_error",
+                    message:
+                      error instanceof Error ? error.message : String(error),
+                  },
+                  incomplete_details: null,
+                  usage: null,
+                  metadata,
                 },
-                incomplete_details: null,
-                usage: null,
-                metadata,
-              },
-            }),
-          });
+              }),
+            });
+          } finally {
+            requestLifecycle?.dispose();
+            await sseStream.close();
+          }
         },
       );
     } catch (error) {
-      cancellationTokenSource?.dispose();
+      requestLifecycle?.dispose();
+
+      if (error instanceof LanguageModelRequestTimeoutError) {
+        logger.error("✕ /v1/responses |", error);
+        return c.json(
+          {
+            error: {
+              type: "timeout_error",
+              message: error.message,
+              param: null,
+              code: "request_timeout",
+            },
+          },
+          504,
+        );
+      }
+
+      if (error instanceof LanguageModelClientDisconnectedError) {
+        logger.info("/v1/responses | client disconnected");
+        return new Response(null, { status: 499 });
+      }
+
       logger.error("✕ /v1/responses |", error);
 
       const logFilePath = await handleErrorWithLogging({

--- a/src/server/utils/languageModelRequestLifecycle.ts
+++ b/src/server/utils/languageModelRequestLifecycle.ts
@@ -1,0 +1,115 @@
+import * as vscode from "vscode";
+
+export const LANGUAGE_MODEL_REQUEST_TIMEOUT_MS = 10 * 60 * 1000;
+
+export class LanguageModelRequestTimeoutError extends Error {
+  constructor(timeoutMs: number) {
+    super(`Language model request timed out after ${timeoutMs}ms`);
+    this.name = "LanguageModelRequestTimeoutError";
+  }
+}
+
+export class LanguageModelClientDisconnectedError extends Error {
+  constructor() {
+    super("Language model request cancelled because the client disconnected");
+    this.name = "LanguageModelClientDisconnectedError";
+  }
+}
+
+export class LanguageModelRequestLifecycle {
+  private readonly cancellationTokenSource =
+    new vscode.CancellationTokenSource();
+  private interruption: Error | undefined;
+  private readonly interruptionWaiters = new Set<(error: Error) => void>();
+  private readonly timeout: NodeJS.Timeout;
+  private disposed = false;
+
+  private readonly handleClientAbort = () => {
+    this.interrupt(new LanguageModelClientDisconnectedError());
+  };
+
+  constructor(
+    private readonly clientSignal: AbortSignal,
+    timeoutMs: number = LANGUAGE_MODEL_REQUEST_TIMEOUT_MS,
+  ) {
+    this.timeout = setTimeout(() => {
+      this.interrupt(new LanguageModelRequestTimeoutError(timeoutMs));
+    }, timeoutMs);
+    this.timeout.unref();
+
+    if (clientSignal.aborted) {
+      this.handleClientAbort();
+    } else {
+      clientSignal.addEventListener("abort", this.handleClientAbort, {
+        once: true,
+      });
+    }
+  }
+
+  get token(): vscode.CancellationToken {
+    return this.cancellationTokenSource.token;
+  }
+
+  async waitFor<T>(operation: PromiseLike<T>): Promise<T> {
+    if (this.interruption) {
+      throw this.interruption;
+    }
+
+    return new Promise<T>((resolve, reject) => {
+      const rejectOnInterruption = (error: Error) => reject(error);
+      this.interruptionWaiters.add(rejectOnInterruption);
+
+      Promise.resolve(operation).then(
+        (value) => {
+          this.interruptionWaiters.delete(rejectOnInterruption);
+          resolve(value);
+        },
+        (error) => {
+          this.interruptionWaiters.delete(rejectOnInterruption);
+          reject(error);
+        },
+      );
+    });
+  }
+
+  dispose(): void {
+    if (this.disposed) {
+      return;
+    }
+
+    this.disposed = true;
+    clearTimeout(this.timeout);
+    this.clientSignal.removeEventListener("abort", this.handleClientAbort);
+    this.interruptionWaiters.clear();
+    this.cancellationTokenSource.dispose();
+  }
+
+  private interrupt(error: Error): void {
+    if (this.interruption || this.disposed) {
+      return;
+    }
+
+    this.interruption = error;
+    this.cancellationTokenSource.cancel();
+    for (const reject of this.interruptionWaiters) {
+      reject(error);
+    }
+    this.interruptionWaiters.clear();
+  }
+}
+
+export async function* interruptibleLanguageModelStream<T>(
+  stream: AsyncIterable<T>,
+  lifecycle: LanguageModelRequestLifecycle,
+): AsyncGenerator<T> {
+  const iterator = stream[Symbol.asyncIterator]();
+
+  while (true) {
+    const result = await lifecycle.waitFor(iterator.next());
+    if (result.done) {
+      return;
+    }
+
+    yield result.value;
+  }
+}

--- a/src/server/utils/openaiResponses.ts
+++ b/src/server/utils/openaiResponses.ts
@@ -95,7 +95,9 @@ export const getCurrentTimestamp = (): number => Math.floor(Date.now() / 1000);
  * Helper for closing a message output item in streaming responses
  */
 export const closeMessageOutputItem = async (
-  sseStream: SSEStreamingApi,
+  writeSSE: (
+    message: Parameters<SSEStreamingApi["writeSSE"]>[0],
+  ) => Promise<void>,
   messageId: string,
   outputIndex: number,
   contentIndex: number,
@@ -105,7 +107,7 @@ export const closeMessageOutputItem = async (
   const nextSeq = () =>
     sequenceNumberRef ? sequenceNumberRef.value++ : undefined;
 
-  await sseStream.writeSSE({
+  await writeSSE({
     event: "response.output_text.done",
     data: JSON.stringify({
       type: "response.output_text.done",
@@ -117,7 +119,7 @@ export const closeMessageOutputItem = async (
     }),
   });
 
-  await sseStream.writeSSE({
+  await writeSSE({
     event: "response.content_part.done",
     data: JSON.stringify({
       type: "response.content_part.done",
@@ -147,7 +149,7 @@ export const closeMessageOutputItem = async (
     status: "completed",
   };
 
-  await sseStream.writeSSE({
+  await writeSSE({
     event: "response.output_item.done",
     data: JSON.stringify({
       type: "response.output_item.done",

--- a/src/test/server/languageModelRequestLifecycle.test.ts
+++ b/src/test/server/languageModelRequestLifecycle.test.ts
@@ -270,10 +270,11 @@ suite("LanguageModelRequestLifecycle Test Suite", () => {
     });
 
     assert.strictEqual(response.status, 504);
-    assert.strictEqual(
-      ((await response.json()) as any).error.code,
-      "request_timeout",
-    );
+    const responseBody = (await response.json()) as {
+      error: { code: string; param: string | null };
+    };
+    assert.strictEqual(responseBody.error.code, "request_timeout");
+    assert.strictEqual(responseBody.error.param, null);
     assert.strictEqual(cancellationObserved, true);
   });
 

--- a/src/test/server/languageModelRequestLifecycle.test.ts
+++ b/src/test/server/languageModelRequestLifecycle.test.ts
@@ -1,0 +1,407 @@
+import { OpenAPIHono } from "@hono/zod-openapi";
+import * as assert from "assert";
+import * as vscode from "vscode";
+
+import { registerAnthropicRoutes } from "../../server/routes/anthropicRoutes";
+import { registerOpenaiChatRoutes } from "../../server/routes/openai/openaiChatRoutes";
+import { registerOpenaiResponsesRoutes } from "../../server/routes/openai/openaiResponsesRoutes";
+import {
+  LanguageModelClientDisconnectedError,
+  LanguageModelRequestLifecycle,
+  LanguageModelRequestTimeoutError,
+  interruptibleLanguageModelStream,
+} from "../../server/utils/languageModelRequestLifecycle";
+
+suite("LanguageModelRequestLifecycle Test Suite", () => {
+  const createStalledModel = (
+    onCancellation: () => void,
+  ): vscode.LanguageModelChat =>
+    ({
+      id: "claude-opus-test",
+      name: "Claude Opus Test",
+      family: "claude",
+      version: "test",
+      vendor: "copilot",
+      maxInputTokens: 200000,
+      capabilities: {
+        supportsImageToText: false,
+        supportsToolCalling: true,
+      },
+      sendRequest: async (_messages, _options, token) => {
+        if (token?.isCancellationRequested) {
+          onCancellation();
+        } else {
+          token?.onCancellationRequested(onCancellation);
+        }
+        return {
+          stream: {
+            [Symbol.asyncIterator]() {
+              return {
+                next: () =>
+                  new Promise<
+                    IteratorResult<
+                      | vscode.LanguageModelTextPart
+                      | vscode.LanguageModelToolCallPart
+                      | vscode.LanguageModelDataPart
+                      | unknown
+                    >
+                  >(() => {}),
+              };
+            },
+          },
+          text: {
+            async *[Symbol.asyncIterator]() {},
+          },
+        };
+      },
+      countTokens: async () => 0,
+    }) as vscode.LanguageModelChat;
+
+  const createAnthropicTestApp = (model: vscode.LanguageModelChat) => {
+    const app = new OpenAPIHono();
+    registerAnthropicRoutes(app, {
+      requestTimeoutMs: 20,
+      resolveChatModelClient: async () => ({ client: model }),
+    });
+    return app;
+  };
+
+  const createOpenaiChatTestApp = (model: vscode.LanguageModelChat) => {
+    const app = new OpenAPIHono();
+    registerOpenaiChatRoutes(app, {
+      requestTimeoutMs: 20,
+      resolveChatModelClient: async () => ({ client: model }),
+    });
+    return app;
+  };
+
+  const createOpenaiResponsesTestApp = (model: vscode.LanguageModelChat) => {
+    const app = new OpenAPIHono();
+    registerOpenaiResponsesRoutes(app, {
+      requestTimeoutMs: 20,
+      resolveChatModelClient: async () => ({ client: model }),
+    });
+    return app;
+  };
+
+  test("cancels a stalled operation when the total timeout expires", async () => {
+    const clientAbortController = new AbortController();
+    const lifecycle = new LanguageModelRequestLifecycle(
+      clientAbortController.signal,
+      20,
+    );
+
+    await assert.rejects(
+      lifecycle.waitFor(new Promise<never>(() => {})),
+      LanguageModelRequestTimeoutError,
+    );
+    assert.strictEqual(lifecycle.token.isCancellationRequested, true);
+
+    lifecycle.dispose();
+  });
+
+  test("cancels immediately when the client disconnects", async () => {
+    const clientAbortController = new AbortController();
+    const lifecycle = new LanguageModelRequestLifecycle(
+      clientAbortController.signal,
+      1000,
+    );
+
+    clientAbortController.abort();
+
+    await assert.rejects(
+      lifecycle.waitFor(new Promise<never>(() => {})),
+      LanguageModelClientDisconnectedError,
+    );
+    assert.strictEqual(lifecycle.token.isCancellationRequested, true);
+
+    lifecycle.dispose();
+  });
+
+  test("does not cancel a normally completed request", async () => {
+    const clientAbortController = new AbortController();
+    const lifecycle = new LanguageModelRequestLifecycle(
+      clientAbortController.signal,
+      1000,
+    );
+
+    assert.strictEqual(await lifecycle.waitFor(Promise.resolve(42)), 42);
+    lifecycle.dispose();
+
+    assert.strictEqual(lifecycle.token.isCancellationRequested, false);
+  });
+
+  test("interrupts an async iterator waiting for its next chunk", async () => {
+    const clientAbortController = new AbortController();
+    const lifecycle = new LanguageModelRequestLifecycle(
+      clientAbortController.signal,
+      20,
+    );
+    const stalledStream: AsyncIterable<string> = {
+      [Symbol.asyncIterator]() {
+        return {
+          next: () => new Promise<IteratorResult<string>>(() => {}),
+        };
+      },
+    };
+    const iterator = interruptibleLanguageModelStream(stalledStream, lifecycle);
+
+    await assert.rejects(iterator.next(), LanguageModelRequestTimeoutError);
+
+    lifecycle.dispose();
+  });
+
+  test("passes through a normally completed async iterator in order", async () => {
+    const lifecycle = new LanguageModelRequestLifecycle(
+      new AbortController().signal,
+      1000,
+    );
+    const chunks: string[] = [];
+
+    for await (const chunk of interruptibleLanguageModelStream(
+      (async function* () {
+        yield "first";
+        yield "second";
+      })(),
+      lifecycle,
+    )) {
+      chunks.push(chunk);
+    }
+
+    assert.deepStrictEqual(chunks, ["first", "second"]);
+    assert.strictEqual(lifecycle.token.isCancellationRequested, false);
+    lifecycle.dispose();
+  });
+
+  test("returns a 504 timeout_error for a stalled non-streaming request", async () => {
+    let cancellationObserved = false;
+    const app = createAnthropicTestApp(
+      createStalledModel(() => {
+        cancellationObserved = true;
+      }),
+    );
+
+    const response = await app.request("/v1/messages", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "claude-opus-test",
+        max_tokens: 100,
+        messages: [{ role: "user", content: "Hello" }],
+      }),
+    });
+
+    assert.strictEqual(response.status, 504);
+    assert.strictEqual(
+      ((await response.json()) as any).error.type,
+      "timeout_error",
+    );
+    assert.strictEqual(cancellationObserved, true);
+  });
+
+  test("emits one timeout error without message_stop for a stalled stream", async () => {
+    let cancellationObserved = false;
+    const app = createAnthropicTestApp(
+      createStalledModel(() => {
+        cancellationObserved = true;
+      }),
+    );
+
+    const response = await app.request("/v1/messages", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "claude-opus-test",
+        max_tokens: 100,
+        stream: true,
+        messages: [{ role: "user", content: "Hello" }],
+      }),
+    });
+    const body = await response.text();
+
+    assert.strictEqual(response.status, 200);
+    assert.strictEqual((body.match(/event: error/g) ?? []).length, 1);
+    assert.ok(body.includes('\"type\":\"timeout_error\"'));
+    assert.ok(!body.includes("event: message_stop"));
+    assert.strictEqual(cancellationObserved, true);
+  });
+
+  test("propagates a client disconnect through the Anthropic route", async () => {
+    let cancellationObserved = false;
+    const app = createAnthropicTestApp(
+      createStalledModel(() => {
+        cancellationObserved = true;
+      }),
+    );
+    const clientAbortController = new AbortController();
+
+    const responsePromise = app.request("/v1/messages", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "claude-opus-test",
+        max_tokens: 100,
+        messages: [{ role: "user", content: "Hello" }],
+      }),
+      signal: clientAbortController.signal,
+    });
+    clientAbortController.abort();
+
+    const response = await responsePromise;
+    assert.strictEqual(response.status, 499);
+    assert.strictEqual(cancellationObserved, true);
+  });
+
+  test("returns a 504 for a stalled non-streaming Chat Completions request", async () => {
+    let cancellationObserved = false;
+    const app = createOpenaiChatTestApp(
+      createStalledModel(() => {
+        cancellationObserved = true;
+      }),
+    );
+
+    const response = await app.request("/v1/chat/completions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "claude-opus-test",
+        messages: [{ role: "user", content: "Hello" }],
+      }),
+    });
+
+    assert.strictEqual(response.status, 504);
+    assert.strictEqual(
+      ((await response.json()) as any).error.code,
+      "request_timeout",
+    );
+    assert.strictEqual(cancellationObserved, true);
+  });
+
+  test("emits one error without a successful Chat Completions terminator", async () => {
+    let cancellationObserved = false;
+    const app = createOpenaiChatTestApp(
+      createStalledModel(() => {
+        cancellationObserved = true;
+      }),
+    );
+
+    const response = await app.request("/v1/chat/completions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "claude-opus-test",
+        stream: true,
+        messages: [{ role: "user", content: "Hello" }],
+      }),
+    });
+    const body = await response.text();
+
+    assert.strictEqual(response.status, 200);
+    assert.strictEqual((body.match(/event: error/g) ?? []).length, 1);
+    assert.ok(body.includes("request_timeout"));
+    assert.ok(!body.includes("data: [DONE]"));
+    assert.ok(!body.includes('\"finish_reason\":\"stop\"'));
+    assert.strictEqual(cancellationObserved, true);
+  });
+
+  test("propagates a client disconnect through Chat Completions", async () => {
+    let cancellationObserved = false;
+    const app = createOpenaiChatTestApp(
+      createStalledModel(() => {
+        cancellationObserved = true;
+      }),
+    );
+    const clientAbortController = new AbortController();
+
+    const responsePromise = app.request("/v1/chat/completions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "claude-opus-test",
+        messages: [{ role: "user", content: "Hello" }],
+      }),
+      signal: clientAbortController.signal,
+    });
+    clientAbortController.abort();
+
+    const response = await responsePromise;
+    assert.strictEqual(response.status, 499);
+    assert.strictEqual(cancellationObserved, true);
+  });
+
+  test("returns a 504 for a stalled non-streaming Responses request", async () => {
+    let cancellationObserved = false;
+    const app = createOpenaiResponsesTestApp(
+      createStalledModel(() => {
+        cancellationObserved = true;
+      }),
+    );
+
+    const response = await app.request("/v1/responses", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "claude-opus-test",
+        input: "Hello",
+      }),
+    });
+
+    assert.strictEqual(response.status, 504);
+    assert.strictEqual(
+      ((await response.json()) as any).error.code,
+      "request_timeout",
+    );
+    assert.strictEqual(cancellationObserved, true);
+  });
+
+  test("emits one response.failed without response.completed", async () => {
+    let cancellationObserved = false;
+    const app = createOpenaiResponsesTestApp(
+      createStalledModel(() => {
+        cancellationObserved = true;
+      }),
+    );
+
+    const response = await app.request("/v1/responses", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "claude-opus-test",
+        input: "Hello",
+        stream: true,
+      }),
+    });
+    const body = await response.text();
+
+    assert.strictEqual(response.status, 200);
+    assert.strictEqual((body.match(/event: response.failed/g) ?? []).length, 1);
+    assert.ok(body.includes("request_timeout"));
+    assert.ok(!body.includes("event: response.completed"));
+    assert.strictEqual(cancellationObserved, true);
+  });
+
+  test("propagates a client disconnect through Responses", async () => {
+    let cancellationObserved = false;
+    const app = createOpenaiResponsesTestApp(
+      createStalledModel(() => {
+        cancellationObserved = true;
+      }),
+    );
+    const clientAbortController = new AbortController();
+
+    const responsePromise = app.request("/v1/responses", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "claude-opus-test",
+        input: "Hello",
+      }),
+      signal: clientAbortController.signal,
+    });
+    clientAbortController.abort();
+
+    const response = await responsePromise;
+    assert.strictEqual(response.status, 499);
+    assert.strictEqual(cancellationObserved, true);
+  });
+});


### PR DESCRIPTION
## Summary

- add a protocol-independent `LanguageModelRequestLifecycle` that owns the VS Code cancellation token source and binds it to the incoming HTTP abort signal
- apply a 10-minute total request deadline to Anthropic Messages, OpenAI Chat Completions, and OpenAI Responses, covering model dispatch, stream iteration, SSE writes, and fallback token counting
- preserve protocol-specific failure semantics: HTTP 504 for non-streaming timeouts, Anthropic `timeout_error`, Chat Completions `event: error`, and Responses `response.failed` for streaming timeouts
- cancel upstream work silently when the client disconnects, and guarantee lifecycle cleanup even if a terminal SSE write fails
- document the behavior, add a patch changeset, and add deterministic timeout/disconnect tests for all three APIs

## Design notes

Issue #196 proposed a 60–120 second per-chunk idle watchdog. This implementation intentionally uses a conservative 10-minute total-request deadline instead. A total deadline is simpler and deterministic across `sendRequest`, stream reads, writes, and token counting, while still preventing an in-flight request from remaining wedged indefinitely. The timeout is not reset by streamed chunks.

The lifecycle helper remains protocol-independent: it owns cancellation and interruption only. Each route maps timeout and disconnect outcomes to its own wire format. Streaming timeouts emit a failure event and never emit a successful terminal event such as `message_stop`, `[DONE]`, or `response.completed`.

Closes #196.

## Test plan

- [x] `CI=true pnpm check-types`
- [x] `CI=true pnpm lint`
- [x] `CI=true pnpm test` — 390 passing
- [x] `git diff --check`

## Changeset

- `.changeset/quiet-pandas-wait.md` (patch)