### PR TITLE
fix(server): recover malformed tool result histories

### DIFF
--- a/.changeset/tidy-tools-recover.md
+++ b/.changeset/tidy-tools-recover.md
@@ -1,0 +1,5 @@
+---
+"agent-maestro": patch
+---
+
+Keep Anthropic and Responses conversations usable after malformed compaction or replay by preserving orphaned tool results as ordinary context and dropping duplicate results before calling the VS Code Language Model API.

--- a/README.md
+++ b/README.md
@@ -231,6 +231,8 @@ Agent Maestro reports real Copilot usage metadata for Anthropic responses when V
 
 - **Codex:** When you run **Agent Maestro: Configure Codex Settings**, Agent Maestro writes `model_context_window` into Codex's `config.toml` using the selected model's reported `maxInputTokens`. This tells Codex the effective context window size upfront so it manages its own conversation history accordingly. To customize it, edit `model_context_window` in `~/.codex/config.toml` directly.
 
+If compaction or replay leaves a tool result without its original call, Agent Maestro preserves the result as ordinary context instead of forwarding an invalid tool transcript. Repeated results for the same call ID are ignored after the first result.
+
 ### Prompt Cache Compatibility
 
 Agent Maestro accepts common prompt cache hints such as Anthropic `cache_control`, OpenAI `prompt_cache_key`, and Gemini `cachedContent` without forwarding unsupported cache controls to VS Code's Language Model API. For Anthropic-compatible responses, Copilot-provided usage metadata is used when available to report `cache_read_input_tokens` and `cache_creation_input_tokens`; fallback estimates report cache usage as `0` rather than synthetic savings.

--- a/src/server/utils/anthropic.ts
+++ b/src/server/utils/anthropic.ts
@@ -4,6 +4,10 @@ import * as vscode from "vscode";
 import { logger } from "../../utils/logger";
 import { extractCopilotUsagePayload } from "./copilotUsage";
 import { mimeForVscodeLm } from "./imageMime";
+import {
+  ToolResultPairingTracker,
+  logToolResultRecovery,
+} from "./toolResultPairing";
 
 const textBlockParamToVSCodePart = (param: Anthropic.Messages.TextBlockParam) =>
   new vscode.LanguageModelTextPart(param.text);
@@ -45,44 +49,45 @@ const toolUseBlockParamToVSCodePart = (
 const toolResultBlockParamToVSCodePart = (
   param: Anthropic.Messages.ToolResultBlockParam,
 ) => {
-  if (!param.content) {
-    // If the tool result has no content, return an empty array of parts to indicate no output was produced.
-    return new vscode.LanguageModelToolResultPart(param.tool_use_id, []);
-  }
-
-  const content =
-    typeof param.content === "string"
-      ? [new vscode.LanguageModelTextPart(param.content)]
-      : param.content.map((c) =>
-          c.type === "text"
-            ? textBlockParamToVSCodePart(c)
-            : c.type === "image"
-              ? imageBlockParamToVSCodePart(c, { preserveMimeType: true })
-              : new vscode.LanguageModelTextPart(JSON.stringify(c)),
-        );
-  return new vscode.LanguageModelToolResultPart(param.tool_use_id, content);
-};
-
-const serverToolUseBlockParamToVSCodePart = (
-  param: Anthropic.Messages.ServerToolUseBlockParam,
-) => {
-  return new vscode.LanguageModelToolCallPart(
-    param.id,
-    param.name,
-    param.input as object,
+  return new vscode.LanguageModelToolResultPart(
+    param.tool_use_id,
+    toolResultBlockParamToVSCodeContent(param),
   );
 };
 
+const toolResultBlockParamToVSCodeContent = (
+  param: Anthropic.Messages.ToolResultBlockParam,
+): Array<vscode.LanguageModelTextPart | vscode.LanguageModelDataPart> =>
+  !param.content
+    ? []
+    : typeof param.content === "string"
+      ? [new vscode.LanguageModelTextPart(param.content)]
+      : param.content.map((content) =>
+          content.type === "text"
+            ? textBlockParamToVSCodePart(content)
+            : content.type === "image"
+              ? imageBlockParamToVSCodePart(content, {
+                  preserveMimeType: true,
+                })
+              : new vscode.LanguageModelTextPart(JSON.stringify(content)),
+        );
+
 const webSearchToolResultBlockParamToVSCodePart = (
   param: Anthropic.Messages.WebSearchToolResultBlockParam,
-) => {
-  const content = Array.isArray(param.content)
-    ? param.content.map(
-        (c) => new vscode.LanguageModelTextPart(JSON.stringify(c)),
-      )
-    : [new vscode.LanguageModelTextPart(JSON.stringify(param.content))];
-  return new vscode.LanguageModelToolResultPart(param.tool_use_id, content);
-};
+) => new vscode.LanguageModelTextPart(JSON.stringify(param));
+
+const orphanedToolResultToVSCodeParts = (
+  callId: unknown,
+  content: Array<vscode.LanguageModelTextPart | vscode.LanguageModelDataPart>,
+  invalid = false,
+) => [
+  new vscode.LanguageModelTextPart(
+    invalid
+      ? `[Tool result with an invalid call ID: ${JSON.stringify(callId) ?? String(callId)}]`
+      : `[Tool result without a matching tool call: ${JSON.stringify(callId)}]`,
+  ),
+  ...content,
+];
 
 const searchResultBlockParamToVSCodePart = (
   param: Anthropic.Messages.SearchResultBlockParam,
@@ -98,6 +103,7 @@ const searchResultBlockParamToVSCodePart = (
  */
 const convertContentToVSCodeParts = (
   content: string | Array<Anthropic.Messages.ContentBlockParam>,
+  pairing?: ToolResultPairingTracker,
 ): Array<
   | vscode.LanguageModelTextPart
   | vscode.LanguageModelToolResultPart
@@ -114,6 +120,7 @@ const convertContentToVSCodeParts = (
     | vscode.LanguageModelToolCallPart
     | vscode.LanguageModelDataPart
   > = [];
+  let droppedDuplicate = false;
 
   for (const block of content) {
     switch (block.type) {
@@ -136,13 +143,37 @@ const convertContentToVSCodeParts = (
         parts.push(redactedThinkingBlockParamToVSCodePart(block));
         break;
       case "tool_use":
+        if (pairing && !pairing.recordCall(block.id)) {
+          parts.push(
+            new vscode.LanguageModelTextPart(
+              `[Tool call with an invalid call ID]\n${JSON.stringify(block)}`,
+            ),
+          );
+          break;
+        }
         parts.push(toolUseBlockParamToVSCodePart(block));
         break;
-      case "tool_result":
+      case "tool_result": {
+        const result = pairing?.recordResult(block.tool_use_id);
+        if (result === "duplicate") {
+          droppedDuplicate = true;
+          break;
+        }
+        if (result === "invalid" || result === "orphaned") {
+          parts.push(
+            ...orphanedToolResultToVSCodeParts(
+              block.tool_use_id,
+              toolResultBlockParamToVSCodeContent(block),
+              result === "invalid",
+            ),
+          );
+          break;
+        }
         parts.push(toolResultBlockParamToVSCodePart(block));
         break;
+      }
       case "server_tool_use":
-        parts.push(serverToolUseBlockParamToVSCodePart(block));
+        parts.push(new vscode.LanguageModelTextPart(JSON.stringify(block)));
         break;
       case "web_search_tool_result":
         parts.push(webSearchToolResultBlockParamToVSCodePart(block));
@@ -153,8 +184,31 @@ const convertContentToVSCodeParts = (
     }
   }
 
-  return parts.length > 0 ? parts : [new vscode.LanguageModelTextPart("")];
+  if (parts.length > 0) {
+    return parts;
+  }
+  return droppedDuplicate ? [] : [new vscode.LanguageModelTextPart("")];
 };
+
+const createVSCodeMessage = (
+  role: Anthropic.Messages.MessageParam["role"],
+  contentParts: ReturnType<typeof convertContentToVSCodeParts>,
+): vscode.LanguageModelChatMessage =>
+  role === "user"
+    ? vscode.LanguageModelChatMessage.User(
+        contentParts as Array<
+          | vscode.LanguageModelTextPart
+          | vscode.LanguageModelToolResultPart
+          | vscode.LanguageModelDataPart
+        >,
+      )
+    : vscode.LanguageModelChatMessage.Assistant(
+        contentParts as Array<
+          | vscode.LanguageModelTextPart
+          | vscode.LanguageModelToolCallPart
+          | vscode.LanguageModelDataPart
+        >,
+      );
 
 /**
  * Convert a single Anthropic MessageParam to VS Code LanguageModelChatMessage(s)
@@ -175,25 +229,7 @@ export const convertAnthropicMessageToVSCode = (
   // Handle array content
   const contentParts = convertContentToVSCodeParts(message.content);
 
-  // Create the message
-  const vsCodeMessage =
-    message.role === "user"
-      ? vscode.LanguageModelChatMessage.User(
-          contentParts as Array<
-            | vscode.LanguageModelTextPart
-            | vscode.LanguageModelToolResultPart
-            | vscode.LanguageModelDataPart
-          >,
-        )
-      : vscode.LanguageModelChatMessage.Assistant(
-          contentParts as Array<
-            | vscode.LanguageModelTextPart
-            | vscode.LanguageModelToolCallPart
-            | vscode.LanguageModelDataPart
-          >,
-        );
-
-  return vsCodeMessage;
+  return createVSCodeMessage(message.role, contentParts);
 };
 
 /**
@@ -207,16 +243,16 @@ export const convertAnthropicMessagesToVSCode = (
   messages: Array<Anthropic.Messages.MessageParam>,
 ): vscode.LanguageModelChatMessage[] => {
   const results: vscode.LanguageModelChatMessage[] = [];
+  const pairing = new ToolResultPairingTracker();
 
   for (const message of messages) {
-    const converted = convertAnthropicMessageToVSCode(message);
-    if (Array.isArray(converted)) {
-      results.push(...converted);
-    } else {
-      results.push(converted);
+    const contentParts = convertContentToVSCodeParts(message.content, pairing);
+    if (contentParts.length > 0) {
+      results.push(createVSCodeMessage(message.role, contentParts));
     }
   }
 
+  logToolResultRecovery("Anthropic", [pairing]);
   return results;
 };
 

--- a/src/server/utils/anthropic.ts
+++ b/src/server/utils/anthropic.ts
@@ -211,14 +211,14 @@ const createVSCodeMessage = (
       );
 
 /**
- * Convert a single Anthropic MessageParam to VS Code LanguageModelChatMessage(s)
+ * Convert a single Anthropic MessageParam to a VS Code LanguageModelChatMessage
  *
  * @param message - Anthropic MessageParam with role and content
- * @returns Single message or array of messages based on content type
+ * @returns VS Code LanguageModelChatMessage
  */
 export const convertAnthropicMessageToVSCode = (
   message: Anthropic.Messages.MessageParam,
-): vscode.LanguageModelChatMessage | vscode.LanguageModelChatMessage[] => {
+): vscode.LanguageModelChatMessage => {
   // Handle string content - always returns single message
   if (typeof message.content === "string") {
     return message.role === "user"
@@ -234,10 +234,9 @@ export const convertAnthropicMessageToVSCode = (
 
 /**
  * Convert an array of Anthropic MessageParams to VS Code LanguageModelChatMessages
- * Flattens any array results from individual message conversions
  *
  * @param messages - Array of Anthropic MessageParam
- * @returns Flat array of VS Code LanguageModelChatMessage
+ * @returns Array of VS Code LanguageModelChatMessage
  */
 export const convertAnthropicMessagesToVSCode = (
   messages: Array<Anthropic.Messages.MessageParam>,

--- a/src/server/utils/openaiResponses.ts
+++ b/src/server/utils/openaiResponses.ts
@@ -27,6 +27,10 @@ import * as vscode from "vscode";
 
 import { logger } from "../../utils/logger";
 import { mimeForVscodeLm } from "./imageMime";
+import {
+  ToolResultPairingTracker,
+  logToolResultRecovery,
+} from "./toolResultPairing";
 
 /**
  * Import types from OpenAI SDK for Responses API
@@ -468,6 +472,69 @@ export const convertResponsesItemToVSCode = (
   return null;
 };
 
+const convertResponsesItemWithPairing = (
+  item: ResponseInputItem,
+  pairing: {
+    customTools: ToolResultPairingTracker;
+    functionTools: ToolResultPairingTracker;
+  },
+): vscode.LanguageModelChatMessage | null => {
+  const type = (item as unknown as { type?: string })?.type;
+  if (type === "function_call") {
+    if (
+      !pairing.functionTools.recordCall(
+        (item as ResponseFunctionToolCall).call_id,
+      )
+    ) {
+      return invalidToolCallToVSCodeMessage(item);
+    }
+  } else if (type === "custom_tool_call") {
+    if (
+      !pairing.customTools.recordCall(
+        (item as unknown as ResponseCustomToolCall).call_id,
+      )
+    ) {
+      return invalidToolCallToVSCodeMessage(item);
+    }
+  } else if (
+    type === "function_call_output" ||
+    type === "custom_tool_call_output"
+  ) {
+    const output = item as unknown as
+      | ResponseInputItem.FunctionCallOutput
+      | ResponseCustomToolCallOutput;
+    const tracker =
+      type === "function_call_output"
+        ? pairing.functionTools
+        : pairing.customTools;
+    const result = tracker.recordResult(output.call_id);
+    if (result === "duplicate") {
+      return null;
+    }
+    if (result === "invalid" || result === "orphaned") {
+      return vscode.LanguageModelChatMessage.User([
+        new vscode.LanguageModelTextPart(
+          result === "invalid"
+            ? `[Tool result with an invalid call ID: ${JSON.stringify(output.call_id) ?? String(output.call_id)}]`
+            : `[Tool result without a matching tool call: ${JSON.stringify(output.call_id)}]`,
+        ),
+        ...convertToolOutputToVSCodeParts(output.output),
+      ]);
+    }
+  }
+
+  return convertResponsesItemToVSCode(item);
+};
+
+const invalidToolCallToVSCodeMessage = (
+  item: ResponseInputItem,
+): vscode.LanguageModelChatMessage =>
+  vscode.LanguageModelChatMessage.Assistant([
+    new vscode.LanguageModelTextPart(
+      `[Tool call with an invalid call ID]\n${JSON.stringify(item)}`,
+    ),
+  ]);
+
 /**
  * Convert Responses API input to VSCode LM messages
  */
@@ -476,6 +543,10 @@ export const convertResponsesInputToVSCode = (
   instruction?: string | ResponseInput | null,
 ): vscode.LanguageModelChatMessage[] => {
   const messages: vscode.LanguageModelChatMessage[] = [];
+  const pairing = {
+    customTools: new ToolResultPairingTracker(),
+    functionTools: new ToolResultPairingTracker(),
+  };
 
   // Add instruction as first user message if present
   if (instruction) {
@@ -483,7 +554,7 @@ export const convertResponsesInputToVSCode = (
       messages.push(vscode.LanguageModelChatMessage.User(instruction));
     } else if (Array.isArray(instruction)) {
       for (const item of instruction) {
-        const converted = convertResponsesItemToVSCode(item);
+        const converted = convertResponsesItemWithPairing(item, pairing);
         if (converted) {
           messages.push(converted);
         }
@@ -494,19 +565,19 @@ export const convertResponsesInputToVSCode = (
   // Handle string input
   if (typeof input === "string") {
     messages.push(vscode.LanguageModelChatMessage.User(input));
-    return messages;
-  }
-
-  // Handle array input
-  if (Array.isArray(input)) {
+  } else if (Array.isArray(input)) {
     for (const item of input) {
-      const converted = convertResponsesItemToVSCode(item);
+      const converted = convertResponsesItemWithPairing(item, pairing);
       if (converted) {
         messages.push(converted);
       }
     }
   }
 
+  logToolResultRecovery("Responses", [
+    pairing.functionTools,
+    pairing.customTools,
+  ]);
   return messages;
 };
 

--- a/src/server/utils/toolResultPairing.ts
+++ b/src/server/utils/toolResultPairing.ts
@@ -1,0 +1,158 @@
+import { logger } from "../../utils/logger";
+
+export type ToolResultPairing = "duplicate" | "invalid" | "orphaned" | "paired";
+
+const SAMPLE_LIMIT = 5;
+const MAX_LOGGED_ID_LENGTH = 80;
+
+export class ToolResultPairingTracker {
+  private readonly pendingCallIds = new Set<string>();
+  private readonly seenResultIds = new Set<string>();
+  private readonly duplicateResultIds: string[] = [];
+  private readonly invalidCallIds: unknown[] = [];
+  private readonly invalidResultIds: unknown[] = [];
+  private readonly orphanedResultIds: string[] = [];
+  private duplicateResultCount = 0;
+  private invalidCallIdCount = 0;
+  private invalidResultIdCount = 0;
+  private orphanedResultCount = 0;
+
+  recordCall(callId: unknown): boolean {
+    if (!isValidToolCallId(callId)) {
+      this.invalidCallIdCount++;
+      this.recordSample(this.invalidCallIds, callId);
+      return false;
+    }
+
+    this.pendingCallIds.add(callId);
+    return true;
+  }
+
+  recordResult(callId: unknown): ToolResultPairing {
+    if (!isValidToolCallId(callId)) {
+      this.invalidResultIdCount++;
+      this.recordSample(this.invalidResultIds, callId);
+      return "invalid";
+    }
+
+    if (this.seenResultIds.has(callId)) {
+      this.duplicateResultCount++;
+      this.recordSample(this.duplicateResultIds, callId);
+      return "duplicate";
+    }
+
+    this.seenResultIds.add(callId);
+    if (this.pendingCallIds.delete(callId)) {
+      return "paired";
+    }
+
+    this.orphanedResultCount++;
+    this.recordSample(this.orphanedResultIds, callId);
+    return "orphaned";
+  }
+
+  get duplicateCount(): number {
+    return this.duplicateResultCount;
+  }
+
+  get duplicateSamples(): readonly string[] {
+    return this.duplicateResultIds;
+  }
+
+  get invalidCallCount(): number {
+    return this.invalidCallIdCount;
+  }
+
+  get invalidCallSamples(): readonly unknown[] {
+    return this.invalidCallIds;
+  }
+
+  get invalidResultCount(): number {
+    return this.invalidResultIdCount;
+  }
+
+  get invalidResultSamples(): readonly unknown[] {
+    return this.invalidResultIds;
+  }
+
+  get orphanedCount(): number {
+    return this.orphanedResultCount;
+  }
+
+  get orphanedSamples(): readonly string[] {
+    return this.orphanedResultIds;
+  }
+
+  private recordSample(samples: unknown[], callId: unknown): void {
+    if (samples.length < SAMPLE_LIMIT) {
+      samples.push(callId);
+    }
+  }
+}
+
+export function logToolResultRecovery(
+  adapter: string,
+  trackers: readonly ToolResultPairingTracker[],
+): void {
+  const orphanedCount = trackers.reduce(
+    (total, tracker) => total + tracker.orphanedCount,
+    0,
+  );
+  const duplicateCount = trackers.reduce(
+    (total, tracker) => total + tracker.duplicateCount,
+    0,
+  );
+  const invalidCallCount = trackers.reduce(
+    (total, tracker) => total + tracker.invalidCallCount,
+    0,
+  );
+  const invalidResultCount = trackers.reduce(
+    (total, tracker) => total + tracker.invalidResultCount,
+    0,
+  );
+  if (
+    orphanedCount === 0 &&
+    duplicateCount === 0 &&
+    invalidCallCount === 0 &&
+    invalidResultCount === 0
+  ) {
+    return;
+  }
+
+  const orphanedSamples = trackers
+    .flatMap((tracker) => tracker.orphanedSamples)
+    .slice(0, SAMPLE_LIMIT);
+  const duplicateSamples = trackers
+    .flatMap((tracker) => tracker.duplicateSamples)
+    .slice(0, SAMPLE_LIMIT);
+  const invalidSamples = trackers
+    .flatMap((tracker) => [
+      ...tracker.invalidCallSamples,
+      ...tracker.invalidResultSamples,
+    ])
+    .slice(0, SAMPLE_LIMIT);
+
+  logger.warn(
+    `${adapter} tool result recovery: converted ${orphanedCount} orphaned result(s) to ordinary content${formatSamples(orphanedSamples)}; converted ${invalidCallCount} call(s) and ${invalidResultCount} result(s) with invalid IDs to ordinary content${formatSamples(invalidSamples)}; dropped ${duplicateCount} duplicate result(s)${formatSamples(duplicateSamples)}`,
+  );
+}
+
+function isValidToolCallId(callId: unknown): callId is string {
+  return typeof callId === "string" && callId.length > 0;
+}
+
+function formatSamples(callIds: readonly unknown[]): string {
+  if (callIds.length === 0) {
+    return "";
+  }
+
+  const samples = callIds.map((callId) => {
+    const value = JSON.stringify(callId) ?? String(callId);
+    const truncated =
+      value.length > MAX_LOGGED_ID_LENGTH
+        ? `${value.slice(0, MAX_LOGGED_ID_LENGTH)}...`
+        : value;
+    return truncated;
+  });
+  return ` (sample call IDs: ${samples.join(", ")})`;
+}

--- a/src/test/server/anthropic.test.ts
+++ b/src/test/server/anthropic.test.ts
@@ -14,6 +14,7 @@ import {
   findAnthropicModelById,
 } from "../../server/utils/anthropicModels";
 import { isResponseTooLongError } from "../../server/utils/languageModelErrors";
+import { logger } from "../../utils/logger";
 import { WEBP_1024x935_BASE64 } from "../utils/imageMime.fixtures";
 
 function createMockModel(
@@ -441,6 +442,226 @@ suite("Anthropic Conversion Utils Test Suite", () => {
     test("should handle empty messages array", () => {
       const result = convertAnthropicMessagesToVSCode([]);
       assert.strictEqual(result.length, 0);
+    });
+
+    test("should pair parallel tool results by ID", () => {
+      const result = convertAnthropicMessagesToVSCode([
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool_use",
+              id: "tool-a",
+              name: "first",
+              input: {},
+            },
+            {
+              type: "tool_use",
+              id: "tool-b",
+              name: "second",
+              input: {},
+            },
+          ],
+        },
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "tool-b",
+              content: "second result",
+            },
+            {
+              type: "tool_result",
+              tool_use_id: "tool-a",
+              content: "first result",
+            },
+          ],
+        },
+      ]);
+
+      const toolResults = result[1].content.filter(
+        (part) => part instanceof vscode.LanguageModelToolResultPart,
+      ) as vscode.LanguageModelToolResultPart[];
+      assert.deepStrictEqual(
+        toolResults.map((part) => part.callId),
+        ["tool-b", "tool-a"],
+      );
+    });
+
+    test("should keep server tool turns as ordinary assistant content", () => {
+      const result = convertAnthropicMessagesToVSCode([
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "server_tool_use",
+              id: "srvtoolu_123",
+              name: "web_search",
+              input: { query: "current weather" },
+            },
+            {
+              type: "web_search_tool_result",
+              tool_use_id: "srvtoolu_123",
+              content: [
+                {
+                  type: "web_search_result",
+                  url: "https://example.com/weather",
+                  title: "Weather",
+                  encrypted_content: "encrypted",
+                },
+              ],
+            },
+          ],
+        },
+      ] as any);
+
+      assert.strictEqual(result.length, 1);
+      assert.strictEqual(
+        result[0].role,
+        vscode.LanguageModelChatMessageRole.Assistant,
+      );
+      assert.ok(
+        result[0].content.every(
+          (part) => part instanceof vscode.LanguageModelTextPart,
+        ),
+      );
+      assert.ok(
+        result[0].content.every(
+          (part) => !(part instanceof vscode.LanguageModelToolCallPart),
+        ),
+      );
+      assert.ok(
+        result[0].content.every(
+          (part) => !(part instanceof vscode.LanguageModelToolResultPart),
+        ),
+      );
+      assert.match(
+        (result[0].content[0] as vscode.LanguageModelTextPart).value,
+        /srvtoolu_123/,
+      );
+      assert.match(
+        (result[0].content[1] as vscode.LanguageModelTextPart).value,
+        /srvtoolu_123/,
+      );
+    });
+
+    test("should preserve orphaned results as text and drop duplicates", () => {
+      const warnings: string[] = [];
+      const originalWarn = logger.warn;
+      logger.warn = (message: string) => warnings.push(message);
+
+      try {
+        const result = convertAnthropicMessagesToVSCode([
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "tool_use",
+                id: "tool-known",
+                name: "known",
+                input: {},
+              },
+            ],
+          },
+          {
+            role: "user",
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: "tool-missing",
+                content: "orphaned output",
+              },
+              {
+                type: "tool_result",
+                tool_use_id: "tool-known",
+                content: "first output",
+              },
+              {
+                type: "tool_result",
+                tool_use_id: "tool-known",
+                content: "duplicate output",
+              },
+              {
+                type: "tool_result",
+                tool_use_id: "tool-missing",
+                content: "duplicate orphaned output",
+              },
+            ],
+          },
+        ]);
+
+        assert.strictEqual(result.length, 2);
+        const parts = result[1].content;
+        assert.ok(parts[0] instanceof vscode.LanguageModelTextPart);
+        assert.match(
+          (parts[0] as vscode.LanguageModelTextPart).value,
+          /tool-missing/,
+        );
+        assert.strictEqual(
+          (parts[1] as vscode.LanguageModelTextPart).value,
+          "orphaned output",
+        );
+        const toolResults = parts.filter(
+          (part) => part instanceof vscode.LanguageModelToolResultPart,
+        ) as vscode.LanguageModelToolResultPart[];
+        assert.strictEqual(toolResults.length, 1);
+        assert.strictEqual(toolResults[0].callId, "tool-known");
+        assert.strictEqual(
+          (toolResults[0].content[0] as vscode.LanguageModelTextPart).value,
+          "first output",
+        );
+        assert.strictEqual(warnings.length, 1);
+        assert.match(warnings[0], /converted 1 orphaned result/);
+        assert.match(warnings[0], /dropped 2 duplicate result/);
+      } finally {
+        logger.warn = originalWarn;
+      }
+    });
+
+    test("should preserve calls and results with invalid IDs as text", () => {
+      const warnings: string[] = [];
+      const originalWarn = logger.warn;
+      logger.warn = (message: string) => warnings.push(message);
+
+      try {
+        const result = convertAnthropicMessagesToVSCode([
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "tool_use",
+                name: "missing-id",
+                input: {},
+              },
+            ],
+          },
+          {
+            role: "user",
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: null,
+                content: "invalid output",
+              },
+            ],
+          },
+        ] as any);
+
+        assert.strictEqual(result.length, 2);
+        assert.ok(
+          result
+            .flatMap((message) => message.content)
+            .every((part) => part instanceof vscode.LanguageModelTextPart),
+        );
+        assert.strictEqual(warnings.length, 1);
+        assert.match(
+          warnings[0],
+          /converted 1 call\(s\) and 1 result\(s\) with invalid IDs/,
+        );
+      } finally {
+        logger.warn = originalWarn;
+      }
     });
   });
 

--- a/src/test/server/languageModelRequestLifecycle.test.ts
+++ b/src/test/server/languageModelRequestLifecycle.test.ts
@@ -57,6 +57,34 @@ suite("LanguageModelRequestLifecycle Test Suite", () => {
       countTokens: async () => 0,
     }) as vscode.LanguageModelChat;
 
+  const createSuccessfulModel = (
+    onRequest: (messages: readonly vscode.LanguageModelChatMessage[]) => void,
+  ): vscode.LanguageModelChat =>
+    ({
+      id: "test-model",
+      name: "Test Model",
+      family: "test",
+      version: "test",
+      vendor: "copilot",
+      maxInputTokens: 200000,
+      capabilities: {
+        supportsImageToText: true,
+        supportsToolCalling: true,
+      },
+      sendRequest: async (messages) => {
+        onRequest(messages);
+        return {
+          stream: (async function* () {
+            yield new vscode.LanguageModelTextPart("ok");
+          })(),
+          text: (async function* () {
+            yield "ok";
+          })(),
+        };
+      },
+      countTokens: async () => 1,
+    }) as vscode.LanguageModelChat;
+
   const createAnthropicTestApp = (model: vscode.LanguageModelChat) => {
     const app = new OpenAPIHono();
     registerAnthropicRoutes(app, {
@@ -417,6 +445,75 @@ suite("LanguageModelRequestLifecycle Test Suite", () => {
     const toolResult = capturedMessages[1].content[0] as any;
     assert.ok(toolResult.content[0] instanceof vscode.LanguageModelTextPart);
     assert.ok(toolResult.content[1] instanceof vscode.LanguageModelDataPart);
+  });
+
+  test("recovers invalid tool IDs before both routes call the model", async () => {
+    const capturedRequests: Array<readonly vscode.LanguageModelChatMessage[]> =
+      [];
+    const model = createSuccessfulModel((messages) => {
+      capturedRequests.push(messages);
+    });
+    const anthropicApp = createAnthropicTestApp(model);
+    const responsesApp = createOpenaiResponsesTestApp(model);
+
+    const anthropicResponse = await anthropicApp.request("/v1/messages", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "test-model",
+        max_tokens: 16,
+        messages: [
+          {
+            role: "assistant",
+            content: [{ type: "tool_use", name: "missing", input: {} }],
+          },
+          {
+            role: "user",
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: null,
+                content: "invalid output",
+              },
+            ],
+          },
+        ],
+      }),
+    });
+    const responsesResponse = await responsesApp.request("/v1/responses", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "test-model",
+        input: [
+          {
+            type: "function_call",
+            id: "fc_missing",
+            name: "missing",
+            arguments: "{}",
+          },
+          {
+            type: "function_call_output",
+            call_id: null,
+            output: "invalid output",
+          },
+        ],
+      }),
+    });
+
+    assert.strictEqual(anthropicResponse.status, 200);
+    assert.strictEqual(responsesResponse.status, 200);
+    assert.strictEqual(capturedRequests.length, 2);
+    for (const request of capturedRequests) {
+      const parts = request.flatMap((message) => message.content);
+      assert.ok(
+        parts.every(
+          (part) =>
+            !(part instanceof vscode.LanguageModelToolCallPart) &&
+            !(part instanceof vscode.LanguageModelToolResultPart),
+        ),
+      );
+    }
   });
 
   test("uses plaintext Codex collaboration arguments in Responses", async () => {

--- a/src/test/server/openaiResponses.test.ts
+++ b/src/test/server/openaiResponses.test.ts
@@ -16,6 +16,7 @@ import {
   generateResponseId,
   narrowToolsForChoice,
 } from "../../server/utils/openaiResponses";
+import { logger } from "../../utils/logger";
 
 const encode = (value: unknown): Uint8Array =>
   new TextEncoder().encode(JSON.stringify(value));
@@ -500,6 +501,174 @@ suite("OpenAI Responses Conversion Utils Test Suite", () => {
       ];
       const result = convertResponsesInputToVSCode(input);
       assert.strictEqual(result.length, 2);
+    });
+
+    test("should pair parallel function outputs by call ID", () => {
+      const result = convertResponsesInputToVSCode([
+        {
+          type: "function_call",
+          id: "fc_a",
+          call_id: "call_a",
+          name: "first",
+          arguments: "{}",
+        },
+        {
+          type: "function_call",
+          id: "fc_b",
+          call_id: "call_b",
+          name: "second",
+          arguments: "{}",
+        },
+        {
+          type: "function_call_output",
+          call_id: "call_b",
+          output: "second result",
+        },
+        {
+          type: "function_call_output",
+          call_id: "call_a",
+          output: "first result",
+        },
+      ]);
+
+      const toolResults = result
+        .flatMap((message) => message.content)
+        .filter(
+          (part) => part instanceof vscode.LanguageModelToolResultPart,
+        ) as vscode.LanguageModelToolResultPart[];
+      assert.deepStrictEqual(
+        toolResults.map((part) => part.callId),
+        ["call_b", "call_a"],
+      );
+    });
+
+    test("should preserve orphaned outputs as text and drop duplicates", () => {
+      const warnings: string[] = [];
+      const originalWarn = logger.warn;
+      logger.warn = (message: string) => warnings.push(message);
+
+      try {
+        const result = convertResponsesInputToVSCode([
+          {
+            type: "function_call",
+            id: "fc_known",
+            call_id: "call_known",
+            name: "known",
+            arguments: "{}",
+          },
+          {
+            type: "custom_tool_call",
+            id: "ctc_known",
+            call_id: "call_custom",
+            name: "shell",
+            input: "pwd",
+          },
+          {
+            type: "function_call_output",
+            call_id: "call_missing",
+            output: "orphaned output",
+          },
+          {
+            type: "function_call_output",
+            call_id: "call_known",
+            output: "first output",
+          },
+          {
+            type: "function_call_output",
+            call_id: "call_known",
+            output: "duplicate output",
+          },
+          {
+            type: "function_call_output",
+            call_id: "call_missing",
+            output: "duplicate orphaned output",
+          },
+          {
+            type: "custom_tool_call_output",
+            call_id: "call_custom",
+            output: "custom output",
+          },
+          {
+            type: "custom_tool_call_output",
+            call_id: "call_custom",
+            output: "duplicate custom output",
+          },
+        ] as any);
+
+        assert.strictEqual(result.length, 5);
+        const orphanedParts = result[2].content;
+        assert.ok(orphanedParts[0] instanceof vscode.LanguageModelTextPart);
+        assert.match(
+          (orphanedParts[0] as vscode.LanguageModelTextPart).value,
+          /call_missing/,
+        );
+        assert.strictEqual(
+          (orphanedParts[1] as vscode.LanguageModelTextPart).value,
+          "orphaned output",
+        );
+        const toolResults = result
+          .flatMap((message) => message.content)
+          .filter(
+            (part) => part instanceof vscode.LanguageModelToolResultPart,
+          ) as vscode.LanguageModelToolResultPart[];
+        assert.deepStrictEqual(
+          toolResults.map((part) => part.callId),
+          ["call_known", "call_custom"],
+        );
+        assert.strictEqual(warnings.length, 1);
+        assert.match(warnings[0], /converted 1 orphaned result/);
+        assert.match(warnings[0], /dropped 3 duplicate result/);
+      } finally {
+        logger.warn = originalWarn;
+      }
+    });
+
+    test("should preserve calls and outputs with invalid IDs as text", () => {
+      const warnings: string[] = [];
+      const originalWarn = logger.warn;
+      logger.warn = (message: string) => warnings.push(message);
+
+      try {
+        const result = convertResponsesInputToVSCode([
+          {
+            type: "function_call",
+            id: "fc_missing",
+            name: "missing",
+            arguments: "{}",
+          },
+          {
+            type: "function_call_output",
+            call_id: null,
+            output: "null output",
+          },
+          {
+            type: "custom_tool_call",
+            id: "ctc_number",
+            call_id: 42,
+            name: "number",
+            input: "pwd",
+          },
+          {
+            type: "custom_tool_call_output",
+            call_id: { invalid: true },
+            output: "object output",
+          },
+        ] as any);
+
+        assert.strictEqual(result.length, 4);
+        assert.ok(
+          result
+            .flatMap((message) => message.content)
+            .every((part) => part instanceof vscode.LanguageModelTextPart),
+        );
+        assert.strictEqual(warnings.length, 1);
+        assert.match(
+          warnings[0],
+          /converted 2 call\(s\) and 2 result\(s\) with invalid IDs/,
+        );
+      } finally {
+        logger.warn = originalWarn;
+      }
     });
   });
 


### PR DESCRIPTION
## Summary

- pair Anthropic and Responses tool results with preceding calls before forwarding history to VS Code LM
- preserve orphaned or invalid-ID tool calls/results as ordinary context and drop duplicate results after the first
- serialize Anthropic server-tool calls/results as ordinary assistant content so tool results never appear in Assistant messages
- aggregate recovery warnings with bounded ID samples

Closes #235

## Test plan

- [x] `pnpm check-types`
- [x] `pnpm lint`
- [x] `pnpm run build-tests`
- [x] `pnpm build`
- [x] Full VS Code 1.120.0 extension-host suite (`408 passing`)
- [x] `git diff --check`

## Changeset

- `.changeset/tidy-tools-recover.md`