### PR TITLE
fix(deps): update form-data and remove unused axios

### DIFF
--- a/package.json
+++ b/package.json
@@ -186,7 +186,6 @@
     "@hono/node-server": "^1.17.1",
     "@hono/zod-openapi": "^1.0.2",
     "@roo-code/types": "^1.86.0",
-    "axios": "^1.9.0",
     "es-toolkit": "^1.39.3",
     "fastmcp": "^3.5.0",
     "hono": "^4.8.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,9 +24,6 @@ importers:
       "@roo-code/types":
         specifier: ^1.86.0
         version: 1.86.0
-      axios:
-        specifier: ^1.9.0
-        version: 1.9.0
       es-toolkit:
         specifier: ^1.39.3
         version: 1.39.3
@@ -1614,12 +1611,6 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
-  axios@1.9.0:
-    resolution:
-      {
-        integrity: sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==,
-      }
-
   azure-devops-node-api@12.5.0:
     resolution:
       {
@@ -2741,10 +2732,10 @@ packages:
       }
     engines: { node: ">=14" }
 
-  form-data@4.0.2:
+  form-data@4.0.6:
     resolution:
       {
-        integrity: sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==,
+        integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==,
       }
     engines: { node: ">= 6" }
 
@@ -4729,12 +4720,6 @@ packages:
         integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==,
       }
     engines: { node: ">= 0.10" }
-
-  proxy-from-env@1.1.0:
-    resolution:
-      {
-        integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==,
-      }
 
   pump@3.0.2:
     resolution:
@@ -7009,7 +6994,7 @@ snapshots:
       cheerio: 1.1.0
       cockatiel: 3.2.1
       commander: 12.1.0
-      form-data: 4.0.2
+      form-data: 4.0.6
       glob: 11.0.2
       hosted-git-info: 4.1.0
       jsonc-parser: 3.3.1
@@ -7116,14 +7101,6 @@ snapshots:
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
-
-  axios@1.9.0:
-    dependencies:
-      follow-redirects: 1.15.9
-      form-data: 4.0.2
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
 
   azure-devops-node-api@12.5.0:
     dependencies:
@@ -7926,11 +7903,12 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  form-data@4.0.2:
+  form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
       mime-types: 2.1.35
 
   formdata-polyfill@4.0.10:
@@ -9073,8 +9051,6 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
-
-  proxy-from-env@1.1.0: {}
 
   pump@3.0.2:
     dependencies:

--- a/src/core/ClineAdapter.ts
+++ b/src/core/ClineAdapter.ts
@@ -1,14 +1,6 @@
-// import * as fs from "fs";
-// import * as os from "os";
-// import * as path from "path";
-// import * as vscode from "vscode";
-
-// import axios from "axios";
-import { logger } from "../utils/logger";
 import { ClineAPI } from "../types/cline";
+import { logger } from "../utils/logger";
 import { ExtensionBaseAdapter } from "./ExtensionBaseAdapter";
-
-// const ClineTestHost = "http://localhost:9876";
 
 export interface ClineTaskOptions {
   task?: string;
@@ -17,7 +9,7 @@ export interface ClineTaskOptions {
 
 /**
  * Dedicated adapter for Cline extension management
- * Handles Cline-specific logic including test mode setup and API interactions
+ * Handles Cline-specific API interactions
  */
 export class ClineAdapter extends ExtensionBaseAdapter<ClineAPI> {
   constructor() {
@@ -39,117 +31,6 @@ export class ClineAdapter extends ExtensionBaseAdapter<ClineAPI> {
   }
 
   /**
-   * Perform pre-activation setup
-   */
-  // protected async preActivation(): Promise<void> {
-  //   await this.enableTestMode();
-  // }
-
-  /**
-   * Perform post-activation setup
-   */
-  // protected async postActivation(): Promise<void> {
-  //   // Verify test mode is working
-  //   const isTestModeEnabled = await this.isTestModeEnabled();
-  //   if (isTestModeEnabled) {
-  //     logger.info("Cline extension activated with test mode enabled");
-  //   } else {
-  //     logger.warn(
-  //       "Cline test mode is not enabled. Please ensure localhost:9876 is running.",
-  //     );
-  //   }
-  // }
-
-  /**
-   * Enable Cline test mode by creating .tmp folder and evals.env file
-   */
-  // private async enableTestMode(): Promise<void> {
-  //   try {
-  //     let workspaceUri = vscode.workspace.workspaceFolders?.[0]?.uri;
-  //     let shouldOpenWorkspace = false;
-
-  //     if (!workspaceUri) {
-  //       workspaceUri = vscode.Uri.file(path.join(os.homedir(), ".tmp"));
-  //       shouldOpenWorkspace = true;
-  //     }
-
-  //     const evalsEnvPath = path.join(workspaceUri.fsPath, "evals.env");
-
-  //     // Create .tmp directory if it doesn't exist
-  //     if (!fs.existsSync(workspaceUri.fsPath)) {
-  //       fs.mkdirSync(workspaceUri.fsPath);
-  //       logger.info("Created .tmp directory for Cline test mode");
-  //     }
-
-  //     // Create empty evals.env file if it doesn't exist
-  //     if (!fs.existsSync(evalsEnvPath)) {
-  //       fs.writeFileSync(evalsEnvPath, "");
-  //       logger.info("Created evals.env file for Cline test mode");
-  //     }
-
-  //     if (shouldOpenWorkspace) {
-  //       await vscode.commands.executeCommand("vscode.openFolder", workspaceUri);
-  //     }
-  //   } catch (error) {
-  //     logger.error("Failed to enable Cline test mode:", error);
-  //     throw error;
-  //   }
-  // }
-
-  /**
-   * Disable Cline test mode by shutting down the server and removing .tmp folder
-   */
-  // private async disableTestMode(): Promise<void> {
-  //   try {
-  //     // First, try to shutdown the local server
-  //     await this.shutdownServer();
-
-  //     const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
-  //     if (!workspaceFolder) {
-  //       throw new Error("No workspace folder found");
-  //     }
-
-  //     const tmpDir = path.join(workspaceFolder.uri.fsPath, ".tmp");
-
-  //     if (fs.existsSync(tmpDir)) {
-  //       fs.rmSync(tmpDir, { recursive: true, force: true });
-  //       logger.info("Removed .tmp directory");
-  //     }
-  //   } catch (error) {
-  //     logger.error("Failed to disable Cline test mode:", error);
-  //     throw error;
-  //   }
-  // }
-
-  /**
-   * Shutdown the Cline test server by calling the /shutdown endpoint
-   */
-  // private async shutdownServer(): Promise<void> {
-  //   try {
-  //     await axios.post(`${ClineTestHost}/shutdown`);
-  //     logger.info("Cline test server shutdown request sent successfully");
-  //   } catch (error) {
-  //     logger.error("Cline test server shutdown failed:", JSON.stringify(error));
-  //   }
-  // }
-
-  /**
-   * Check if Cline test mode is enabled by testing if localhost:9876 is alive
-   */
-  // private async isTestModeEnabled(): Promise<boolean> {
-  //   logger.info(`Checking ${ClineTestHost} status for Cline test mode`);
-  //   try {
-  //     await axios.get(ClineTestHost);
-  //     return true;
-  //   } catch (error) {
-  //     if ((error as axios.AxiosError).code === "ECONNREFUSED") {
-  //       return false;
-  //     }
-  //     return true;
-  //   }
-  // }
-
-  /**
    * Start a new task
    */
   async startNewTask(options: ClineTaskOptions = {}): Promise<void> {
@@ -160,31 +41,6 @@ export class ClineAdapter extends ExtensionBaseAdapter<ClineAPI> {
     logger.info("Starting new Cline task");
     await this.api.startNewTask(options.task, options.images);
   }
-
-  /**
-   * Start a new task by HTTP request
-   */
-  // async startNewTaskInTestMode(task: string, apiKey?: string): Promise<string> {
-  //   if (!this.api) {
-  //     throw new Error("Cline API not available");
-  //   }
-
-  //   logger.info("Starting new Cline task in test mode");
-  //   await vscode.commands.executeCommand(
-  //     "workbench.view.extension.claude-dev-ActivityBar",
-  //   );
-
-  //   const response = await axios.post(`${ClineTestHost}/task`, {
-  //     task,
-  //     apiKey,
-  //   });
-  //   if (response.status !== 200) {
-  //     throw new Error(
-  //       `Failed to start task in test mode: ${response.statusText}`,
-  //     );
-  //   }
-  //   return response.data;
-  // }
 
   /**
    * Get custom instructions
@@ -213,9 +69,6 @@ export class ClineAdapter extends ExtensionBaseAdapter<ClineAPI> {
    */
   async dispose(): Promise<void> {
     this.api = undefined;
-    // if (this.isActive) {
-    //   await this.disableTestMode();
-    // }
     this.isActive = false;
   }
 }


### PR DESCRIPTION
## Summary

- update the transitive `form-data` resolution from 4.0.2 to 4.0.6 to address multipart boundary and CRLF injection vulnerabilities
- remove the unused `axios` runtime dependency and its orphaned lockfile entries
- delete the long-disabled Cline test-server implementation

Closes #237

## Test plan

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm run build-tests`
- [x] `pnpm run build`
- [x] `pnpm run lint`
- [x] `pnpm exec vscode-test --code-version 1.129.0`
- [x] `pnpm audit` reports no `form-data` or `axios` advisories

No changeset: this only affects development/publishing tooling and removes unused runtime code.
