### PR TITLE
fix(server): keep SSE streams alive during slow responses

### DIFF
--- a/.changeset/quiet-dodos-smile.md
+++ b/.changeset/quiet-dodos-smile.md
@@ -1,0 +1,5 @@
+---
+"agent-maestro": patch
+---
+
+Keep Anthropic, OpenAI, and Gemini SSE responses active while waiting for slow language model output.

--- a/docs/2026-08-11-sse-heartbeats.md
+++ b/docs/2026-08-11-sse-heartbeats.md
@@ -1,0 +1,40 @@
+# SSE heartbeats
+
+## Problem
+
+Streaming routes establish an SSE response before VS Code LM produces its first
+chunk. With large contexts or concurrent requests, that wait can be long enough
+for clients such as Claude Code to treat the otherwise healthy connection as
+idle and retry ([#227](https://github.com/Joouis/agent-maestro/issues/227)).
+
+The existing request timeout solves a different problem: it cancels an upstream
+request that exceeds its total lifetime. A heartbeat keeps the downstream
+connection active while that request is still within the allowed lifetime.
+
+## Design
+
+Wrap the upstream async iterable with a small `withSseHeartbeat()` helper. While
+one `iterator.next()` is pending, the helper yields a heartbeat marker every 10
+seconds. Routes handle that marker using their protocol's wire format:
+
+| Route                        | Heartbeat frame                      |
+| ---------------------------- | ------------------------------------ |
+| Anthropic Messages           | `event: ping` with `{"type":"ping"}` |
+| OpenAI Chat/Responses        | SSE comment `: keep-alive`           |
+| Gemini streamGenerateContent | SSE comment `: keep-alive`           |
+
+SSE comments produce network traffic but are ignored by compliant parsers, so
+they do not introduce non-JSON data events into OpenAI or Gemini streams.
+
+The helper does not own a background interval and never calls `next()`
+concurrently. Heartbeats and model chunks are therefore written in order.
+Request timeout, client cancellation, and route error handling remain
+authoritative and are not reset by heartbeats. Gemini's streaming route uses
+the same request lifecycle as Anthropic and OpenAI so either condition also
+cancels its VS Code LM request.
+
+## Verification
+
+Unit tests cover repeated heartbeats during a stalled `next()`, normal chunk
+ordering, and timer cleanup. Route tests verify the Anthropic ping frame and the
+OpenAI/Gemini comment frame.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -34,6 +34,7 @@ pnpm run watch-tests
 | `server/openaiChat.test.ts`                    | 15    | OpenAI → VS Code message conversion                       |
 | `server/openaiResponses.test.ts`               | 54    | OpenAI Responses → VS Code conversion                     |
 | `server/gemini.test.ts`                        | 27    | Gemini → VS Code message conversion                       |
+| `server/sseHeartbeat.test.ts`                  | 8     | SSE heartbeat scheduling, lifecycle, and protocol frames  |
 
 ## How Tests Prevent Regressions
 

--- a/src/server/routes/anthropicRoutes.ts
+++ b/src/server/routes/anthropicRoutes.ts
@@ -33,6 +33,7 @@ import {
   LanguageModelRequestTimeoutError,
   interruptibleLanguageModelStream,
 } from "../utils/languageModelRequestLifecycle";
+import { SSE_HEARTBEAT, withSseHeartbeat } from "../utils/sseHeartbeat";
 
 const prepareAnthropicMessages = async ({
   requestBody,
@@ -273,6 +274,7 @@ const modelRoute = createRoute({
 });
 
 export interface AnthropicRoutesOptions {
+  heartbeatIntervalMs?: number;
   requestTimeoutMs?: number;
   resolveChatModelClient?: typeof getChatModelClient;
 }
@@ -577,10 +579,23 @@ export function registerAnthropicRoutes(
           let stopReason: Anthropic.Messages.StopReason = "end_turn";
 
           try {
-            for await (const chunk of interruptibleLanguageModelStream(
-              response.stream,
-              requestLifecycle!,
+            for await (const chunk of withSseHeartbeat(
+              interruptibleLanguageModelStream(
+                response.stream,
+                requestLifecycle!,
+              ),
+              options.heartbeatIntervalMs,
             )) {
+              if (chunk === SSE_HEARTBEAT) {
+                await requestLifecycle!.waitFor(
+                  stream.writeSSE({
+                    event: "ping",
+                    data: JSON.stringify({ type: "ping" }),
+                  }),
+                );
+                continue;
+              }
+
               const lastBlock = contentBlocks.at(-1);
               if (chunk instanceof vscode.LanguageModelTextPart) {
                 // Stop last non-text block if it exists

--- a/src/server/routes/geminiRoutes.ts
+++ b/src/server/routes/geminiRoutes.ts
@@ -23,6 +23,13 @@ import {
   convertGeminiToolsToVSCode,
   extractGeminiUsage,
 } from "../utils/gemini";
+import {
+  LanguageModelClientDisconnectedError,
+  LanguageModelRequestLifecycle,
+  LanguageModelRequestTimeoutError,
+  interruptibleLanguageModelStream,
+} from "../utils/languageModelRequestLifecycle";
+import { SSE_HEARTBEAT, withSseHeartbeat } from "../utils/sseHeartbeat";
 
 // ============================================================================
 // Shared Helper Functions
@@ -304,7 +311,19 @@ const countTokensRoute = createRoute({
 // Route Handlers
 // ============================================================================
 
-export function registerGeminiRoutes(app: OpenAPIHono) {
+export interface GeminiRoutesOptions {
+  heartbeatIntervalMs?: number;
+  requestTimeoutMs?: number;
+  resolveChatModelClient?: typeof getChatModelClient;
+}
+
+export function registerGeminiRoutes(
+  app: OpenAPIHono,
+  options: GeminiRoutesOptions = {},
+) {
+  const resolveChatModelClient =
+    options.resolveChatModelClient ?? getChatModelClient;
+
   // POST /v1beta/models/{model}:generateContent
   app.openapi(generateContentRoute, async (c: Context) => {
     let rawRequestBody: GenerateContentRequest | undefined;
@@ -321,7 +340,8 @@ export function registerGeminiRoutes(app: OpenAPIHono) {
       rawRequestBody = requestBody;
 
       // 1. Get chat model client
-      const { client, error: clientError } = await getChatModelClient(modelId);
+      const { client, error: clientError } =
+        await resolveChatModelClient(modelId);
 
       if (clientError) {
         return c.json(
@@ -450,7 +470,7 @@ export function registerGeminiRoutes(app: OpenAPIHono) {
       let lmChatMessages: vscode.LanguageModelChatMessage[] | undefined;
       let modelId = "";
       let inputTokens = 0;
-      let cancellationTokenSource: vscode.CancellationTokenSource | undefined;
+      let requestLifecycle: LanguageModelRequestLifecycle | undefined;
 
       try {
         // Parse request
@@ -461,7 +481,7 @@ export function registerGeminiRoutes(app: OpenAPIHono) {
 
         // 1. Get chat model client
         const { client, error: clientError } =
-          await getChatModelClient(modelId);
+          await resolveChatModelClient(modelId);
 
         if (clientError) {
           return c.json(
@@ -477,7 +497,10 @@ export function registerGeminiRoutes(app: OpenAPIHono) {
         }
 
         // 2. Prepare request
-        cancellationTokenSource = new vscode.CancellationTokenSource();
+        requestLifecycle = new LanguageModelRequestLifecycle(
+          c.req.raw.signal,
+          options.requestTimeoutMs,
+        );
         const { vsCodeLmMessages, lmRequestOptions } = prepareGeminiRequest({
           requestBody,
         });
@@ -491,11 +514,13 @@ export function registerGeminiRoutes(app: OpenAPIHono) {
 
         // 3. Send request to VSCode LM API
         // No Gemini request field is currently mapped to Copilot reasoning effort.
-        const cancellationToken = cancellationTokenSource.token;
-        const response = await client.sendRequest(
-          vsCodeLmMessages,
-          withCopilotConfiguration(client, lmRequestOptions),
-          cancellationToken,
+        const cancellationToken = requestLifecycle.token;
+        const response = await requestLifecycle.waitFor(
+          client.sendRequest(
+            vsCodeLmMessages,
+            withCopilotConfiguration(client, lmRequestOptions),
+            cancellationToken,
+          ),
         );
 
         // 4. Always stream the response
@@ -505,7 +530,20 @@ export function registerGeminiRoutes(app: OpenAPIHono) {
             let accumulatedText = "";
             let responseUsage: GeminiTokenUsage | undefined;
 
-            for await (const chunk of response.stream) {
+            for await (const chunk of withSseHeartbeat(
+              interruptibleLanguageModelStream(
+                response.stream,
+                requestLifecycle!,
+              ),
+              options.heartbeatIntervalMs,
+            )) {
+              if (chunk === SSE_HEARTBEAT) {
+                await requestLifecycle!.waitFor(
+                  stream.write(": keep-alive\n\n"),
+                );
+                continue;
+              }
+
               if (chunk instanceof vscode.LanguageModelTextPart) {
                 const text = chunk.value;
                 accumulatedText += text;
@@ -523,9 +561,11 @@ export function registerGeminiRoutes(app: OpenAPIHono) {
                   ],
                 };
 
-                await stream.writeSSE({
-                  data: JSON.stringify(streamChunk),
-                });
+                await requestLifecycle!.waitFor(
+                  stream.writeSSE({
+                    data: JSON.stringify(streamChunk),
+                  }),
+                );
               } else if (chunk instanceof vscode.LanguageModelToolCallPart) {
                 const functionCallPart: Part = {
                   functionCall: {
@@ -549,9 +589,11 @@ export function registerGeminiRoutes(app: OpenAPIHono) {
                   ],
                 };
 
-                await stream.writeSSE({
-                  data: JSON.stringify(streamChunk),
-                });
+                await requestLifecycle!.waitFor(
+                  stream.writeSSE({
+                    data: JSON.stringify(streamChunk),
+                  }),
+                );
               } else if (chunk instanceof vscode.LanguageModelDataPart) {
                 responseUsage = extractGeminiUsage(chunk) ?? responseUsage;
               }
@@ -560,12 +602,14 @@ export function registerGeminiRoutes(app: OpenAPIHono) {
             // Send final chunk with usage metadata
             const usageMetadata =
               responseUsage ??
-              (await getFallbackGeminiUsage({
-                accumulatedText,
-                cancellationToken,
-                client,
-                requestBody,
-              }));
+              (await requestLifecycle!.waitFor(
+                getFallbackGeminiUsage({
+                  accumulatedText,
+                  cancellationToken,
+                  client,
+                  requestBody,
+                }),
+              ));
             inputTokens = usageMetadata.promptTokenCount;
 
             const finalChunk: GenerateContentResponse = {
@@ -579,21 +623,31 @@ export function registerGeminiRoutes(app: OpenAPIHono) {
               modelVersion: modelId,
             };
 
-            await stream.writeSSE({
-              data: JSON.stringify(finalChunk),
-            });
+            await requestLifecycle!.waitFor(
+              stream.writeSSE({
+                data: JSON.stringify(finalChunk),
+              }),
+            );
 
             logger.info(
               `← /v1beta/models/${modelWithMethod} (stream) | input: ${usageMetadata.promptTokenCount} | cache_read: ${usageMetadata.cachedContentTokenCount} | output: ${usageMetadata.candidatesTokenCount} | thoughts: ${usageMetadata.thoughtsTokenCount}`,
             );
-            cancellationTokenSource?.dispose();
+            requestLifecycle?.dispose();
           },
           async (error, stream) => {
+            if (error instanceof LanguageModelClientDisconnectedError) {
+              logger.info(
+                `/v1beta/models/${modelWithMethod} | client disconnected`,
+              );
+              requestLifecycle?.dispose();
+              await stream.close();
+              return;
+            }
+
             logger.error(
               `✕ /v1beta/models/${modelWithMethod} (stream) |`,
               error,
             );
-            cancellationTokenSource?.dispose();
 
             // Send final chunk with error finish reason
             const errorChunk: GenerateContentResponse = {
@@ -620,13 +674,43 @@ export function registerGeminiRoutes(app: OpenAPIHono) {
               modelVersion: modelId,
             };
 
-            await stream.writeSSE({
-              data: JSON.stringify(errorChunk),
-            });
+            try {
+              await stream.writeSSE({
+                data: JSON.stringify(errorChunk),
+              });
+            } finally {
+              requestLifecycle?.dispose();
+              await stream.close();
+            }
           },
         );
       } catch (error) {
-        cancellationTokenSource?.dispose();
+        requestLifecycle?.dispose();
+
+        if (error instanceof LanguageModelRequestTimeoutError) {
+          logger.error(
+            `✕ /v1beta/models/${modelId}:streamGenerateContent |`,
+            error,
+          );
+          return c.json(
+            {
+              error: {
+                code: 504,
+                message: error.message,
+                status: "DEADLINE_EXCEEDED",
+              },
+            },
+            504,
+          );
+        }
+
+        if (error instanceof LanguageModelClientDisconnectedError) {
+          logger.info(
+            `/v1beta/models/${modelId}:streamGenerateContent | client disconnected`,
+          );
+          return new Response(null, { status: 499 });
+        }
+
         logger.error(
           `✕ /v1beta/models/${modelId}:streamGenerateContent |`,
           error,
@@ -670,7 +754,8 @@ export function registerGeminiRoutes(app: OpenAPIHono) {
       const requestBody = await c.req.json();
 
       // 1. Get chat model client
-      const { client, error: clientError } = await getChatModelClient(modelId);
+      const { client, error: clientError } =
+        await resolveChatModelClient(modelId);
 
       if (clientError) {
         return c.json(

--- a/src/server/routes/openai/openaiChatRoutes.ts
+++ b/src/server/routes/openai/openaiChatRoutes.ts
@@ -23,6 +23,7 @@ import {
   convertOpenAIChatCompletionToolToVSCode,
   convertOpenAIMessagesToVSCode,
 } from "../../utils/openaiChat";
+import { SSE_HEARTBEAT, withSseHeartbeat } from "../../utils/sseHeartbeat";
 
 // OpenAPI route definition for /v1/chat/completions
 const chatCompletionsRoute = createRoute({
@@ -106,6 +107,7 @@ const chatCompletionsRoute = createRoute({
 });
 
 export interface OpenaiChatRoutesOptions {
+  heartbeatIntervalMs?: number;
   requestTimeoutMs?: number;
   resolveChatModelClient?: typeof getChatModelClient;
 }
@@ -314,10 +316,18 @@ export function registerOpenaiChatRoutes(
           let accumulatedText = "";
           let toolCalls: vscode.LanguageModelToolCallPart[] = [];
           let completionUsage: OpenAI.CompletionUsage | undefined;
-          for await (const chunk of interruptibleLanguageModelStream(
-            response.stream,
-            requestLifecycle!,
+          for await (const chunk of withSseHeartbeat(
+            interruptibleLanguageModelStream(
+              response.stream,
+              requestLifecycle!,
+            ),
+            options.heartbeatIntervalMs,
           )) {
+            if (chunk === SSE_HEARTBEAT) {
+              await requestLifecycle!.waitFor(stream.write(": keep-alive\n\n"));
+              continue;
+            }
+
             if (chunk instanceof vscode.LanguageModelTextPart) {
               const contentChunk: OpenAI.ChatCompletionChunk = {
                 id: chatCompletionId,

--- a/src/server/routes/openai/openaiResponsesRoutes.ts
+++ b/src/server/routes/openai/openaiResponsesRoutes.ts
@@ -45,6 +45,7 @@ import {
   getResponsesWebSearchTool,
   narrowToolsForChoice,
 } from "../../utils/openaiResponses";
+import { SSE_HEARTBEAT, withSseHeartbeat } from "../../utils/sseHeartbeat";
 
 type NonStreamingResponse = Omit<
   OpenAI.Responses.Response,
@@ -142,6 +143,7 @@ Limitations:
 });
 
 export interface OpenaiResponsesRoutesOptions {
+  heartbeatIntervalMs?: number;
   requestTimeoutMs?: number;
   resolveChatModelClient?: typeof getChatModelClient;
 }
@@ -535,10 +537,20 @@ export function registerOpenaiResponsesRoutes(
           let totalOutputText = ""; // Track all output for token counting
           let responseUsage: ResponseUsage | undefined;
 
-          for await (const chunk of interruptibleLanguageModelStream(
-            response.stream,
-            requestLifecycle!,
+          for await (const chunk of withSseHeartbeat(
+            interruptibleLanguageModelStream(
+              response.stream,
+              requestLifecycle!,
+            ),
+            options.heartbeatIntervalMs,
           )) {
+            if (chunk === SSE_HEARTBEAT) {
+              await requestLifecycle!.waitFor(
+                sseStream.write(": keep-alive\n\n"),
+              );
+              continue;
+            }
+
             if (chunk instanceof vscode.LanguageModelTextPart) {
               if (!currentMessageId) {
                 // Start new message output item

--- a/src/server/utils/sseHeartbeat.ts
+++ b/src/server/utils/sseHeartbeat.ts
@@ -1,0 +1,62 @@
+export const SSE_HEARTBEAT_INTERVAL_MS = 10_000;
+export const SSE_HEARTBEAT = Symbol("sse-heartbeat");
+
+type NextOutcome<T> = {
+  kind: "next";
+  result: IteratorResult<T>;
+};
+
+type HeartbeatOutcome = {
+  kind: "heartbeat";
+};
+
+export async function* withSseHeartbeat<T>(
+  stream: AsyncIterable<T>,
+  intervalMs: number = SSE_HEARTBEAT_INTERVAL_MS,
+): AsyncGenerator<T | typeof SSE_HEARTBEAT> {
+  if (!Number.isFinite(intervalMs) || intervalMs <= 0) {
+    throw new RangeError("SSE heartbeat interval must be greater than zero");
+  }
+
+  const iterator = stream[Symbol.asyncIterator]();
+  let completed = false;
+  let pendingNext: Promise<NextOutcome<T>> = iterator
+    .next()
+    .then((result) => ({ kind: "next", result }));
+
+  try {
+    while (true) {
+      let timeout: NodeJS.Timeout | undefined;
+      const heartbeat = new Promise<HeartbeatOutcome>((resolve) => {
+        timeout = setTimeout(() => resolve({ kind: "heartbeat" }), intervalMs);
+        timeout.unref();
+      });
+
+      let outcome: NextOutcome<T> | HeartbeatOutcome;
+      try {
+        outcome = await Promise.race([pendingNext, heartbeat]);
+      } finally {
+        clearTimeout(timeout);
+      }
+
+      if (outcome.kind === "heartbeat") {
+        yield SSE_HEARTBEAT;
+        continue;
+      }
+
+      if (outcome.result.done) {
+        completed = true;
+        return;
+      }
+
+      yield outcome.result.value;
+      pendingNext = iterator
+        .next()
+        .then((result) => ({ kind: "next", result }));
+    }
+  } finally {
+    if (!completed) {
+      await iterator.return?.();
+    }
+  }
+}

--- a/src/test/server/sseHeartbeat.test.ts
+++ b/src/test/server/sseHeartbeat.test.ts
@@ -1,0 +1,287 @@
+import { OpenAPIHono } from "@hono/zod-openapi";
+import * as assert from "assert";
+import * as vscode from "vscode";
+
+import { registerAnthropicRoutes } from "../../server/routes/anthropicRoutes";
+import { registerGeminiRoutes } from "../../server/routes/geminiRoutes";
+import { registerOpenaiChatRoutes } from "../../server/routes/openai/openaiChatRoutes";
+import { registerOpenaiResponsesRoutes } from "../../server/routes/openai/openaiResponsesRoutes";
+import {
+  SSE_HEARTBEAT,
+  withSseHeartbeat,
+} from "../../server/utils/sseHeartbeat";
+
+suite("SSE Heartbeat Test Suite", () => {
+  const heartbeatIntervalMs = 5;
+
+  const createDelayedModel = (): vscode.LanguageModelChat =>
+    ({
+      id: "claude-opus-test",
+      name: "Claude Opus Test",
+      family: "claude",
+      version: "test",
+      vendor: "copilot",
+      maxInputTokens: 200000,
+      capabilities: {
+        supportsImageToText: false,
+        supportsToolCalling: true,
+      },
+      sendRequest: async () => ({
+        stream: (async function* () {
+          await new Promise((resolve) => setTimeout(resolve, 25));
+          yield new vscode.LanguageModelTextPart("Hello");
+        })(),
+        text: (async function* () {
+          yield "Hello";
+        })(),
+      }),
+      countTokens: async () => 1,
+    }) as vscode.LanguageModelChat;
+
+  const createStalledModel = (
+    onCancellation: () => void,
+  ): vscode.LanguageModelChat =>
+    ({
+      id: "claude-opus-test",
+      name: "Claude Opus Test",
+      family: "claude",
+      version: "test",
+      vendor: "copilot",
+      maxInputTokens: 200000,
+      capabilities: {
+        supportsImageToText: false,
+        supportsToolCalling: true,
+      },
+      sendRequest: async (_messages, _options, token) => {
+        token?.onCancellationRequested(onCancellation);
+        return {
+          stream: {
+            [Symbol.asyncIterator]() {
+              return {
+                next: () =>
+                  new Promise<
+                    IteratorResult<
+                      | vscode.LanguageModelTextPart
+                      | vscode.LanguageModelToolCallPart
+                      | vscode.LanguageModelDataPart
+                    >
+                  >(() => {}),
+              };
+            },
+          },
+          text: (async function* () {})(),
+        };
+      },
+      countTokens: async () => 1,
+    }) as vscode.LanguageModelChat;
+
+  test("emits repeated heartbeats without requesting concurrent chunks", async () => {
+    let nextCalls = 0;
+    let returnCalls = 0;
+    const stalledStream: AsyncIterable<string> = {
+      [Symbol.asyncIterator]() {
+        return {
+          next: () => {
+            nextCalls++;
+            return new Promise<IteratorResult<string>>(() => {});
+          },
+          return: async () => {
+            returnCalls++;
+            return { done: true, value: undefined };
+          },
+        };
+      },
+    };
+    const iterator = withSseHeartbeat(stalledStream, heartbeatIntervalMs);
+
+    assert.strictEqual((await iterator.next()).value, SSE_HEARTBEAT);
+    assert.strictEqual((await iterator.next()).value, SSE_HEARTBEAT);
+    assert.strictEqual(nextCalls, 1);
+
+    await iterator.return(undefined);
+    assert.strictEqual(returnCalls, 1);
+  });
+
+  test("passes through immediately available chunks in order", async () => {
+    const values: Array<string | typeof SSE_HEARTBEAT> = [];
+
+    for await (const value of withSseHeartbeat(
+      (async function* () {
+        yield "first";
+        yield "second";
+      })(),
+      heartbeatIntervalMs,
+    )) {
+      values.push(value);
+    }
+
+    assert.deepStrictEqual(values, ["first", "second"]);
+  });
+
+  test("writes Anthropic ping events while the model stream is idle", async () => {
+    const app = new OpenAPIHono();
+    registerAnthropicRoutes(app, {
+      heartbeatIntervalMs,
+      requestTimeoutMs: 1000,
+      resolveChatModelClient: async () => ({
+        client: createDelayedModel(),
+      }),
+    });
+
+    const response = await app.request("/v1/messages", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "claude-opus-test",
+        max_tokens: 100,
+        stream: true,
+        messages: [{ role: "user", content: "Hello" }],
+      }),
+    });
+    const body = await response.text();
+
+    assert.match(body, /event: ping\ndata: \{"type":"ping"\}\n\n/);
+    assert.ok(body.includes("event: message_stop"));
+  });
+
+  test("writes SSE comments for OpenAI Chat Completions", async () => {
+    const app = new OpenAPIHono();
+    registerOpenaiChatRoutes(app, {
+      heartbeatIntervalMs,
+      requestTimeoutMs: 1000,
+      resolveChatModelClient: async () => ({
+        client: createDelayedModel(),
+      }),
+    });
+
+    const response = await app.request("/v1/chat/completions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "claude-opus-test",
+        stream: true,
+        messages: [{ role: "user", content: "Hello" }],
+      }),
+    });
+    const body = await response.text();
+
+    assert.ok(body.includes(": keep-alive\n\n"));
+    assert.ok(body.includes("data: [DONE]"));
+  });
+
+  test("writes SSE comments for OpenAI Responses", async () => {
+    const app = new OpenAPIHono();
+    registerOpenaiResponsesRoutes(app, {
+      heartbeatIntervalMs,
+      requestTimeoutMs: 1000,
+      resolveChatModelClient: async () => ({
+        client: createDelayedModel(),
+      }),
+    });
+
+    const response = await app.request("/v1/responses", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "claude-opus-test",
+        input: "Hello",
+        stream: true,
+      }),
+    });
+    const body = await response.text();
+
+    assert.ok(body.includes(": keep-alive\n\n"));
+    assert.ok(body.includes("event: response.completed"));
+  });
+
+  test("writes SSE comments for Gemini streamGenerateContent", async () => {
+    const app = new OpenAPIHono();
+    registerGeminiRoutes(app, {
+      heartbeatIntervalMs,
+      resolveChatModelClient: async () => ({
+        client: createDelayedModel(),
+      }),
+    });
+
+    const response = await app.request(
+      "/v1beta/models/claude-opus-test:streamGenerateContent",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          contents: [{ role: "user", parts: [{ text: "Hello" }] }],
+        }),
+      },
+    );
+    const body = await response.text();
+
+    assert.ok(body.includes(": keep-alive\n\n"));
+    assert.ok(body.includes('"finishReason":"STOP"'));
+  });
+
+  test("cancels a stalled Gemini stream when its total timeout expires", async () => {
+    let cancellationObserved = false;
+    const app = new OpenAPIHono();
+    registerGeminiRoutes(app, {
+      heartbeatIntervalMs,
+      requestTimeoutMs: 25,
+      resolveChatModelClient: async () => ({
+        client: createStalledModel(() => {
+          cancellationObserved = true;
+        }),
+      }),
+    });
+
+    const response = await app.request(
+      "/v1beta/models/claude-opus-test:streamGenerateContent",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          contents: [{ role: "user", parts: [{ text: "Hello" }] }],
+        }),
+      },
+    );
+    const body = await response.text();
+
+    assert.strictEqual(response.status, 200);
+    assert.ok(body.includes('"finishReason":"OTHER"'));
+    assert.ok(body.includes("timed out after 25ms"));
+    assert.strictEqual(cancellationObserved, true);
+  });
+
+  test("cancels a stalled Gemini stream when the client disconnects", async () => {
+    let resolveCancellation: (() => void) | undefined;
+    const cancellationObserved = new Promise<void>((resolve) => {
+      resolveCancellation = resolve;
+    });
+    const app = new OpenAPIHono();
+    registerGeminiRoutes(app, {
+      heartbeatIntervalMs,
+      requestTimeoutMs: 1000,
+      resolveChatModelClient: async () => ({
+        client: createStalledModel(() => resolveCancellation?.()),
+      }),
+    });
+    const clientAbortController = new AbortController();
+
+    const response = await app.request(
+      "/v1beta/models/claude-opus-test:streamGenerateContent",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          contents: [{ role: "user", parts: [{ text: "Hello" }] }],
+        }),
+        signal: clientAbortController.signal,
+      },
+    );
+    const reader = response.body!.getReader();
+    await reader.read();
+    clientAbortController.abort();
+
+    await cancellationObserved;
+    const result = await reader.read();
+    assert.strictEqual(result.done, true);
+  });
+});


### PR DESCRIPTION
## Summary

- send reusable idle heartbeats while Anthropic, OpenAI, and Gemini streams wait for VS Code LM output
- use Anthropic `ping` events and SSE comments for OpenAI/Gemini compatibility
- cancel Gemini upstream work on client disconnect or total request timeout
- document the design and add a patch changeset

## Test plan

- [x] `pnpm check-types`
- [x] `pnpm lint`
- [x] `pnpm exec vscode-test --code-version 1.120.0`

Changeset: `.changeset/quiet-dodos-smile.md`

Closes #227