### PR TITLE
refactor(core): use built-in UUID generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -193,7 +193,6 @@
     "image-size": "^2.0.2",
     "openai": "^6.46.0",
     "smol-toml": "^1.6.0",
-    "uuid": "^11.1.0",
     "zod": "^4.0.10"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,9 +45,6 @@ importers:
       smol-toml:
         specifier: ^1.6.0
         version: 1.6.0
-      uuid:
-        specifier: ^11.1.0
-        version: 11.1.0
       zod:
         specifier: ^4.0.10
         version: 4.0.10
@@ -5742,13 +5739,6 @@ packages:
         integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==,
       }
 
-  uuid@11.1.0:
-    resolution:
-      {
-        integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==,
-      }
-    hasBin: true
-
   uuid@8.3.2:
     resolution:
       {
@@ -9730,8 +9720,6 @@ snapshots:
   url-join@4.0.1: {}
 
   util-deprecate@1.0.2: {}
-
-  uuid@11.1.0: {}
 
   uuid@8.3.2: {}
 

--- a/src/core/McpTaskManager.ts
+++ b/src/core/McpTaskManager.ts
@@ -1,7 +1,7 @@
 import { RooCodeEventName } from "@roo-code/types";
+import { randomUUID } from "crypto";
 import { Semaphore, isEqual } from "es-toolkit";
 import type { Content } from "fastmcp";
-import { v4 as uuidv4 } from "uuid";
 
 import { TaskEvent } from "../server/types";
 import { closeAllEmptyTabGroups } from "../utils/extension";
@@ -211,7 +211,7 @@ export class McpTaskManager {
     } catch (error) {
       logger.error(`Failed to start RooCode task: ${taskQuery}`, error);
 
-      const fallbackId = taskId || uuidv4();
+      const fallbackId = taskId || randomUUID();
       run[fallbackId] = {
         task: taskQuery,
         status: "failed",


### PR DESCRIPTION
## Summary

- replace the remaining direct `uuid` v4 call with Node.js `crypto.randomUUID()`
- remove the direct `uuid` dependency and its lockfile entries
- retain the transitive `uuid@8` dependency required elsewhere in the dependency graph

## Test plan

- [x] `pnpm check-types`
- [x] `pnpm lint`