### PR TITLE
feat(claude): configure Claude Desktop proxy settings

### DIFF
--- a/.changeset/configure-claude-desktop.md
+++ b/.changeset/configure-claude-desktop.md
@@ -1,5 +1,0 @@
----
-"agent-maestro": patch
----
-
-Add a command that configures Claude Desktop to use the Agent Maestro proxy.

--- a/.changeset/configure-claude-desktop.md
+++ b/.changeset/configure-claude-desktop.md
@@ -1,0 +1,5 @@
+---
+"agent-maestro": patch
+---
+
+Add a command that configures Claude Desktop to use the Agent Maestro proxy.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.11.1 - 2026.07.17
+
+- Add `Configure Claude Desktop Settings` command to point Claude Desktop at the Agent Maestro proxy.
+
 ## v2.11.0 - 2026.07.15
 
 - Add experimental commands that patch the currently loaded Copilot Chat bundle to append the OpenAI web search tool declaration for supported GPT-5 Codex requests, and restore backups created by that patch. Tested with `ChatGPT 26.707.72221`: `GPT-5.4` and `GPT-5.5` work; `GPT-5.6` does not yet forward the web search tool declaration to the server.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ This automatically creates or updates `.claude/settings.json` with Agent Maestro
 
 > **1M Context Support**: Agent Maestro supports Claude 1M context models (e.g. `claude-opus-4.7-1m-internal`). To use the extended context window, run `Agent Maestro: Configure Claude Code Settings` and select the desired 1M model. Agent Maestro writes the model in the format Claude Code expects so the 1M path is selected consistently.
 
+### One-Click Setup for Claude Desktop
+
+Configure Claude Desktop to use Agent Maestro's Anthropic-compatible proxy with `Agent Maestro: Configure Claude Desktop Settings` via Command Palette. The command creates or updates the local third-party inference configuration for macOS, Windows, or Linux. Fully quit and reopen Claude Desktop after configuring it.
+
 ### One-Click Setup for Codex
 
 Configure Codex to use VS Code's language models with a single command `Agent Maestro: Configure Codex Settings` via Command Palette.
@@ -128,6 +132,7 @@ See [docs/experimental-gpt5-plus-web-search.md](docs/experimental-gpt5-plus-web-
    **Configuration Commands:**
 
    - `Agent Maestro: Configure Claude Code Settings` - One-click Claude Code setup
+   - `Agent Maestro: Configure Claude Desktop Settings` - One-click Claude Desktop setup
    - `Agent Maestro: Configure Codex Settings` - One-click Codex setup
    - `Agent Maestro: Configure Gemini CLI Settings` - One-click Gemini CLI setup
    - `Agent Maestro: Enable Experimental GPT-5+ Web Search` - Patch the current VS Code Copilot bundle to append web search for GPT major version 5 or newer model requests

--- a/package.json
+++ b/package.json
@@ -145,6 +145,11 @@
         "category": "Agent Maestro"
       },
       {
+        "command": "agent-maestro.configureClaudeDesktop",
+        "title": "Configure Claude Desktop Settings",
+        "category": "Agent Maestro"
+      },
+      {
         "command": "agent-maestro.configureCodex",
         "title": "Configure Codex Settings",
         "category": "Agent Maestro"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "agent-maestro",
   "displayName": "Agent Maestro",
   "description": "Turn VS Code into your compliant AI playground! With Agent Maestro, spin up Cline or Roo on demand and plug Claude Code or Codex straight in through an OpenAI/Anthropic-compatible API.",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "icon": "assets/icons/icon.png",
   "publisher": "Joouis",
   "repository": "https://github.com/Joouis/agent-maestro",

--- a/src/commands/configuratorCommands.ts
+++ b/src/commands/configuratorCommands.ts
@@ -11,6 +11,11 @@ import {
   ensureClaudeConfigExists,
   ensureClaudeOnboardingComplete,
 } from "../utils/claude";
+import {
+  createClaudeDesktopGatewayConfig,
+  getClaudeDesktopConfigDirectory,
+  updateClaudeDesktopMetadata,
+} from "../utils/claudeDesktop";
 import { logger } from "../utils/logger";
 import { updateEnvFile } from "../utils/updateEnvFile";
 import { createCommandHandler } from "./commandHandler";
@@ -189,6 +194,87 @@ export function registerConfiguratorCommands(
           `Claude Code settings ${fileExists ? "updated" : "created"}: ${settingsFile.fsPath}`,
         );
       }, "Failed to configure Claude Code settings"),
+    ),
+
+    vscode.commands.registerCommand(
+      "agent-maestro.configureClaudeDesktop",
+      createCommandHandler(async () => {
+        const configDirectory = getClaudeDesktopConfigDirectory();
+        const metadataPath = path.join(configDirectory, "_meta.json");
+        let metadata: {
+          appliedId?: string;
+          entries?: Array<{ id: string; name: string }>;
+        } = {};
+
+        try {
+          metadata = JSON.parse(fs.readFileSync(metadataPath, "utf8"));
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+            vscode.window.showErrorMessage(
+              `Failed to read Claude Desktop metadata: ${(error as Error).message}`,
+            );
+            return;
+          }
+        }
+
+        const updatedMetadata = updateClaudeDesktopMetadata(metadata);
+        const settingsPath = path.join(
+          configDirectory,
+          `${updatedMetadata.appliedId}.json`,
+        );
+        let existingSettings: Record<string, unknown> = {};
+        let fileExists = false;
+
+        try {
+          existingSettings = JSON.parse(fs.readFileSync(settingsPath, "utf8"));
+          fileExists = true;
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+            vscode.window.showErrorMessage(
+              `Failed to read Claude Desktop settings: ${(error as Error).message}`,
+            );
+            return;
+          }
+        }
+
+        if (fileExists) {
+          const shouldOverride = await vscode.window.showQuickPick(
+            ["Yes", "No"],
+            {
+              title: "Claude Desktop Settings Found",
+              placeHolder:
+                "Settings already exist for Agent Maestro. Do you want to update them?",
+            },
+          );
+
+          if (shouldOverride !== "Yes") {
+            return;
+          }
+        }
+
+        const proxyPort = proxy.getStatus().port;
+        const updatedSettings = {
+          ...existingSettings,
+          ...createClaudeDesktopGatewayConfig(proxyPort),
+        };
+
+        fs.mkdirSync(configDirectory, { recursive: true });
+        fs.writeFileSync(
+          settingsPath,
+          JSON.stringify(updatedSettings, null, 2),
+        );
+        fs.writeFileSync(
+          metadataPath,
+          JSON.stringify(updatedMetadata, null, 2),
+        );
+
+        vscode.window.showInformationMessage(
+          `Claude Desktop settings ${fileExists ? "updated" : "created"} successfully! Fully quit and reopen Claude Desktop to apply the Agent Maestro proxy configuration.`,
+        );
+        logger.info(
+          `Claude Desktop settings ${fileExists ? "updated" : "created"}: ${settingsPath}`,
+        );
+      }, "Failed to configure Claude Desktop settings"),
     ),
 
     vscode.commands.registerCommand(

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -70,6 +70,7 @@ suite("Extension Test Suite", () => {
 
       const configuratorCommands = [
         "agent-maestro.configureClaudeCode",
+        "agent-maestro.configureClaudeDesktop",
         "agent-maestro.configureCodex",
         "agent-maestro.configureGeminiCli",
       ];

--- a/src/test/utils/claudeDesktop.test.ts
+++ b/src/test/utils/claudeDesktop.test.ts
@@ -1,0 +1,82 @@
+import * as assert from "assert";
+import * as path from "path";
+
+import {
+  createClaudeDesktopGatewayConfig,
+  getClaudeDesktopConfigDirectory,
+  updateClaudeDesktopMetadata,
+} from "../../utils/claudeDesktop";
+
+suite("Claude Desktop Configuration Test Suite", () => {
+  test("uses the documented local config directories on each platform", () => {
+    assert.strictEqual(
+      getClaudeDesktopConfigDirectory("darwin", "/Users/example"),
+      path.join(
+        "/Users/example",
+        "Library",
+        "Application Support",
+        "Claude-3p",
+        "configLibrary",
+      ),
+    );
+    assert.strictEqual(
+      getClaudeDesktopConfigDirectory(
+        "win32",
+        "C:\\Users\\example",
+        "C:\\Users\\example\\AppData\\Local",
+      ),
+      path.join(
+        "C:\\Users\\example\\AppData\\Local",
+        "Claude-3p",
+        "configLibrary",
+      ),
+    );
+    assert.strictEqual(
+      getClaudeDesktopConfigDirectory("linux", "/home/example"),
+      path.join("/home/example", ".config", "Claude-3p", "configLibrary"),
+    );
+  });
+
+  test("adds and applies an Agent Maestro metadata entry", () => {
+    const metadata = updateClaudeDesktopMetadata(
+      {
+        appliedId: "default-id",
+        entries: [{ id: "default-id", name: "Default" }],
+      },
+      () => "agent-maestro-id",
+    );
+
+    assert.deepStrictEqual(metadata, {
+      appliedId: "agent-maestro-id",
+      entries: [
+        { id: "default-id", name: "Default" },
+        { id: "agent-maestro-id", name: "agent-maestro" },
+      ],
+    });
+  });
+
+  test("reuses an existing Agent Maestro metadata entry", () => {
+    const entries = [
+      { id: "default-id", name: "Default" },
+      { id: "agent-maestro-id", name: "agent-maestro" },
+    ];
+    const metadata = updateClaudeDesktopMetadata(
+      { appliedId: "default-id", entries },
+      () => {
+        throw new Error("A new id should not be created");
+      },
+    );
+
+    assert.strictEqual(metadata.appliedId, "agent-maestro-id");
+    assert.strictEqual(metadata.entries, entries);
+  });
+
+  test("creates the expected gateway settings", () => {
+    assert.deepStrictEqual(createClaudeDesktopGatewayConfig(45678), {
+      inferenceGatewayBaseUrl: "http://127.0.0.1:45678/api/anthropic",
+      inferenceGatewayApiKey: "Powered by Agent Maestro",
+      inferenceProvider: "gateway",
+      inferenceCredentialKind: "static",
+    });
+  });
+});

--- a/src/utils/claudeDesktop.ts
+++ b/src/utils/claudeDesktop.ts
@@ -1,0 +1,91 @@
+import { randomUUID } from "crypto";
+import * as os from "os";
+import * as path from "path";
+
+export const CLAUDE_DESKTOP_AGENT_MAESTRO_ENTRY_NAME = "agent-maestro";
+
+export interface ClaudeDesktopConfigEntry {
+  id: string;
+  name: string;
+}
+
+export interface ClaudeDesktopConfigMetadata {
+  appliedId: string;
+  entries: ClaudeDesktopConfigEntry[];
+}
+
+export interface ClaudeDesktopGatewayConfig {
+  inferenceCredentialKind: "static";
+  inferenceGatewayApiKey: string;
+  inferenceGatewayBaseUrl: string;
+  inferenceProvider: "gateway";
+}
+
+// Claude Desktop stores third-party inference settings in this platform-specific
+// local config library. See https://claude.com/docs/third-party/claude-desktop/configuration.
+export function getClaudeDesktopConfigDirectory(
+  platform = process.platform,
+  homeDirectory = os.homedir(),
+  localAppData = process.env.LOCALAPPDATA,
+): string {
+  switch (platform) {
+    case "darwin":
+      return path.join(
+        homeDirectory,
+        "Library",
+        "Application Support",
+        "Claude-3p",
+        "configLibrary",
+      );
+    case "win32":
+      return path.join(
+        localAppData ?? path.join(homeDirectory, "AppData", "Local"),
+        "Claude-3p",
+        "configLibrary",
+      );
+    case "linux":
+      return path.join(homeDirectory, ".config", "Claude-3p", "configLibrary");
+    default:
+      throw new Error(
+        `Claude Desktop configuration is not supported on ${platform}.`,
+      );
+  }
+}
+
+export function updateClaudeDesktopMetadata(
+  metadata: Partial<ClaudeDesktopConfigMetadata>,
+  createId: () => string = randomUUID,
+): ClaudeDesktopConfigMetadata {
+  const existingEntry = metadata.entries?.find(
+    (entry) => entry.name === CLAUDE_DESKTOP_AGENT_MAESTRO_ENTRY_NAME,
+  );
+
+  if (existingEntry) {
+    return {
+      ...metadata,
+      appliedId: existingEntry.id,
+      entries: metadata.entries ?? [],
+    };
+  }
+
+  const id = createId();
+  return {
+    ...metadata,
+    appliedId: id,
+    entries: [
+      ...(metadata.entries ?? []),
+      { id, name: CLAUDE_DESKTOP_AGENT_MAESTRO_ENTRY_NAME },
+    ],
+  };
+}
+
+export function createClaudeDesktopGatewayConfig(
+  proxyPort: number,
+): ClaudeDesktopGatewayConfig {
+  return {
+    inferenceGatewayBaseUrl: `http://127.0.0.1:${proxyPort}/api/anthropic`,
+    inferenceGatewayApiKey: "Powered by Agent Maestro",
+    inferenceProvider: "gateway",
+    inferenceCredentialKind: "static",
+  };
+}


### PR DESCRIPTION
## Summary

- add `Agent Maestro: Configure Claude Desktop Settings` for the local Claude Desktop third-party inference configuration
- create or reuse the `agent-maestro` configuration entry, switch the active profile, and write the current Agent Maestro proxy endpoint
- support the documented per-user config locations on macOS, Windows, and Linux while preserving unrelated settings in the selected profile
- document the command, add a patch changeset, and cover paths, metadata behavior, gateway output, and command registration

## Test plan

- [x] `pnpm check-types`
- [x] `pnpm lint`
- [x] `pnpm test -- --grep "Claude Desktop Configuration|configurator commands should be registered"`