### PR TITLE
fix(openai): preserve Codex subagent tasks

### DIFF
--- a/.changeset/plaintext-codex-collaboration.md
+++ b/.changeset/plaintext-codex-collaboration.md
@@ -1,0 +1,5 @@
+---
+"agent-maestro": patch
+---
+
+Fix Codex Multi-Agent V2 subagents receiving empty tasks through the Responses API by using Codex's plaintext collaboration contract across the VS Code Language Model boundary.

--- a/docs/codex-multi-agent-e2e.md
+++ b/docs/codex-multi-agent-e2e.md
@@ -1,0 +1,149 @@
+# Codex Multi-Agent Responses E2E Runbook
+
+Use this procedure when changing Responses tool conversion, namespace handling,
+function-call streaming, or Codex collaboration compatibility. This is a manual
+smoke test rather than a regular CI test because it requires an authenticated
+Copilot session inside VS Code Insiders and consumes model quota.
+
+## Prerequisites
+
+- VS Code Insiders with GitHub Copilot signed in and the target model available.
+- A Codex CLI version that supports Multi-Agent V2 plaintext collaboration
+  messages (`encrypted_function_args: []`).
+- Free local ports for an isolated Agent Maestro instance. The examples use
+  `24333` and `24334` to avoid replacing a normal installation on the default
+  ports.
+
+## 1. Build and launch the extension
+
+From the repository root:
+
+```bash
+pnpm build
+
+AGENT_MAESTRO_PROXY_PORT=24333 \
+AGENT_MAESTRO_MCP_PORT=24334 \
+code-insiders \
+  --new-window \
+  --wait \
+  --extensionDevelopmentPath="$PWD" \
+  "$PWD"
+```
+
+Keep this process running. In another terminal, verify that the development
+extension is serving requests and that the intended model is available:
+
+```bash
+curl -fsS http://127.0.0.1:24333/api/v1/lm/chatModels |
+  jq '.[] | select(.id == "gpt-5.6-sol")'
+```
+
+## 2. Probe the Responses contract directly
+
+Send a forced collaboration tool call:
+
+```bash
+curl -fsS http://127.0.0.1:24333/api/openai/v1/responses \
+  -H 'content-type: application/json' \
+  -d '{
+    "model": "gpt-5.6-sol",
+    "input": "Call spawn_agent with task_name canary, fork_turns none, and message exactly PLAINTEXT_CANARY.",
+    "tools": [{
+      "type": "namespace",
+      "name": "collaboration",
+      "description": "Sub-agent tools",
+      "tools": [{
+        "type": "function",
+        "name": "spawn_agent",
+        "description": "Spawn an agent",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "task_name": { "type": "string" },
+            "fork_turns": { "type": "string" },
+            "message": { "type": "string", "encrypted": true }
+          },
+          "required": ["task_name", "message"],
+          "additionalProperties": false
+        }
+      }]
+    }],
+    "tool_choice": { "type": "function", "name": "spawn_agent" },
+    "stream": false
+  }' |
+  jq '.output'
+```
+
+The function-call output must contain plaintext arguments and the explicit
+Codex plaintext marker:
+
+```json
+{
+  "type": "function_call",
+  "name": "spawn_agent",
+  "namespace": "collaboration",
+  "arguments": "{\"task_name\":\"canary\",\"fork_turns\":\"none\",\"message\":\"PLAINTEXT_CANARY\"}",
+  "encrypted_function_args": []
+}
+```
+
+## 3. Run a real Codex V2 subagent
+
+Do not use `--ephemeral`; the rollout files are needed for verification.
+
+```bash
+codex exec \
+  --json \
+  --enable multi_agent_v2 \
+  -m gpt-5.6-sol \
+  -c 'model_provider="agent-maestro"' \
+  -c 'model_providers.agent-maestro.base_url="http://127.0.0.1:24333/api/openai/v1"' \
+  -C "$PWD" \
+  'Use spawn_agent exactly once with task_name plaintext_canary, fork_turns none, and message exactly: Reply exactly CHILD_PLAINTEXT_CANARY. Wait for that child to finish, then return its exact reply. Do not inspect or modify files.'
+```
+
+The command must finish with `CHILD_PLAINTEXT_CANARY`.
+
+## 4. Inspect the parent and child rollouts
+
+Locate the two new rollout files under the current date in
+`~/.codex/sessions/YYYY/MM/DD/`. The parent rollout must contain:
+
+```json
+{
+  "type": "function_call",
+  "name": "spawn_agent",
+  "namespace": "collaboration",
+  "arguments": "{\"fork_turns\":\"none\",\"message\":\"Reply exactly CHILD_PLAINTEXT_CANARY.\",\"task_name\":\"plaintext_canary\"}",
+  "encrypted_function_args": []
+}
+```
+
+The child rollout must contain a readable task:
+
+```json
+{
+  "type": "agent_message",
+  "author": "/root",
+  "recipient": "/root/plaintext_canary",
+  "content": [
+    {
+      "type": "input_text",
+      "text": "Message Type: NEW_TASK\nTask name: /root/plaintext_canary\nSender: /root\nPayload:\nReply exactly CHILD_PLAINTEXT_CANARY."
+    }
+  ]
+}
+```
+
+The validation fails if the child task contains an `encrypted_content` part, if
+the visible text stops after `Payload:`, or if the child reports that no task
+details were provided.
+
+## 5. Clean up
+
+Close only the Insiders window created for this validation and confirm that the
+isolated proxy port is no longer listening:
+
+```bash
+lsof -nP -iTCP:24333 -sTCP:LISTEN
+```

--- a/docs/openai-responses-api-design.md
+++ b/docs/openai-responses-api-design.md
@@ -108,6 +108,15 @@ Agent Maestro is stateless and doesn't persist responses between requests.
 | `namespace`        | Nested `function`/`custom` tools are flattened. Since VSCode LM's tool-call shape has no namespace slot, each nested tool is registered under an encoded name `<namespace>__<name>` and decoded back into a separate `namespace` + bare `name` on output via a mapping table. |
 | `additional_tools` | Developer-injected tools carried on input items; merged with request-level tools before dispatch.                                                                                                                                                                             |
 
+Codex Multi-Agent V2 marks the `message` parameter of
+`collaboration.spawn_agent`, `send_message`, and `followup_task` as encrypted.
+The stable VS Code Language Model API cannot preserve that provider-specific
+encrypted-argument contract. Agent Maestro therefore removes the `encrypted`
+marker for those parameters before model dispatch and adds
+`encrypted_function_args: []` to their returned function-call items. This tells
+Codex to deliver the generated message as plaintext instead of wrapping it in
+an `agent_message.encrypted_content` item.
+
 ### Unsupported Tools
 
 Other tool types are filtered out with a debug log.
@@ -132,6 +141,13 @@ Other tool types are filtered out with a debug log.
 | `input_file`    | Not supported, serialized as JSON text                            |
 | `annotations`   | Always empty (VSCode LM doesn't provide annotations)              |
 | Reasoning items | Never generated (VSCode LM doesn't expose reasoning)              |
+
+### Manual E2E Validation
+
+Follow the
+[Codex Multi-Agent Responses E2E runbook](./codex-multi-agent-e2e.md) when
+changing tool conversion, namespace handling, function-call streaming, or Codex
+collaboration compatibility.
 
 ### Ignored Parameters
 

--- a/src/server/routes/openai/openaiResponsesRoutes.ts
+++ b/src/server/routes/openai/openaiResponsesRoutes.ts
@@ -36,6 +36,7 @@ import {
   generateResponseId,
   getCurrentTimestamp,
   narrowToolsForChoice,
+  plaintextFunctionCallMetadata,
 } from "../../utils/openaiResponses";
 import { SSE_HEARTBEAT, withSseHeartbeat } from "../../utils/sseHeartbeat";
 
@@ -676,6 +677,7 @@ export function registerOpenaiResponsesRoutes(
                     arguments: "",
                     status: "in_progress",
                     ...(toolNamespace ? { namespace: toolNamespace } : {}),
+                    ...plaintextFunctionCallMetadata(toolInfo),
                   },
                   sequence_number: sequenceNumberRef.value++,
                 }),
@@ -711,6 +713,7 @@ export function registerOpenaiResponsesRoutes(
                 arguments: argsStr,
                 status: "completed",
                 ...(toolNamespace ? { namespace: toolNamespace } : {}),
+                ...plaintextFunctionCallMetadata(toolInfo),
               });
 
               await writeSSE({

--- a/src/server/schemas/openai.ts
+++ b/src/server/schemas/openai.ts
@@ -544,6 +544,7 @@ const FunctionToolCall = z.looseObject({
   call_id: z.string(),
   name: z.string(),
   arguments: z.string(),
+  encrypted_function_args: z.array(z.string()).optional(),
   status: z.enum(["in_progress", "completed", "failed"]).optional(),
 });
 

--- a/src/server/utils/openaiResponses.ts
+++ b/src/server/utils/openaiResponses.ts
@@ -44,9 +44,13 @@ export type ToolChoice =
 /**
  * Output item types for Responses API (subset we generate)
  */
+export type PlaintextResponseFunctionToolCall = ResponseFunctionToolCall & {
+  encrypted_function_args?: string[];
+};
+
 export type OutputItem =
   | ResponseOutputMessage
-  | ResponseFunctionToolCall
+  | PlaintextResponseFunctionToolCall
   | ResponseCustomToolCall;
 
 /**
@@ -533,6 +537,7 @@ export type ToolCallInfo = {
   namespace?: string;
   name: string;
   isCustom: boolean;
+  plaintextArguments?: boolean;
 };
 
 export type ToolMap = Map<string, ToolCallInfo>;
@@ -540,6 +545,57 @@ export type ToolMap = Map<string, ToolCallInfo>;
 export type ConvertedTools = {
   tools: vscode.LanguageModelChatTool[];
   toolMap: ToolMap;
+};
+
+const PLAINTEXT_COLLABORATION_TOOLS = new Set([
+  "spawn_agent",
+  "send_message",
+  "followup_task",
+]);
+
+const usesPlaintextCollaborationArguments = (info: ToolCallInfo): boolean =>
+  info.namespace === "collaboration" &&
+  !info.isCustom &&
+  PLAINTEXT_COLLABORATION_TOOLS.has(info.name);
+
+const removeEncryptedMessageMarker = (parameters: unknown): unknown => {
+  if (
+    !parameters ||
+    typeof parameters !== "object" ||
+    Array.isArray(parameters)
+  ) {
+    return parameters;
+  }
+
+  const schema = parameters as Record<string, unknown>;
+  const properties = schema.properties;
+  if (
+    !properties ||
+    typeof properties !== "object" ||
+    Array.isArray(properties)
+  ) {
+    return parameters;
+  }
+
+  const message = (properties as Record<string, unknown>).message;
+  if (!message || typeof message !== "object" || Array.isArray(message)) {
+    return parameters;
+  }
+
+  const messageSchema = message as Record<string, unknown>;
+  if (!Object.hasOwn(messageSchema, "encrypted")) {
+    return parameters;
+  }
+
+  const plaintextMessageSchema = { ...messageSchema };
+  delete plaintextMessageSchema.encrypted;
+  return {
+    ...schema,
+    properties: {
+      ...properties,
+      message: plaintextMessageSchema,
+    },
+  };
 };
 
 export const convertResponsesToolsToVSCode = (
@@ -563,14 +619,21 @@ export const convertResponsesToolsToVSCode = (
       );
       return;
     }
+    const plaintextArguments = usesPlaintextCollaborationArguments(info);
+    const mappedInfo = plaintextArguments
+      ? { ...info, plaintextArguments: true }
+      : info;
+    const inputSchema = plaintextArguments
+      ? removeEncryptedMessageMarker(parameters)
+      : parameters;
     vsCodeTools.push({
       name: encodedName,
       description: description ?? "",
       inputSchema: info.isCustom
         ? undefined
-        : ((parameters as object) ?? undefined),
+        : ((inputSchema as object | null | undefined) ?? undefined),
     });
-    toolMap.set(encodedName, info);
+    toolMap.set(encodedName, mappedInfo);
   };
 
   for (const tool of tools) {
@@ -755,12 +818,18 @@ export const buildResponseOutput = (
         arguments: JSON.stringify(tc.input ?? {}),
         status: "completed",
         ...(info?.namespace ? { namespace: info.namespace } : {}),
-      } as ResponseFunctionToolCall);
+        ...plaintextFunctionCallMetadata(info),
+      } as PlaintextResponseFunctionToolCall);
     }
   }
 
   return output;
 };
+
+export const plaintextFunctionCallMetadata = (
+  info?: ToolCallInfo,
+): { encrypted_function_args?: string[] } =>
+  info?.plaintextArguments ? { encrypted_function_args: [] } : {};
 
 /**
  * A `custom` tool's input is a raw string. We wrap it as `{ input: <string> }`

--- a/src/test/server/languageModelRequestLifecycle.test.ts
+++ b/src/test/server/languageModelRequestLifecycle.test.ts
@@ -419,6 +419,92 @@ suite("LanguageModelRequestLifecycle Test Suite", () => {
     assert.ok(toolResult.content[1] instanceof vscode.LanguageModelDataPart);
   });
 
+  test("uses plaintext Codex collaboration arguments in Responses", async () => {
+    let capturedOptions: vscode.LanguageModelChatRequestOptions | undefined;
+    const model = {
+      id: "gpt-5.6-test",
+      name: "GPT 5.6 Test",
+      family: "gpt-5.6",
+      version: "test",
+      vendor: "copilot",
+      maxInputTokens: 200000,
+      capabilities: { supportsImageToText: false, supportsToolCalling: true },
+      sendRequest: async (
+        _messages: readonly vscode.LanguageModelChatMessage[],
+        options?: vscode.LanguageModelChatRequestOptions,
+      ) => {
+        capturedOptions = options;
+        return {
+          stream: (async function* () {
+            yield new vscode.LanguageModelToolCallPart(
+              "call_spawn_1",
+              "collaboration__spawn_agent",
+              {
+                task_name: "reviewer",
+                fork_turns: "none",
+                message: "Review the current diff",
+              },
+            );
+          })(),
+          text: (async function* () {})(),
+        };
+      },
+      countTokens: async () => 1,
+    } as unknown as vscode.LanguageModelChat;
+    const app = createOpenaiResponsesTestApp(model);
+    const request = {
+      model: "gpt-5.6-test",
+      input: "Delegate this review",
+      tools: [
+        {
+          type: "namespace",
+          name: "collaboration",
+          description: "Sub-agent tools",
+          tools: [
+            {
+              type: "function",
+              name: "spawn_agent",
+              description: "Spawn a reviewer",
+              parameters: {
+                type: "object",
+                properties: {
+                  task_name: { type: "string" },
+                  message: { type: "string", encrypted: true },
+                },
+                required: ["task_name", "message"],
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    const response = await app.request("/v1/responses", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(request),
+    });
+    const body = (await response.json()) as any;
+    const inputSchema = capturedOptions?.tools?.[0].inputSchema as any;
+
+    assert.strictEqual(response.status, 200);
+    assert.strictEqual(inputSchema.properties.message.encrypted, undefined);
+    assert.deepStrictEqual(body.output[0].encrypted_function_args, []);
+
+    const streamingResponse = await app.request("/v1/responses", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ...request, stream: true }),
+    });
+    const streamingBody = await streamingResponse.text();
+
+    assert.strictEqual(streamingResponse.status, 200);
+    assert.strictEqual(
+      (streamingBody.match(/"encrypted_function_args":\[\]/g) ?? []).length,
+      3,
+    );
+  });
+
   test("handles requests containing only unsupported Responses tools", async () => {
     let capturedOptions: vscode.LanguageModelChatRequestOptions | undefined;
     const model = {

--- a/src/test/server/openaiResponses.test.ts
+++ b/src/test/server/openaiResponses.test.ts
@@ -580,12 +580,84 @@ suite("OpenAI Responses Conversion Utils Test Suite", () => {
         namespace: "collaboration",
         name: "spawn_agent",
         isCustom: false,
+        plaintextArguments: true,
       });
       assert.deepStrictEqual(toolMap.get("collaboration__raw_helper"), {
         namespace: "collaboration",
         name: "raw_helper",
         isCustom: true,
       });
+    });
+
+    test("should expose Codex collaboration messages as plaintext", () => {
+      const parameters = {
+        type: "object",
+        properties: {
+          message: {
+            type: "string",
+            description: "Initial task",
+            encrypted: true,
+          },
+          task_name: { type: "string" },
+        },
+        required: ["task_name", "message"],
+      };
+      const tools = [
+        {
+          type: "namespace",
+          name: "collaboration",
+          description: "Sub-agent tools",
+          tools: [
+            ...["spawn_agent", "send_message", "followup_task"].map((name) => ({
+              type: "function",
+              name,
+              parameters,
+            })),
+          ],
+        },
+      ];
+
+      const { tools: result, toolMap } = convertResponsesToolsToVSCode(
+        tools as any,
+      );
+      assert.strictEqual(result.length, 3);
+      for (const tool of result) {
+        const inputSchema = tool.inputSchema as any;
+        assert.strictEqual(inputSchema.properties.message.encrypted, undefined);
+        assert.strictEqual(inputSchema.properties.message.type, "string");
+        assert.strictEqual(toolMap.get(tool.name)?.plaintextArguments, true);
+      }
+      assert.strictEqual(
+        parameters.properties.message.encrypted,
+        true,
+        "request schema must not be mutated",
+      );
+    });
+
+    test("should preserve encrypted markers on unrelated function tools", () => {
+      const tools = [
+        {
+          type: "function",
+          name: "store_secret",
+          parameters: {
+            type: "object",
+            properties: {
+              message: { type: "string", encrypted: true },
+            },
+          },
+        },
+      ];
+
+      const { tools: result, toolMap } = convertResponsesToolsToVSCode(
+        tools as any,
+      );
+      const inputSchema = result[0].inputSchema as any;
+
+      assert.strictEqual(inputSchema.properties.message.encrypted, true);
+      assert.strictEqual(
+        toolMap.get("store_secret")?.plaintextArguments,
+        undefined,
+      );
     });
 
     test("should keep the first duplicate tool definition", () => {
@@ -860,7 +932,12 @@ suite("OpenAI Responses Conversion Utils Test Suite", () => {
       const toolMap = new Map([
         [
           "collaboration__spawn_agent",
-          { namespace: "collaboration", name: "spawn_agent", isCustom: false },
+          {
+            namespace: "collaboration",
+            name: "spawn_agent",
+            isCustom: false,
+            plaintextArguments: true,
+          },
         ],
         [
           "collaboration__raw_helper",
@@ -872,6 +949,7 @@ suite("OpenAI Responses Conversion Utils Test Suite", () => {
       assert.strictEqual(fc.type, "function_call");
       assert.strictEqual(fc.name, "spawn_agent");
       assert.strictEqual(fc.namespace, "collaboration");
+      assert.deepStrictEqual(fc.encrypted_function_args, []);
       const ctc = output[1] as any;
       assert.strictEqual(ctc.type, "custom_tool_call");
       assert.strictEqual(ctc.name, "raw_helper");


### PR DESCRIPTION
## Summary

- bridge Codex Multi-Agent V2 collaboration tools through the VS Code LM API using plaintext arguments
- emit `encrypted_function_args: []` on streaming and non-streaming function calls so Codex selects `DirectPlaintextMessage`
- document and test the authenticated VS Code Insiders/Codex E2E validation flow

## Test plan

- [x] `pnpm check-types`
- [x] `pnpm lint`
- [x] Full VS Code extension test suite (370 passing)
- [x] VS Code Insiders endpoint probe against `gpt-5.6-sol`
- [x] Codex `0.149.0-alpha.1` Multi-Agent V2 subagent canary

Changeset: `.changeset/plaintext-codex-collaboration.md`