### PR TITLE
chore: release v2.13.0

### DIFF
--- a/.changeset/friendly-searches-arrive.md
+++ b/.changeset/friendly-searches-arrive.md
@@ -1,5 +1,0 @@
----
-"agent-maestro": minor
----
-
-Add transparent Anthropic-compatible server web search through Exa, including hidden tool execution, source links, streaming, usage accounting, anonymous access, and secure optional API-key storage.

--- a/.changeset/plaintext-codex-collaboration.md
+++ b/.changeset/plaintext-codex-collaboration.md
@@ -1,5 +1,0 @@
----
-"agent-maestro": patch
----
-
-Fix Codex Multi-Agent V2 subagents receiving empty tasks through the Responses API by using Codex's plaintext collaboration contract across the VS Code Language Model boundary.

--- a/.changeset/quiet-ravens-filter.md
+++ b/.changeset/quiet-ravens-filter.md
@@ -1,5 +1,0 @@
----
-"agent-maestro": patch
----
-
-Add MiniMax as a supported Roo Code API provider while keeping its API key out of settings and profile responses.

--- a/.changeset/tidy-tools-recover.md
+++ b/.changeset/tidy-tools-recover.md
@@ -1,5 +1,0 @@
----
-"agent-maestro": patch
----
-
-Keep Anthropic and Responses conversations usable after malformed compaction or replay by preserving orphaned tool results as ordinary context and dropping duplicate results before calling the VS Code Language Model API.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v2.13.0 - 2026.08.28
+
+- Add transparent Exa-powered web search to Anthropic-compatible requests, with streamed source links and support for anonymous or securely authenticated access.
+- Fix Codex Multi-Agent V2 subagents receiving empty tasks through the Responses API.
+- Prevent malformed compaction or replay data from breaking Anthropic and Responses conversations by preserving orphaned tool results and ignoring duplicates.
+- Add MiniMax support to Roo Code without exposing its API key in settings or profile responses.
+
 ## v2.12.0 - 2026.08.20
 
 - Add the global `agent-maestro.fallbackModelId` setting and `Agent Maestro: Select Fallback Model` command for requests whose model ID cannot be matched to an available VS Code language model.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "agent-maestro",
   "displayName": "Agent Maestro",
   "description": "Turn VS Code into your compliant AI playground! With Agent Maestro, spin up Cline or Roo on demand and plug Claude Code or Codex straight in through an OpenAI/Anthropic-compatible API.",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "icon": "assets/icons/icon.png",
   "publisher": "Joouis",
   "repository": "https://github.com/Joouis/agent-maestro",


### PR DESCRIPTION
## Summary

- Release Agent Maestro v2.13.0
- Consume four pending changesets
- Add the polished v2.13.0 changelog covering Exa web search, Codex Multi-Agent V2, MiniMax support, and conversation recovery

## Test plan

- [x] Pre-commit ESLint and Prettier checks pass
- [x] Verify `package.json` version is `2.13.0`
- [x] Review the generated changelog