### PR TITLE
feat(models): add configurable fallback model

### DIFF
--- a/.changeset/configurable-model-fallback.md
+++ b/.changeset/configurable-model-fallback.md
@@ -1,0 +1,5 @@
+---
+"agent-maestro": minor
+---
+
+Add a global fallback model setting and selection command for requests whose model ID cannot be matched to an available VS Code language model.

--- a/.changeset/configurable-model-fallback.md
+++ b/.changeset/configurable-model-fallback.md
@@ -1,5 +1,0 @@
----
-"agent-maestro": minor
----
-
-Add a global fallback model setting and selection command for requests whose model ID cannot be matched to an available VS Code language model.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.12.0 - 2026.08.20
+
+- Add a global fallback model setting and selection command for requests whose model ID cannot be matched to an available VS Code language model.
+
 ## v2.11.2 - 2026.08.20
 
 - Preserve images nested in OpenAI Responses tool outputs as VS Code language model data parts instead of serializing their base64 payloads as text.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v2.12.0 - 2026.08.20
 
-- Add a global fallback model setting and selection command for requests whose model ID cannot be matched to an available VS Code language model.
+- Add the global `agent-maestro.fallbackModelId` setting and `Agent Maestro: Select Fallback Model` command for requests whose model ID cannot be matched to an available VS Code language model.
 
 ## v2.11.2 - 2026.08.20
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ Additionally, it creates or updates `settings.json` in the same folder to skip t
 }
 ```
 
+### Fallback Model
+
+Run `Agent Maestro: Select Fallback Model` to choose which available VS Code language model Agent Maestro should use when a client requests an unknown model ID. Exact and fuzzy model matches still take priority. Select the `auto` model to retain VS Code's automatic model selection.
+
 ### Usage
 
 1. **Explore API Capabilities**: Access the complete OpenAPI specification at [`http://localhost:23333/openapi.json`](http://localhost:23333/openapi.json).
@@ -117,6 +121,7 @@ Additionally, it creates or updates `settings.json` in the same folder to skip t
    - `Agent Maestro: Configure Claude Desktop Settings` - One-click Claude Desktop setup
    - `Agent Maestro: Configure Codex Settings` - One-click Codex setup
    - `Agent Maestro: Configure Gemini CLI Settings` - One-click Gemini CLI setup
+   - `Agent Maestro: Select Fallback Model` - Select a global fallback for unknown model IDs
    - `Agent Maestro: Set LLM API Key` - Configure authentication for LLM API endpoints
 
 3. **Development Resources**:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -19,7 +19,7 @@ pnpm run watch-tests
 
 | Test File                                      | Tests | What It Covers                                            |
 | ---------------------------------------------- | ----- | --------------------------------------------------------- |
-| `extension.test.ts`                            | 11    | Extension activation, command registration, configuration |
+| `extension.test.ts`                            | 12    | Extension activation, command registration, configuration |
 | `utils/config.test.ts`                         | 5     | Configuration defaults and reading                        |
 | `utils/mimeTypes.test.ts`                      | 12    | MIME type detection for file extensions                   |
 | `utils/rooSettingsFilter.test.ts`              | 5     | API key filtering from settings                           |
@@ -29,7 +29,7 @@ pnpm run watch-tests
 | `schemas/common.test.ts`                       | 7     | Common schemas (file ops, extension info, OS info)        |
 | `server/anthropic.test.ts`                     | 23    | Anthropic → VS Code message conversion                    |
 | `server/languageModelRequestLifecycle.test.ts` | 14    | LM request timeout and disconnect cancellation            |
-| `server/modelResolution.test.ts`               | 16    | Model matching and Copilot model configuration            |
+| `server/modelResolution.test.ts`               | 17    | Model matching and Copilot model configuration            |
 | `server/openaiChat.test.ts`                    | 15    | OpenAI → VS Code message conversion                       |
 | `server/openaiResponses.test.ts`               | 52    | OpenAI Responses → VS Code conversion                     |
 | `server/gemini.test.ts`                        | 27    | Gemini → VS Code message conversion                       |

--- a/package.json
+++ b/package.json
@@ -84,6 +84,12 @@
           "default": false,
           "description": "Allow the extension to access files outside of the current workspace",
           "scope": "application"
+        },
+        "agent-maestro.fallbackModelId": {
+          "type": "string",
+          "default": "",
+          "description": "Model ID to use when a requested model is unavailable after exact and fuzzy matching. Leave empty to use VS Code's automatic model fallback.",
+          "scope": "application"
         }
       }
     },
@@ -151,6 +157,11 @@
       {
         "command": "agent-maestro.configureGeminiCli",
         "title": "Configure Gemini CLI Settings",
+        "category": "Agent Maestro"
+      },
+      {
+        "command": "agent-maestro.selectFallbackModel",
+        "title": "Select Fallback Model",
         "category": "Agent Maestro"
       },
       {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "agent-maestro",
   "displayName": "Agent Maestro",
   "description": "Turn VS Code into your compliant AI playground! With Agent Maestro, spin up Cline or Roo on demand and plug Claude Code or Codex straight in through an OpenAI/Anthropic-compatible API.",
-  "version": "2.11.2",
+  "version": "2.12.0",
   "icon": "assets/icons/icon.png",
   "publisher": "Joouis",
   "repository": "https://github.com/Joouis/agent-maestro",

--- a/src/commands/configuratorCommands.ts
+++ b/src/commands/configuratorCommands.ts
@@ -113,7 +113,7 @@ export function registerConfiguratorCommands(
 
         if (modelOptions.length === 0) {
           vscode.window.showErrorMessage(
-            "No available chat model provided by VS Code LM API.",
+            "No chat models are currently available from the VS Code Language Model API.",
           );
           return;
         }
@@ -336,7 +336,7 @@ export function registerConfiguratorCommands(
 
         if (modelOptions.length === 0) {
           vscode.window.showErrorMessage(
-            "No available chat model provided by VS Code LM API.",
+            "No chat models are currently available from the VS Code Language Model API.",
           );
           return;
         }
@@ -494,7 +494,7 @@ export function registerConfiguratorCommands(
 
         if (modelOptions.length === 0) {
           vscode.window.showErrorMessage(
-            "No available chat model provided by VS Code LM API.",
+            "No chat models are currently available from the VS Code Language Model API.",
           );
           return;
         }

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -6,6 +6,7 @@ import { ProxyServer } from "../server/ProxyServer";
 import { registerConfiguratorCommands } from "./configuratorCommands";
 import { registerLlmApiKeyCommands } from "./llmApiKeyCommands";
 import { registerMcpCommands } from "./mcpCommands";
+import { registerModelCommands } from "./modelCommands";
 import { registerProxyCommands } from "./proxyCommands";
 import { registerStatusCommands } from "./statusCommands";
 
@@ -18,6 +19,7 @@ export function registerAllCommands(
   registerProxyCommands(proxy, context);
   registerMcpCommands(mcpServer, context);
   registerConfiguratorCommands(proxy, context);
+  registerModelCommands(context);
   registerStatusCommands(controller, context);
   registerLlmApiKeyCommands(proxy, context);
 }

--- a/src/commands/modelCommands.ts
+++ b/src/commands/modelCommands.ts
@@ -1,0 +1,49 @@
+import * as vscode from "vscode";
+
+import { getChatModelsQuickPickItems } from "../utils/chatModels";
+import { DEFAULT_CONFIG } from "../utils/config";
+import { createCommandHandler } from "./commandHandler";
+
+export function registerModelCommands(context: vscode.ExtensionContext) {
+  const disposable = vscode.commands.registerCommand(
+    "agent-maestro.selectFallbackModel",
+    createCommandHandler(async () => {
+      const configuration = vscode.workspace.getConfiguration("agent-maestro");
+      const currentModelId = configuration
+        .get<string>("fallbackModelId", DEFAULT_CONFIG.fallbackModelId)
+        .trim();
+      const modelOptions = await getChatModelsQuickPickItems();
+      if (modelOptions.length === 0) {
+        vscode.window.showErrorMessage(
+          "No available chat model provided by VS Code LM API.",
+        );
+        return;
+      }
+      const selectedModel = await vscode.window.showQuickPick(modelOptions, {
+        title: "Select Fallback Model",
+        placeHolder: currentModelId
+          ? `Current fallback: ${currentModelId}`
+          : "Choose a fallback model for unknown model IDs",
+      });
+
+      if (
+        !selectedModel ||
+        ("kind" in selectedModel &&
+          selectedModel.kind === vscode.QuickPickItemKind.Separator)
+      ) {
+        return;
+      }
+
+      await configuration.update(
+        "fallbackModelId",
+        selectedModel.modelId,
+        vscode.ConfigurationTarget.Global,
+      );
+      vscode.window.showInformationMessage(
+        `Fallback model set to ${selectedModel.modelId}.`,
+      );
+    }, "Failed to select fallback model"),
+  );
+
+  context.subscriptions.push(disposable);
+}

--- a/src/commands/modelCommands.ts
+++ b/src/commands/modelCommands.ts
@@ -15,7 +15,7 @@ export function registerModelCommands(context: vscode.ExtensionContext) {
       const modelOptions = await getChatModelsQuickPickItems();
       if (modelOptions.length === 0) {
         vscode.window.showErrorMessage(
-          "No available chat model provided by VS Code LM API.",
+          "No chat models are currently available from the VS Code Language Model API.",
         );
         return;
       }

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -73,6 +73,7 @@ suite("Extension Test Suite", () => {
         "agent-maestro.configureClaudeDesktop",
         "agent-maestro.configureCodex",
         "agent-maestro.configureGeminiCli",
+        "agent-maestro.selectFallbackModel",
       ];
 
       for (const cmd of configuratorCommands) {
@@ -139,6 +140,13 @@ suite("Extension Test Suite", () => {
         typeof identifier === "string" && identifier.length > 0,
         "defaultRooIdentifier should be a non-empty string",
       );
+    });
+
+    test("fallbackModelId should be a string", () => {
+      const config = vscode.workspace.getConfiguration("agent-maestro");
+      const fallbackModelId = config.get<string>("fallbackModelId");
+
+      assert.strictEqual(typeof fallbackModelId, "string");
     });
   });
 });

--- a/src/test/server/modelResolution.test.ts
+++ b/src/test/server/modelResolution.test.ts
@@ -3,6 +3,8 @@ import * as vscode from "vscode";
 
 import {
   type CopilotModelConfiguration,
+  chatModelsCache,
+  getChatModelClient,
   getCopilotModelConfiguration,
   jaccardSimilarity,
   withCopilotConfiguration,
@@ -93,6 +95,72 @@ suite("Model Resolution Test Suite", () => {
       const oneM = jaccardSimilarity("claude-opus-4-6", "claude-opus-4.6-1m");
       assert.ok(base >= 0.3, `base (${base.toFixed(3)}) should be >= 0.3`);
       assert.ok(oneM >= 0.3, `1m (${oneM.toFixed(3)}) should be >= 0.3`);
+    });
+  });
+
+  suite("getChatModelClient fallback", () => {
+    test("uses configured, auto, then first-available fallback models", async () => {
+      const configured = createMockModel({
+        id: "gpt-5.6-sol",
+        version: "5.6",
+      });
+      const sameVersionAsAuto = createMockModel({
+        id: "another-model",
+        version: "auto-version",
+      });
+      const auto = createMockModel({ id: "auto", version: "auto-version" });
+      const configuration = vscode.workspace.getConfiguration("agent-maestro");
+      const previousFallbackModelId =
+        configuration.inspect<string>("fallbackModelId")?.globalValue;
+      const originalGetChatModels = chatModelsCache.getChatModels;
+
+      try {
+        chatModelsCache.getChatModels = async () => [
+          sameVersionAsAuto,
+          configured,
+          auto,
+        ];
+        await configuration.update(
+          "fallbackModelId",
+          configured.id,
+          vscode.ConfigurationTarget.Global,
+        );
+        assert.strictEqual(
+          (await getChatModelClient("codex-auto-review")).client,
+          configured,
+        );
+
+        await configuration.update(
+          "fallbackModelId",
+          "missing-model",
+          vscode.ConfigurationTarget.Global,
+        );
+        assert.strictEqual(
+          (await getChatModelClient("codex-auto-review")).client,
+          auto,
+        );
+
+        await configuration.update(
+          "fallbackModelId",
+          undefined,
+          vscode.ConfigurationTarget.Global,
+        );
+        chatModelsCache.getChatModels = async () => [
+          sameVersionAsAuto,
+          configured,
+        ];
+        assert.strictEqual(
+          (await getChatModelClient("codex-auto-review")).client,
+          sameVersionAsAuto,
+        );
+      } finally {
+        chatModelsCache.getChatModels = originalGetChatModels;
+        await configuration.update(
+          "fallbackModelId",
+          previousFallbackModelId,
+          vscode.ConfigurationTarget.Global,
+        );
+      }
     });
   });
 

--- a/src/test/utils/config.test.ts
+++ b/src/test/utils/config.test.ts
@@ -20,6 +20,7 @@ suite("Config Test Suite", () => {
       assert.strictEqual(DEFAULT_CONFIG.proxyServerPort, 23333);
       assert.strictEqual(DEFAULT_CONFIG.mcpServerPort, 23334);
       assert.strictEqual(DEFAULT_CONFIG.allowOutsideWorkspaceAccess, false);
+      assert.strictEqual(DEFAULT_CONFIG.fallbackModelId, "");
     });
   });
 
@@ -44,6 +45,10 @@ suite("Config Test Suite", () => {
       assert.strictEqual(
         CONFIG_KEYS.ALLOW_OUTSIDE_WORKSPACE_ACCESS,
         "agent-maestro.allowOutsideWorkspaceAccess",
+      );
+      assert.strictEqual(
+        CONFIG_KEYS.FALLBACK_MODEL_ID,
+        "agent-maestro.fallbackModelId",
       );
     });
   });
@@ -72,6 +77,10 @@ suite("Config Test Suite", () => {
       assert.ok(
         typeof config.allowOutsideWorkspaceAccess === "boolean",
         "allowOutsideWorkspaceAccess should be a boolean",
+      );
+      assert.ok(
+        typeof config.fallbackModelId === "string",
+        "fallbackModelId should be a string",
       );
     });
 

--- a/src/utils/chatModels.ts
+++ b/src/utils/chatModels.ts
@@ -1,8 +1,10 @@
 import * as vscode from "vscode";
 
+import { readConfiguration } from "./config";
 import { logger } from "./logger";
 
 const SUPPORTED_VENDOR = "copilot";
+const warnedUnavailableFallbackModelIds = new Set<string>();
 
 async function selectSupportedModels(): Promise<vscode.LanguageModelChat[]> {
   const allModels = await vscode.lm.selectChatModels();
@@ -351,7 +353,8 @@ function findBestMatch(
  * This function handles:
  * 1. Exact match lookup
  * 2. Fuzzy matching using Jaccard similarity
- * 3. Fallback to "auto" or first available model
+ * 3. Configured fallback model
+ * 4. Fallback to "auto" or first available model
  *
  * Note: We don't refresh the cache if a model isn't found because vscode.lm.selectChatModels()
  * doesn't update dynamically when network state changes - the VS Code API returns the same
@@ -360,24 +363,38 @@ function findBestMatch(
 export const getChatModelClient = async (modelId: string) => {
   const models = await chatModelsCache.getChatModels();
 
-  // 1. Try exact match
-  let client = models.find((m) => m.id === modelId);
+  let client = models.find((model) => model.id === modelId);
   if (client) {
     return { client };
   }
 
-  // 2. Try fuzzy matching with Jaccard similarity
   const fuzzyMatch = findBestMatch(modelId, models);
   if (fuzzyMatch) {
     return { client: fuzzyMatch };
   }
 
-  // 3. Fallback to "auto" or first model
-  const autoModel = models.find((m) => m.id === "auto");
-  client = models.find((m) => m.version === autoModel?.version);
-  if (client) {
-    logger.info(`Model "${modelId}" not found, using ${client.id} model`);
-    return { client };
+  const fallbackModelId = readConfiguration().fallbackModelId.trim();
+  if (fallbackModelId) {
+    client = models.find((model) => model.id === fallbackModelId);
+    if (client) {
+      warnedUnavailableFallbackModelIds.delete(fallbackModelId);
+      logger.info(
+        `Model "${modelId}" not found, using configured fallback model: ${client.id}`,
+      );
+      return { client };
+    }
+    if (!warnedUnavailableFallbackModelIds.has(fallbackModelId)) {
+      warnedUnavailableFallbackModelIds.add(fallbackModelId);
+      logger.warn(
+        `Configured fallback model "${fallbackModelId}" is unavailable; continuing with automatic fallback`,
+      );
+    }
+  }
+
+  const autoModel = models.find((model) => model.id === "auto");
+  if (autoModel) {
+    logger.info(`Model "${modelId}" not found, using auto model`);
+    return { client: autoModel };
   }
 
   if (models.length > 0) {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -6,6 +6,7 @@ export interface AgentMaestroConfiguration {
   proxyServerPort: number;
   mcpServerPort: number;
   allowOutsideWorkspaceAccess: boolean;
+  fallbackModelId: string;
 }
 
 /**
@@ -17,6 +18,7 @@ export const CONFIG_KEYS = {
   PROXY_SERVER_PORT: "agent-maestro.proxyServerPort",
   MCP_SERVER_PORT: "agent-maestro.mcpServerPort",
   ALLOW_OUTSIDE_WORKSPACE_ACCESS: "agent-maestro.allowOutsideWorkspaceAccess",
+  FALLBACK_MODEL_ID: "agent-maestro.fallbackModelId",
 } as const;
 
 /**
@@ -28,6 +30,7 @@ export const DEFAULT_CONFIG: AgentMaestroConfiguration = {
   proxyServerPort: 23333,
   mcpServerPort: 23334,
   allowOutsideWorkspaceAccess: false,
+  fallbackModelId: "",
 };
 
 /**
@@ -56,6 +59,10 @@ export const readConfiguration = (): AgentMaestroConfiguration => {
     allowOutsideWorkspaceAccess: config.get<boolean>(
       CONFIG_KEYS.ALLOW_OUTSIDE_WORKSPACE_ACCESS,
       DEFAULT_CONFIG.allowOutsideWorkspaceAccess,
+    ),
+    fallbackModelId: config.get<string>(
+      CONFIG_KEYS.FALLBACK_MODEL_ID,
+      DEFAULT_CONFIG.fallbackModelId,
     ),
   };
 };


### PR DESCRIPTION
## Summary

- Add a global `agent-maestro.fallbackModelId` setting for unknown client model IDs.
- Add `Agent Maestro: Select Fallback Model` to select from currently available Copilot chat models.
- Resolve models in this order: exact, fuzzy, configured fallback, `auto`, then first available.
- Warn once when a configured fallback is unavailable and continue with automatic fallback.

## Changeset

- `.changeset/configurable-model-fallback.md`

## Test plan

- [x] `pnpm check-types`
- [x] `pnpm lint`
- [x] Full VS Code test suite on VS Code 1.129.0 (`366 passing`)
- [x] Manual fallback-model selection