### PR TITLE
feat(codex): add standalone web search endpoint

### DIFF
--- a/.changeset/add-codex-standalone-web-search.md
+++ b/.changeset/add-codex-standalone-web-search.md
@@ -1,0 +1,5 @@
+---
+"agent-maestro": minor
+---
+
+Add a Codex-compatible `/v1/alpha/search` endpoint backed by the experimental GPT-5+ Copilot web-search patch.

--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ Perfect for Codex and OpenAI model integration:
 
 - **`POST /api/openai/v1/chat/completions`** - OpenAI Chat Completions API compatibility using VS Code's Language Model API
 - **`POST /api/openai/v1/responses`** - OpenAI Responses API compatibility using VS Code's Language Model API
+- **`POST /api/openai/v1/alpha/search`** - Codex standalone web search through the experimental GPT-5+ Copilot patch
 
 Anthropic Messages and both OpenAI endpoints cancel the upstream language model request when the client disconnects or when the request remains unfinished for 10 minutes. Non-streaming timeouts return HTTP 504; streaming timeouts use each protocol's error event instead of a successful completion event.
 

--- a/docs/experimental-gpt5-plus-web-search.md
+++ b/docs/experimental-gpt5-plus-web-search.md
@@ -45,6 +45,12 @@ For `/v1/responses` requests:
 
 Because hosted web search is handled by the model backend, a successful search may not produce a local VS Code tool call.
 
+### Codex Standalone Search
+
+Recent Codex models that use Responses Lite do not attach hosted tools to `/v1/responses`. When Codex enables its `standalone_web_search` feature for an opted-in custom provider, it instead calls `POST /v1/alpha/search`. Agent Maestro exposes that endpoint and adapts the Codex search command to the same patched Copilot hosted web-search path.
+
+The endpoint requires the experimental patch setting and a GPT-5+ Copilot model. It returns the Copilot search text in the Codex `output` field, including source URLs supplied by the backend. Agent Maestro does not synthesize Codex structured `results` metadata. Custom Codex providers must set `supports_standalone_web_search = true` and enable Codex's `standalone_web_search` feature before Codex will call this endpoint.
+
 ## Restore Flow
 
 Run `Agent Maestro: Restore Experimental GPT-5+ Web Search Backup` from the Command Palette.

--- a/src/commands/configuratorCommands.ts
+++ b/src/commands/configuratorCommands.ts
@@ -44,7 +44,13 @@ export function buildCodexConfig(
   );
   const supportsStandaloneWebSearch =
     experimentalWebSearchEnabled && !!modelMatch && Number(modelMatch[1]) >= 5;
-  const features = { ...existingConfig.features };
+  const existingFeatures =
+    existingConfig.features &&
+    typeof existingConfig.features === "object" &&
+    !Array.isArray(existingConfig.features)
+      ? existingConfig.features
+      : {};
+  const features = { ...existingFeatures };
   delete features.standalone_web_search;
   if (supportsStandaloneWebSearch) {
     features.standalone_web_search = true;

--- a/src/commands/configuratorCommands.ts
+++ b/src/commands/configuratorCommands.ts
@@ -16,6 +16,7 @@ import {
   getClaudeDesktopConfigDirectory,
   updateClaudeDesktopMetadata,
 } from "../utils/claudeDesktop";
+import { readConfiguration } from "../utils/config";
 import { logger } from "../utils/logger";
 import { updateEnvFile } from "../utils/updateEnvFile";
 import { createCommandHandler } from "./commandHandler";
@@ -36,12 +37,13 @@ export function buildCodexConfig(
   modelId: string,
   modelContextWindow: number | undefined,
   proxyPort: number,
+  experimentalWebSearchEnabled = false,
 ): UpdatedCodexConfig {
   const modelMatch = /^gpt-(\d+)/.exec(
     modelId.toLowerCase().replace(/\./g, "-"),
   );
   const supportsStandaloneWebSearch =
-    !!modelMatch && Number(modelMatch[1]) >= 5;
+    experimentalWebSearchEnabled && !!modelMatch && Number(modelMatch[1]) >= 5;
 
   return {
     ...existingConfig,
@@ -407,6 +409,7 @@ export function registerConfiguratorCommands(
           selectedModel.modelId,
           modelContextWindow,
           proxyPort,
+          readConfiguration().experimentalGpt5PlusWebSearchEnabled,
         );
 
         // Ensure .codex directory exists

--- a/src/commands/configuratorCommands.ts
+++ b/src/commands/configuratorCommands.ts
@@ -44,6 +44,11 @@ export function buildCodexConfig(
   );
   const supportsStandaloneWebSearch =
     experimentalWebSearchEnabled && !!modelMatch && Number(modelMatch[1]) >= 5;
+  const features = { ...existingConfig.features };
+  delete features.standalone_web_search;
+  if (supportsStandaloneWebSearch) {
+    features.standalone_web_search = true;
+  }
 
   return {
     ...existingConfig,
@@ -52,12 +57,7 @@ export function buildCodexConfig(
     ...(modelContextWindow !== undefined && {
       model_context_window: modelContextWindow,
     }),
-    ...(supportsStandaloneWebSearch && {
-      features: {
-        ...existingConfig.features,
-        standalone_web_search: true,
-      },
-    }),
+    features: Object.keys(features).length > 0 ? features : undefined,
     model_providers: {
       ...existingConfig.model_providers,
       "agent-maestro": {

--- a/src/commands/configuratorCommands.ts
+++ b/src/commands/configuratorCommands.ts
@@ -22,6 +22,54 @@ import { createCommandHandler } from "./commandHandler";
 
 const LOOPBACK_HOST = "127.0.0.1";
 
+type CodexConfig = Record<string, unknown> & {
+  features?: Record<string, unknown>;
+  model_providers?: Record<string, Record<string, unknown>>;
+};
+
+type UpdatedCodexConfig = CodexConfig & {
+  model_providers: Record<string, Record<string, unknown>>;
+};
+
+export function buildCodexConfig(
+  existingConfig: CodexConfig,
+  modelId: string,
+  modelContextWindow: number | undefined,
+  proxyPort: number,
+): UpdatedCodexConfig {
+  const modelMatch = /^gpt-(\d+)/.exec(
+    modelId.toLowerCase().replace(/\./g, "-"),
+  );
+  const supportsStandaloneWebSearch =
+    !!modelMatch && Number(modelMatch[1]) >= 5;
+
+  return {
+    ...existingConfig,
+    model: modelId,
+    model_provider: "agent-maestro",
+    ...(modelContextWindow !== undefined && {
+      model_context_window: modelContextWindow,
+    }),
+    ...(supportsStandaloneWebSearch && {
+      features: {
+        ...existingConfig.features,
+        standalone_web_search: true,
+      },
+    }),
+    model_providers: {
+      ...existingConfig.model_providers,
+      "agent-maestro": {
+        name: "Agent Maestro",
+        base_url: `http://${LOOPBACK_HOST}:${proxyPort}/api/openai/v1`,
+        wire_api: "responses",
+        ...(supportsStandaloneWebSearch && {
+          supports_standalone_web_search: true,
+        }),
+      },
+    },
+  };
+}
+
 export function registerConfiguratorCommands(
   proxy: ProxyServer,
   context: vscode.ExtensionContext,
@@ -354,23 +402,12 @@ export function registerConfiguratorCommands(
 
         const modelContextWindow = selectedModel.maxInputTokens ?? undefined;
 
-        // Build updated config by merging with existing config
-        const updatedConfig = {
-          ...existingConfig,
-          model: selectedModel.modelId,
-          model_provider: "agent-maestro",
-          ...(modelContextWindow !== undefined && {
-            model_context_window: modelContextWindow,
-          }),
-          model_providers: {
-            ...existingConfig.model_providers,
-            "agent-maestro": {
-              name: "Agent Maestro",
-              base_url: `http://${LOOPBACK_HOST}:${proxyPort}/api/openai/v1`,
-              wire_api: "responses",
-            },
-          },
-        };
+        const updatedConfig = buildCodexConfig(
+          existingConfig,
+          selectedModel.modelId,
+          modelContextWindow,
+          proxyPort,
+        );
 
         // Ensure .codex directory exists
         const codexDir = path.dirname(codexConfigPath);

--- a/src/server/routes/openai/openaiRoutes.ts
+++ b/src/server/routes/openai/openaiRoutes.ts
@@ -2,8 +2,10 @@ import { OpenAPIHono } from "@hono/zod-openapi";
 
 import { registerOpenaiChatRoutes } from "./openaiChatRoutes";
 import { registerOpenaiResponsesRoutes } from "./openaiResponsesRoutes";
+import { registerOpenaiSearchRoutes } from "./openaiSearchRoutes";
 
 export function registerOpenaiRoutes(app: OpenAPIHono) {
   registerOpenaiChatRoutes(app);
   registerOpenaiResponsesRoutes(app);
+  registerOpenaiSearchRoutes(app);
 }

--- a/src/server/routes/openai/openaiSearchRoutes.ts
+++ b/src/server/routes/openai/openaiSearchRoutes.ts
@@ -321,17 +321,7 @@ export function registerOpenaiSearchRoutes(
       }
       if (error instanceof LanguageModelClientDisconnectedError) {
         logger.info("/v1/alpha/search | client disconnected");
-        return c.json(
-          {
-            error: {
-              type: "client_disconnected",
-              message: error.message,
-              param: null,
-              code: "client_disconnected",
-            },
-          },
-          500,
-        );
+        return new Response(null, { status: 499 });
       }
 
       logger.error("✕ /v1/alpha/search |", error);

--- a/src/server/routes/openai/openaiSearchRoutes.ts
+++ b/src/server/routes/openai/openaiSearchRoutes.ts
@@ -32,8 +32,10 @@ type SearchRequest = {
   settings?: {
     search_context_size?: unknown;
     user_location?: unknown;
+    external_web_access?: unknown;
   };
   reasoning?: { effort?: unknown };
+  max_output_tokens?: unknown;
 };
 
 const searchRoute = createRoute({
@@ -124,10 +126,7 @@ export function registerOpenaiSearchRoutes(
           400,
         );
       }
-      if (
-        !requestBody.commands ||
-        Object.keys(requestBody.commands).length === 0
-      ) {
+      if (!requestBody.commands) {
         return c.json(
           {
             error: {
@@ -149,6 +148,20 @@ export function registerOpenaiSearchRoutes(
                 "Enable the experimental GPT-5+ web search patch before using standalone search",
               param: null,
               code: "web_search_disabled",
+            },
+          },
+          400,
+        );
+      }
+      if (requestBody.settings?.external_web_access !== true) {
+        return c.json(
+          {
+            error: {
+              type: "invalid_request_error",
+              message:
+                "Agent Maestro standalone search only supports live external web access",
+              param: "settings.external_web_access",
+              code: "unsupported_web_search_mode",
             },
           },
           400,
@@ -208,6 +221,10 @@ export function registerOpenaiSearchRoutes(
       };
       const requestOptions: vscode.LanguageModelChatRequestOptions = {
         justification: "Codex standalone web-search endpoint",
+        modelOptions:
+          typeof requestBody.max_output_tokens === "number"
+            ? { maxTokens: requestBody.max_output_tokens }
+            : undefined,
         tools: [sentinelTool],
         toolMode: vscode.LanguageModelChatToolMode.Required,
       };

--- a/src/server/routes/openai/openaiSearchRoutes.ts
+++ b/src/server/routes/openai/openaiSearchRoutes.ts
@@ -1,0 +1,302 @@
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import { ResponseInput } from "openai/resources/responses/responses";
+import * as vscode from "vscode";
+
+import {
+  getChatModelClient,
+  getCopilotModelConfiguration,
+  isGpt5PlusModel,
+  withCopilotConfiguration,
+} from "../../../utils/chatModels";
+import { readConfiguration } from "../../../utils/config";
+import {
+  AGENT_MAESTRO_WEB_SEARCH_SENTINEL_PARAMETER,
+  AGENT_MAESTRO_WEB_SEARCH_SENTINEL_TOOL_NAME,
+} from "../../../utils/copilotWebSearchConstants";
+import { logger } from "../../../utils/logger";
+import { CommonResponseError } from "../../schemas/openai";
+import { handleErrorWithLogging } from "../../utils/errorDiagnostics";
+import {
+  LanguageModelClientDisconnectedError,
+  LanguageModelRequestLifecycle,
+  LanguageModelRequestTimeoutError,
+  interruptibleLanguageModelStream,
+} from "../../utils/languageModelRequestLifecycle";
+import { convertResponsesInputToVSCode } from "../../utils/openaiResponses";
+
+type SearchRequest = {
+  id?: string;
+  model?: string;
+  input?: string | ResponseInput;
+  commands?: Record<string, unknown>;
+  settings?: {
+    search_context_size?: unknown;
+    user_location?: unknown;
+  };
+  reasoning?: { effort?: unknown };
+};
+
+const searchRoute = createRoute({
+  method: "post",
+  path: "/v1/alpha/search",
+  tags: ["OpenAI API"],
+  summary: "Run a Codex standalone web search",
+  description:
+    "Executes Codex standalone web-search commands through the experimental Copilot hosted web-search patch.",
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: z
+            .object()
+            .describe("Codex standalone web-search request body."),
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      content: {
+        "application/json": {
+          schema: z
+            .object()
+            .describe("Codex standalone web-search response body."),
+        },
+      },
+      description: "Search completed",
+    },
+    400: {
+      content: { "application/json": { schema: CommonResponseError } },
+      description: "Invalid request or web search is disabled",
+    },
+    404: {
+      content: { "application/json": { schema: CommonResponseError } },
+      description: "Model not found",
+    },
+    500: {
+      content: { "application/json": { schema: CommonResponseError } },
+      description: "Internal server error",
+    },
+    504: {
+      content: { "application/json": { schema: CommonResponseError } },
+      description: "Language model request timed out",
+    },
+  },
+});
+
+export interface OpenaiSearchRoutesOptions {
+  requestTimeoutMs?: number;
+  resolveChatModelClient?: typeof getChatModelClient;
+  isExperimentalWebSearchEnabled?: () => boolean;
+}
+
+export function registerOpenaiSearchRoutes(
+  app: OpenAPIHono,
+  options: OpenaiSearchRoutesOptions = {},
+) {
+  const resolveChatModelClient =
+    options.resolveChatModelClient ?? getChatModelClient;
+  const isExperimentalWebSearchEnabled =
+    options.isExperimentalWebSearchEnabled ??
+    (() => readConfiguration().experimentalGpt5PlusWebSearchEnabled);
+
+  app.openAPIRegistry.registerPath(searchRoute);
+  app.post(searchRoute.path, async (c) => {
+    let requestBody: SearchRequest | undefined;
+    let messages: vscode.LanguageModelChatMessage[] | undefined;
+    let requestedModelId = "";
+    let lifecycle: LanguageModelRequestLifecycle | undefined;
+
+    try {
+      requestBody = (await c.req.json()) as SearchRequest;
+      requestedModelId = requestBody.model ?? "";
+
+      if (!requestBody.model) {
+        return c.json(
+          {
+            error: {
+              type: "invalid_request_error",
+              message: "model is required",
+              param: "model",
+              code: "missing_required_parameter",
+            },
+          },
+          400,
+        );
+      }
+      if (
+        !requestBody.commands ||
+        Object.keys(requestBody.commands).length === 0
+      ) {
+        return c.json(
+          {
+            error: {
+              type: "invalid_request_error",
+              message: "commands is required",
+              param: "commands",
+              code: "missing_required_parameter",
+            },
+          },
+          400,
+        );
+      }
+      if (!isExperimentalWebSearchEnabled()) {
+        return c.json(
+          {
+            error: {
+              type: "invalid_request_error",
+              message:
+                "Enable the experimental GPT-5+ web search patch before using standalone search",
+              param: null,
+              code: "web_search_disabled",
+            },
+          },
+          400,
+        );
+      }
+
+      const { client, error: clientError } = await resolveChatModelClient(
+        requestBody.model,
+      );
+      if (clientError) {
+        return c.json(clientError, 404);
+      }
+      if (!isGpt5PlusModel(requestBody.model, client)) {
+        return c.json(
+          {
+            error: {
+              type: "invalid_request_error",
+              message: "Standalone web search requires a GPT-5+ Copilot model",
+              param: "model",
+              code: "unsupported_model",
+            },
+          },
+          400,
+        );
+      }
+
+      messages = convertResponsesInputToVSCode(requestBody.input);
+      messages.push(
+        vscode.LanguageModelChatMessage.User(
+          "Execute this web-search command and return the useful results with their source URLs:\n" +
+            JSON.stringify(requestBody.commands),
+        ),
+      );
+
+      const webSearchTool = {
+        type: "web_search",
+        ...(requestBody.settings?.search_context_size !== undefined
+          ? {
+              search_context_size: requestBody.settings.search_context_size,
+            }
+          : {}),
+        ...(requestBody.settings?.user_location !== undefined
+          ? { user_location: requestBody.settings.user_location }
+          : {}),
+      };
+      const sentinelTool: vscode.LanguageModelChatTool = {
+        name: AGENT_MAESTRO_WEB_SEARCH_SENTINEL_TOOL_NAME,
+        description: "Internal Agent Maestro standalone web-search marker.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            [AGENT_MAESTRO_WEB_SEARCH_SENTINEL_PARAMETER]: {
+              const: webSearchTool,
+            },
+          },
+        },
+      };
+      const requestOptions: vscode.LanguageModelChatRequestOptions = {
+        justification: "Codex standalone web-search endpoint",
+        tools: [sentinelTool],
+        toolMode: vscode.LanguageModelChatToolMode.Required,
+      };
+
+      lifecycle = new LanguageModelRequestLifecycle(
+        c.req.raw.signal,
+        options.requestTimeoutMs,
+      );
+      logger.info(`→ /v1/alpha/search | model: ${requestBody.model}`);
+      const response = await lifecycle.waitFor(
+        client.sendRequest(
+          messages,
+          withCopilotConfiguration(
+            client,
+            requestOptions,
+            getCopilotModelConfiguration({
+              reasoningEffort: requestBody.reasoning?.effort,
+            }),
+          ),
+          lifecycle.token,
+        ),
+      );
+
+      let output = "";
+      for await (const chunk of interruptibleLanguageModelStream(
+        response.stream,
+        lifecycle,
+      )) {
+        if (chunk instanceof vscode.LanguageModelTextPart) {
+          output += chunk.value;
+        }
+      }
+
+      logger.info(`← /v1/alpha/search | chars: ${output.length}`);
+      return c.json({ output });
+    } catch (error) {
+      if (error instanceof LanguageModelRequestTimeoutError) {
+        logger.error("✕ /v1/alpha/search |", error);
+        return c.json(
+          {
+            error: {
+              type: "timeout_error",
+              message: error.message,
+              param: null,
+              code: "request_timeout",
+            },
+          },
+          504,
+        );
+      }
+      if (error instanceof LanguageModelClientDisconnectedError) {
+        logger.info("/v1/alpha/search | client disconnected");
+        return c.json(
+          {
+            error: {
+              type: "client_disconnected",
+              message: error.message,
+              param: null,
+              code: "client_disconnected",
+            },
+          },
+          500,
+        );
+      }
+
+      logger.error("✕ /v1/alpha/search |", error);
+      const logFilePath = await handleErrorWithLogging({
+        requestBody,
+        inputTokens: 0,
+        lmChatMessages: messages,
+        error,
+        endpoint: "/api/openai/v1/alpha/search",
+        modelId: requestedModelId,
+      });
+      return c.json(
+        {
+          error: {
+            type: "internal_error",
+            message:
+              error instanceof Error ? error.message : "Internal server error",
+            param: null,
+            code: null,
+            log_file: logFilePath,
+          },
+        },
+        500,
+      );
+    } finally {
+      lifecycle?.dispose();
+    }
+  });
+}

--- a/src/server/routes/openai/openaiSearchRoutes.ts
+++ b/src/server/routes/openai/openaiSearchRoutes.ts
@@ -24,19 +24,48 @@ import {
 } from "../../utils/languageModelRequestLifecycle";
 import { convertResponsesInputToVSCode } from "../../utils/openaiResponses";
 
-type SearchRequest = {
-  id?: string;
-  model?: string;
-  input?: string | ResponseInput;
-  commands?: Record<string, unknown>;
-  settings?: {
-    search_context_size?: unknown;
-    user_location?: unknown;
-    external_web_access?: unknown;
-  };
-  reasoning?: { effort?: unknown };
-  max_output_tokens?: unknown;
-};
+const SearchSettingsSchema = z
+  .object({
+    search_context_size: z.enum(["low", "medium", "high"]).optional(),
+    user_location: z
+      .object({
+        type: z.literal("approximate"),
+        country: z.string().optional(),
+        region: z.string().optional(),
+        city: z.string().optional(),
+        timezone: z.string().optional(),
+      })
+      .optional(),
+    filters: z
+      .object({
+        allowed_domains: z.array(z.string()).optional(),
+        blocked_domains: z.array(z.string()).optional(),
+      })
+      .optional(),
+    external_web_access: z
+      .union([z.boolean(), z.enum(["cached", "indexed", "live"])])
+      .optional(),
+  })
+  .passthrough();
+
+const SearchRequestSchema = z
+  .object({
+    id: z.string().optional(),
+    model: z.string().min(1),
+    input: z.union([z.string(), z.array(z.unknown())]).optional() as z.ZodType<
+      string | ResponseInput | undefined
+    >,
+    commands: z.record(z.string(), z.unknown()),
+    settings: SearchSettingsSchema.optional(),
+    reasoning: z
+      .object({ effort: z.string().optional() })
+      .passthrough()
+      .optional(),
+    max_output_tokens: z.number().int().positive().optional(),
+  })
+  .passthrough();
+
+type SearchRequest = z.infer<typeof SearchRequestSchema>;
 
 const searchRoute = createRoute({
   method: "post",
@@ -49,9 +78,9 @@ const searchRoute = createRoute({
     body: {
       content: {
         "application/json": {
-          schema: z
-            .object()
-            .describe("Codex standalone web-search request body."),
+          schema: SearchRequestSchema.describe(
+            "Codex standalone web-search request body.",
+          ),
         },
       },
     },
@@ -61,7 +90,7 @@ const searchRoute = createRoute({
       content: {
         "application/json": {
           schema: z
-            .object()
+            .object({ output: z.string() })
             .describe("Codex standalone web-search response body."),
         },
       },
@@ -110,35 +139,41 @@ export function registerOpenaiSearchRoutes(
     let lifecycle: LanguageModelRequestLifecycle | undefined;
 
     try {
-      requestBody = (await c.req.json()) as SearchRequest;
-      requestedModelId = requestBody.model ?? "";
+      let rawRequestBody: unknown;
+      try {
+        rawRequestBody = await c.req.json();
+      } catch {
+        return c.json(
+          {
+            error: {
+              type: "invalid_request_error",
+              message: "Request body must be valid JSON",
+              param: null,
+              code: "invalid_json",
+            },
+          },
+          400,
+        );
+      }
 
-      if (!requestBody.model) {
+      const parsedRequest = SearchRequestSchema.safeParse(rawRequestBody);
+      if (!parsedRequest.success) {
+        const issue = parsedRequest.error.issues[0];
+        const param = issue?.path.join(".") || null;
         return c.json(
           {
             error: {
               type: "invalid_request_error",
-              message: "model is required",
-              param: "model",
-              code: "missing_required_parameter",
+              message: issue?.message ?? "Invalid request body",
+              param,
+              code: "invalid_request",
             },
           },
           400,
         );
       }
-      if (!requestBody.commands) {
-        return c.json(
-          {
-            error: {
-              type: "invalid_request_error",
-              message: "commands is required",
-              param: "commands",
-              code: "missing_required_parameter",
-            },
-          },
-          400,
-        );
-      }
+      requestBody = parsedRequest.data;
+      requestedModelId = requestBody.model;
       if (!isExperimentalWebSearchEnabled()) {
         return c.json(
           {
@@ -153,15 +188,14 @@ export function registerOpenaiSearchRoutes(
           400,
         );
       }
-      if (requestBody.settings?.external_web_access !== true) {
+      if (requestBody.settings?.external_web_access === undefined) {
         return c.json(
           {
             error: {
               type: "invalid_request_error",
-              message:
-                "Agent Maestro standalone search only supports live external web access",
+              message: "settings.external_web_access is required",
               param: "settings.external_web_access",
-              code: "unsupported_web_search_mode",
+              code: "missing_required_parameter",
             },
           },
           400,
@@ -174,7 +208,7 @@ export function registerOpenaiSearchRoutes(
       if (clientError) {
         return c.json(clientError, 404);
       }
-      if (!isGpt5PlusModel(requestBody.model, client)) {
+      if (!isGpt5PlusModel("", client)) {
         return c.json(
           {
             error: {
@@ -198,6 +232,13 @@ export function registerOpenaiSearchRoutes(
 
       const webSearchTool = {
         type: "web_search",
+        external_web_access:
+          requestBody.settings.external_web_access === true ||
+          requestBody.settings.external_web_access === "live" ||
+          requestBody.settings.external_web_access === "indexed",
+        ...(requestBody.settings.external_web_access === "indexed"
+          ? { indexed_web_access: true }
+          : {}),
         ...(requestBody.settings?.search_context_size !== undefined
           ? {
               search_context_size: requestBody.settings.search_context_size,
@@ -205,6 +246,9 @@ export function registerOpenaiSearchRoutes(
           : {}),
         ...(requestBody.settings?.user_location !== undefined
           ? { user_location: requestBody.settings.user_location }
+          : {}),
+        ...(requestBody.settings?.filters !== undefined
+          ? { filters: requestBody.settings.filters }
           : {}),
       };
       const sentinelTool: vscode.LanguageModelChatTool = {

--- a/src/test/server/openaiSearch.test.ts
+++ b/src/test/server/openaiSearch.test.ts
@@ -339,4 +339,34 @@ suite("OpenAI Standalone Search Route Test Suite", () => {
     assert.strictEqual((await response.json()).error.code, "request_timeout");
     assert.strictEqual(cancelled, true);
   });
+
+  test("returns 499 with an empty body when the client disconnects", async () => {
+    let cancelled = false;
+    let markRequestStarted: (() => void) | undefined;
+    const requestStarted = new Promise<void>((resolve) => {
+      markRequestStarted = resolve;
+    });
+    const model = createModel(async (_messages, _options, token) => {
+      token?.onCancellationRequested(() => {
+        cancelled = true;
+      });
+      markRequestStarted?.();
+      return new Promise<vscode.LanguageModelChatResponse>(() => {});
+    });
+    const controller = new AbortController();
+    const responsePromise = createApp(model).request("/v1/alpha/search", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(searchRequest),
+      signal: controller.signal,
+    });
+
+    await requestStarted;
+    controller.abort();
+
+    const response = await responsePromise;
+    assert.strictEqual(response.status, 499);
+    assert.strictEqual(await response.text(), "");
+    assert.strictEqual(cancelled, true);
+  });
 });

--- a/src/test/server/openaiSearch.test.ts
+++ b/src/test/server/openaiSearch.test.ts
@@ -1,0 +1,174 @@
+import { OpenAPIHono } from "@hono/zod-openapi";
+import * as assert from "assert";
+import * as vscode from "vscode";
+
+import { registerOpenaiSearchRoutes } from "../../server/routes/openai/openaiSearchRoutes";
+import {
+  AGENT_MAESTRO_WEB_SEARCH_SENTINEL_PARAMETER,
+  AGENT_MAESTRO_WEB_SEARCH_SENTINEL_TOOL_NAME,
+} from "../../utils/copilotWebSearchConstants";
+
+suite("OpenAI Standalone Search Route Test Suite", () => {
+  const searchRequest = {
+    id: "search-1",
+    model: "gpt-5.6-sol",
+    input: "Find OpenAI",
+    commands: { search_query: [{ q: "OpenAI official site" }] },
+  };
+
+  function createModel(
+    sendRequest: vscode.LanguageModelChat["sendRequest"],
+    family = "gpt-5.6",
+  ): vscode.LanguageModelChat {
+    return {
+      id: family,
+      name: family,
+      family,
+      version: "test",
+      vendor: "copilot",
+      maxInputTokens: 100000,
+      capabilities: { supportsImageToText: true, supportsToolCalling: true },
+      sendRequest,
+      countTokens: async () => 0,
+    } as vscode.LanguageModelChat;
+  }
+
+  function createApp(
+    model: vscode.LanguageModelChat,
+    options: { enabled?: boolean; timeoutMs?: number } = {},
+  ): OpenAPIHono {
+    const app = new OpenAPIHono();
+    registerOpenaiSearchRoutes(app, {
+      requestTimeoutMs: options.timeoutMs,
+      resolveChatModelClient: async () => ({ client: model }),
+      isExperimentalWebSearchEnabled: () => options.enabled ?? true,
+    });
+    return app;
+  }
+
+  function post(app: OpenAPIHono, body: unknown): Promise<Response> {
+    return Promise.resolve(
+      app.request("/v1/alpha/search", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+      }),
+    );
+  }
+
+  test("converts a Codex search request into hosted Copilot web search", async () => {
+    let capturedOptions: vscode.LanguageModelChatRequestOptions | undefined;
+    const model = createModel(async (_messages, options) => {
+      capturedOptions = options;
+      return {
+        stream: (async function* () {
+          yield new vscode.LanguageModelTextPart("OpenAI: https://openai.com/");
+        })(),
+        text: (async function* () {})(),
+      };
+    });
+
+    const response = await post(createApp(model), searchRequest);
+
+    assert.strictEqual(response.status, 200);
+    assert.deepStrictEqual(await response.json(), {
+      output: "OpenAI: https://openai.com/",
+    });
+    assert.strictEqual(
+      capturedOptions?.toolMode,
+      vscode.LanguageModelChatToolMode.Required,
+    );
+    const sentinel = capturedOptions?.tools?.[0];
+    assert.strictEqual(
+      sentinel?.name,
+      AGENT_MAESTRO_WEB_SEARCH_SENTINEL_TOOL_NAME,
+    );
+    assert.deepStrictEqual(
+      (sentinel?.inputSchema as any).properties[
+        AGENT_MAESTRO_WEB_SEARCH_SENTINEL_PARAMETER
+      ].const,
+      { type: "web_search" },
+    );
+  });
+
+  test("registers the standalone endpoint in OpenAPI", () => {
+    const model = createModel(async () => {
+      throw new Error("should not send a model request");
+    });
+    const app = createApp(model);
+
+    const document = app.getOpenAPIDocument({
+      openapi: "3.0.0",
+      info: { title: "test", version: "1" },
+    });
+
+    assert.ok(document.paths?.["/v1/alpha/search"]?.post);
+  });
+
+  test("rejects standalone search when the experimental patch is disabled", async () => {
+    const model = createModel(async () => {
+      throw new Error("should not send a model request");
+    });
+
+    const response = await post(
+      createApp(model, { enabled: false }),
+      searchRequest,
+    );
+
+    assert.strictEqual(response.status, 400);
+    assert.strictEqual(
+      (await response.json()).error.code,
+      "web_search_disabled",
+    );
+  });
+
+  test("rejects requests without commands", async () => {
+    const model = createModel(async () => {
+      throw new Error("should not send a model request");
+    });
+
+    const response = await post(createApp(model), {
+      model: "gpt-5.6-sol",
+      input: "Find OpenAI",
+    });
+
+    assert.strictEqual(response.status, 400);
+    assert.strictEqual(
+      (await response.json()).error.code,
+      "missing_required_parameter",
+    );
+  });
+
+  test("rejects non-GPT-5 Copilot models", async () => {
+    const model = createModel(async () => {
+      throw new Error("should not send a model request");
+    }, "gpt-4.1");
+
+    const response = await post(createApp(model), {
+      ...searchRequest,
+      model: "gpt-4.1",
+    });
+
+    assert.strictEqual(response.status, 400);
+    assert.strictEqual((await response.json()).error.code, "unsupported_model");
+  });
+
+  test("returns 504 and cancels a stalled search", async () => {
+    let cancelled = false;
+    const model = createModel(async (_messages, _options, token) => {
+      token?.onCancellationRequested(() => {
+        cancelled = true;
+      });
+      return new Promise<vscode.LanguageModelChatResponse>(() => {});
+    });
+
+    const response = await post(
+      createApp(model, { timeoutMs: 20 }),
+      searchRequest,
+    );
+
+    assert.strictEqual(response.status, 504);
+    assert.strictEqual((await response.json()).error.code, "request_timeout");
+    assert.strictEqual(cancelled, true);
+  });
+});

--- a/src/test/server/openaiSearch.test.ts
+++ b/src/test/server/openaiSearch.test.ts
@@ -58,6 +58,16 @@ suite("OpenAI Standalone Search Route Test Suite", () => {
     );
   }
 
+  function postRaw(app: OpenAPIHono, body: string): Promise<Response> {
+    return Promise.resolve(
+      app.request("/v1/alpha/search", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body,
+      }),
+    );
+  }
+
   test("converts a Codex search request into hosted Copilot web search", async () => {
     let capturedOptions: vscode.LanguageModelChatRequestOptions | undefined;
     const model = createModel(async (_messages, options) => {
@@ -90,7 +100,7 @@ suite("OpenAI Standalone Search Route Test Suite", () => {
       (sentinel?.inputSchema as any).properties[
         AGENT_MAESTRO_WEB_SEARCH_SENTINEL_PARAMETER
       ].const,
-      { type: "web_search" },
+      { type: "web_search", external_web_access: true },
     );
   });
 
@@ -106,6 +116,9 @@ suite("OpenAI Standalone Search Route Test Suite", () => {
     });
 
     assert.ok(document.paths?.["/v1/alpha/search"]?.post);
+    const operation = document.paths?.["/v1/alpha/search"]?.post;
+    assert.ok(operation && "requestBody" in operation);
+    assert.ok(operation?.responses?.["200"]);
   });
 
   test("rejects standalone search when the experimental patch is disabled", async () => {
@@ -136,10 +149,55 @@ suite("OpenAI Standalone Search Route Test Suite", () => {
     });
 
     assert.strictEqual(response.status, 400);
-    assert.strictEqual(
-      (await response.json()).error.code,
-      "missing_required_parameter",
-    );
+    assert.strictEqual((await response.json()).error.code, "invalid_request");
+  });
+
+  test("returns 400 for malformed JSON", async () => {
+    const model = createModel(async () => {
+      throw new Error("should not send a model request");
+    });
+
+    const response = await postRaw(createApp(model), "{");
+
+    assert.strictEqual(response.status, 400);
+    assert.strictEqual((await response.json()).error.code, "invalid_json");
+  });
+
+  test("returns 400 for invalid request body shapes", async () => {
+    const model = createModel(async () => {
+      throw new Error("should not send a model request");
+    });
+
+    for (const body of [
+      null,
+      [],
+      { ...searchRequest, model: 5 },
+      { ...searchRequest, input: {} },
+      { ...searchRequest, commands: [] },
+      { ...searchRequest, settings: "live" },
+      {
+        ...searchRequest,
+        settings: { external_web_access: true, search_context_size: "huge" },
+      },
+      {
+        ...searchRequest,
+        settings: { external_web_access: true, user_location: {} },
+      },
+      {
+        ...searchRequest,
+        settings: {
+          external_web_access: true,
+          filters: { allowed_domains: [1] },
+        },
+      },
+      { ...searchRequest, reasoning: { effort: 5 } },
+      { ...searchRequest, max_output_tokens: -1 },
+    ]) {
+      const response = await post(createApp(model), body);
+
+      assert.strictEqual(response.status, 400);
+      assert.strictEqual((await response.json()).error.code, "invalid_request");
+    }
   });
 
   test("accepts an empty commands object", async () => {
@@ -158,21 +216,82 @@ suite("OpenAI Standalone Search Route Test Suite", () => {
     assert.strictEqual(response.status, 200);
   });
 
-  test("rejects non-live external web access modes", async () => {
+  test("requires an explicit external web access mode", async () => {
     const model = createModel(async () => {
       throw new Error("should not send a model request");
     });
 
-    for (const externalWebAccess of [false, "indexed", "cached"]) {
-      const response = await post(createApp(model), {
-        ...searchRequest,
-        settings: { external_web_access: externalWebAccess },
+    const response = await post(createApp(model), {
+      ...searchRequest,
+      settings: {},
+    });
+
+    assert.strictEqual(response.status, 400);
+    assert.strictEqual(
+      (await response.json()).error.code,
+      "missing_required_parameter",
+    );
+  });
+
+  test("accepts the explicit live external web access mode and forwards filters", async () => {
+    let capturedOptions: vscode.LanguageModelChatRequestOptions | undefined;
+    const model = createModel(async (_messages, options) => {
+      capturedOptions = options;
+      return {
+        stream: (async function* () {})(),
+        text: (async function* () {})(),
+      };
+    });
+
+    const response = await post(createApp(model), {
+      ...searchRequest,
+      settings: {
+        external_web_access: "live",
+        filters: { allowed_domains: ["openai.com"] },
+      },
+    });
+
+    assert.strictEqual(response.status, 200);
+    const sentinel = capturedOptions?.tools?.[0];
+    assert.deepStrictEqual(
+      (sentinel?.inputSchema as any).properties[
+        AGENT_MAESTRO_WEB_SEARCH_SENTINEL_PARAMETER
+      ].const,
+      {
+        type: "web_search",
+        external_web_access: true,
+        filters: { allowed_domains: ["openai.com"] },
+      },
+    );
+  });
+
+  test("maps indexed and cached standalone modes to hosted search options", async () => {
+    for (const [mode, expected] of [
+      ["indexed", { external_web_access: true, indexed_web_access: true }],
+      ["cached", { external_web_access: false }],
+      [false, { external_web_access: false }],
+    ] as const) {
+      let capturedOptions: vscode.LanguageModelChatRequestOptions | undefined;
+      const model = createModel(async (_messages, options) => {
+        capturedOptions = options;
+        return {
+          stream: (async function* () {})(),
+          text: (async function* () {})(),
+        };
       });
 
-      assert.strictEqual(response.status, 400);
-      assert.strictEqual(
-        (await response.json()).error.code,
-        "unsupported_web_search_mode",
+      const response = await post(createApp(model), {
+        ...searchRequest,
+        settings: { external_web_access: mode },
+      });
+
+      assert.strictEqual(response.status, 200);
+      const sentinel = capturedOptions?.tools?.[0];
+      assert.deepStrictEqual(
+        (sentinel?.inputSchema as any).properties[
+          AGENT_MAESTRO_WEB_SEARCH_SENTINEL_PARAMETER
+        ].const,
+        { type: "web_search", ...expected },
       );
     }
   });
@@ -186,6 +305,17 @@ suite("OpenAI Standalone Search Route Test Suite", () => {
       ...searchRequest,
       model: "gpt-4.1",
     });
+
+    assert.strictEqual(response.status, 400);
+    assert.strictEqual((await response.json()).error.code, "unsupported_model");
+  });
+
+  test("rejects a GPT-5 request that resolves to an earlier model", async () => {
+    const model = createModel(async () => {
+      throw new Error("should not send a model request");
+    }, "gpt-4.1");
+
+    const response = await post(createApp(model), searchRequest);
 
     assert.strictEqual(response.status, 400);
     assert.strictEqual((await response.json()).error.code, "unsupported_model");

--- a/src/test/server/openaiSearch.test.ts
+++ b/src/test/server/openaiSearch.test.ts
@@ -14,6 +14,8 @@ suite("OpenAI Standalone Search Route Test Suite", () => {
     model: "gpt-5.6-sol",
     input: "Find OpenAI",
     commands: { search_query: [{ q: "OpenAI official site" }] },
+    settings: { external_web_access: true },
+    max_output_tokens: 2500,
   };
 
   function createModel(
@@ -78,6 +80,7 @@ suite("OpenAI Standalone Search Route Test Suite", () => {
       capturedOptions?.toolMode,
       vscode.LanguageModelChatToolMode.Required,
     );
+    assert.deepStrictEqual(capturedOptions?.modelOptions, { maxTokens: 2500 });
     const sentinel = capturedOptions?.tools?.[0];
     assert.strictEqual(
       sentinel?.name,
@@ -137,6 +140,41 @@ suite("OpenAI Standalone Search Route Test Suite", () => {
       (await response.json()).error.code,
       "missing_required_parameter",
     );
+  });
+
+  test("accepts an empty commands object", async () => {
+    const model = createModel(async () => ({
+      stream: (async function* () {
+        yield new vscode.LanguageModelTextPart("No search command supplied");
+      })(),
+      text: (async function* () {})(),
+    }));
+
+    const response = await post(createApp(model), {
+      ...searchRequest,
+      commands: {},
+    });
+
+    assert.strictEqual(response.status, 200);
+  });
+
+  test("rejects non-live external web access modes", async () => {
+    const model = createModel(async () => {
+      throw new Error("should not send a model request");
+    });
+
+    for (const externalWebAccess of [false, "indexed", "cached"]) {
+      const response = await post(createApp(model), {
+        ...searchRequest,
+        settings: { external_web_access: externalWebAccess },
+      });
+
+      assert.strictEqual(response.status, 400);
+      assert.strictEqual(
+        (await response.json()).error.code,
+        "unsupported_web_search_mode",
+      );
+    }
   });
 
   test("rejects non-GPT-5 Copilot models", async () => {

--- a/src/test/utils/codexConfig.test.ts
+++ b/src/test/utils/codexConfig.test.ts
@@ -1,0 +1,31 @@
+import * as assert from "assert";
+
+import { buildCodexConfig } from "../../commands/configuratorCommands";
+
+suite("Codex Configuration Test Suite", () => {
+  test("enables standalone search for GPT-5+ models", () => {
+    const config = buildCodexConfig(
+      { features: { existing_feature: true } },
+      "gpt-5.6-sol",
+      100000,
+      23333,
+    );
+
+    assert.strictEqual(config.features?.existing_feature, true);
+    assert.strictEqual(config.features?.standalone_web_search, true);
+    assert.strictEqual(
+      config.model_providers["agent-maestro"].supports_standalone_web_search,
+      true,
+    );
+  });
+
+  test("does not advertise standalone search for earlier models", () => {
+    const config = buildCodexConfig({}, "gpt-4.1", 100000, 23333);
+
+    assert.strictEqual(config.features, undefined);
+    assert.strictEqual(
+      config.model_providers["agent-maestro"].supports_standalone_web_search,
+      undefined,
+    );
+  });
+});

--- a/src/test/utils/codexConfig.test.ts
+++ b/src/test/utils/codexConfig.test.ts
@@ -9,6 +9,7 @@ suite("Codex Configuration Test Suite", () => {
       "gpt-5.6-sol",
       100000,
       23333,
+      true,
     );
 
     assert.strictEqual(config.features?.existing_feature, true);
@@ -20,7 +21,17 @@ suite("Codex Configuration Test Suite", () => {
   });
 
   test("does not advertise standalone search for earlier models", () => {
-    const config = buildCodexConfig({}, "gpt-4.1", 100000, 23333);
+    const config = buildCodexConfig({}, "gpt-4.1", 100000, 23333, true);
+
+    assert.strictEqual(config.features, undefined);
+    assert.strictEqual(
+      config.model_providers["agent-maestro"].supports_standalone_web_search,
+      undefined,
+    );
+  });
+
+  test("does not advertise standalone search while the patch is disabled", () => {
+    const config = buildCodexConfig({}, "gpt-5.6-sol", 100000, 23333);
 
     assert.strictEqual(config.features, undefined);
     assert.strictEqual(

--- a/src/test/utils/codexConfig.test.ts
+++ b/src/test/utils/codexConfig.test.ts
@@ -73,4 +73,18 @@ suite("Codex Configuration Test Suite", () => {
 
     assert.strictEqual(config.features, undefined);
   });
+
+  test("replaces malformed legacy features values", () => {
+    for (const features of [null, "legacy", []]) {
+      const config = buildCodexConfig(
+        { features: features as unknown as Record<string, unknown> },
+        "gpt-5.6-sol",
+        100000,
+        23333,
+        true,
+      );
+
+      assert.deepStrictEqual(config.features, { standalone_web_search: true });
+    }
+  });
 });

--- a/src/test/utils/codexConfig.test.ts
+++ b/src/test/utils/codexConfig.test.ts
@@ -39,4 +39,38 @@ suite("Codex Configuration Test Suite", () => {
       undefined,
     );
   });
+
+  test("removes stale standalone search configuration", () => {
+    const config = buildCodexConfig(
+      {
+        features: { standalone_web_search: true, existing_feature: true },
+        model_providers: {
+          "agent-maestro": { supports_standalone_web_search: true },
+        },
+      },
+      "gpt-4.1",
+      100000,
+      23333,
+      true,
+    );
+
+    assert.strictEqual(config.features?.standalone_web_search, undefined);
+    assert.strictEqual(config.features?.existing_feature, true);
+    assert.strictEqual(
+      config.model_providers["agent-maestro"].supports_standalone_web_search,
+      undefined,
+    );
+  });
+
+  test("removes the features table when standalone search was its only entry", () => {
+    const config = buildCodexConfig(
+      { features: { standalone_web_search: true } },
+      "gpt-5.6-sol",
+      100000,
+      23333,
+      false,
+    );
+
+    assert.strictEqual(config.features, undefined);
+  });
 });


### PR DESCRIPTION
## Summary

- Add POST /api/openai/v1/alpha/search for Codex models that use Responses Lite standalone search.
- Adapt Codex search commands to the existing experimental GPT-5+ Copilot hosted web-search transport.
- Update one-click Codex configuration to opt GPT-5+ providers into standalone search while preserving existing features.
- Document the capability and add route, OpenAPI, validation, timeout, cancellation, and config-merge coverage.

This complements the hosted /v1/responses support introduced in #207. It is intentionally separate from the VS Code 1.131 matcher regression fixed by #225 (issue #224). The endpoint requires that experimental Copilot patch to be enabled.

## Changeset

- .changeset/add-codex-standalone-web-search.md

## Test plan

- [x] pnpm run check-types
- [x] pnpm exec eslint src
- [x] pnpm run build-tests
- [x] New Codex config and standalone search suites: 8 passing on VS Code 1.131.0
- [x] Full suite: 380 passing; one pre-existing platform-specific path assertion fails on Windows (getCopilotBundlePath expects a macOS-style path)
- [x] Combined with #225: production build and VSIX packaging pass
- [x] End-to-end Codex JSONL verification produced item.started and item.completed events with type web_search, query official OpenAI homepage, and source URL https://openai.com/