### PR TITLE
fix(openai): preserve custom tool source input

### DIFF
--- a/.changeset/bright-tools-exec.md
+++ b/.changeset/bright-tools-exec.md
@@ -1,0 +1,5 @@
+---
+"agent-maestro": patch
+---
+
+Preserve Codex custom tool source input when proxying OpenAI Responses tool calls.

--- a/src/server/utils/openaiResponses.ts
+++ b/src/server/utils/openaiResponses.ts
@@ -719,19 +719,25 @@ export const buildResponseOutput = (
 
 /**
  * A `custom` tool's input is a raw string. We wrap it as `{ input: <string> }`
- * when replaying history into VSCode LM, so unwrap that shape on the way out;
- * fall back to JSON for anything else.
+ * when replaying history into VSCode LM, while Copilot may return generated
+ * free-form input as `{ source: <string> }`. Unwrap either shape on the way
+ * out; fall back to JSON for anything else.
  */
 export const customToolCallInput = (input: unknown): string => {
   if (typeof input === "string") {
     return input;
   }
-  if (
-    input &&
-    typeof input === "object" &&
-    typeof (input as { input?: unknown }).input === "string"
-  ) {
-    return (input as { input: string }).input;
+  if (input && typeof input === "object") {
+    const wrappedInput = input as {
+      input?: unknown;
+      source?: unknown;
+    };
+    if (typeof wrappedInput.input === "string") {
+      return wrappedInput.input;
+    }
+    if (typeof wrappedInput.source === "string") {
+      return wrappedInput.source;
+    }
   }
   return input === null || input === undefined ? "" : JSON.stringify(input);
 };

--- a/src/test/server/openaiResponses.test.ts
+++ b/src/test/server/openaiResponses.test.ts
@@ -805,7 +805,7 @@ suite("OpenAI Responses Conversion Utils Test Suite", () => {
         {
           callId: "call_2",
           name: "collaboration__raw_helper",
-          input: { input: "raw" },
+          input: { source: "raw" },
         },
       ];
       const toolMap = new Map([
@@ -869,6 +869,12 @@ suite("OpenAI Responses Conversion Utils Test Suite", () => {
 
     test("should unwrap the { input } wrapper", () => {
       assert.strictEqual(customToolCallInput({ input: "ls -la" }), "ls -la");
+    });
+
+    test("should unwrap the { source } wrapper", () => {
+      const source =
+        'const r = await tools.exec_command({cmd: "git status --short"}); text(r.output);';
+      assert.strictEqual(customToolCallInput({ source }), source);
     });
 
     test("should JSON-stringify other object shapes", () => {


### PR DESCRIPTION
## Summary

- unwrap Copilot custom-tool `{ source: string }` payloads back to raw Responses API input
- keep existing `{ input: string }` replay handling and JSON fallback behavior
- add unit and namespaced custom-tool regression coverage
- include a patch changeset

Fixes #213

## Test plan

- [x] `pnpm check-types`
- [x] `pnpm lint`
- [x] VS Code Insiders extension test suite — 391 passing
- [x] Codex CLI end-to-end through the current branch proxy: observed a successful `command_execution` event for `pwd`