### PR TITLE
fix(openai): recover downstream tool history mismatch

### DIFF
--- a/.changeset/calm-tools-recover.md
+++ b/.changeset/calm-tools-recover.md
@@ -1,0 +1,5 @@
+---
+"agent-maestro": patch
+---
+
+Recover Codex Responses sessions when Copilot rejects previously paired tool history after downstream truncation (#245). Agent Maestro retries once with historical tool calls and results preserved as ordinary context, and never retries after model output has started.

--- a/src/server/routes/openai/openaiResponsesRoutes.ts
+++ b/src/server/routes/openai/openaiResponsesRoutes.ts
@@ -33,12 +33,14 @@ import {
   closeMessageOutputItem,
   convertResponsesInputToVSCode,
   customToolCallInput,
+  downgradeResponsesToolHistory,
   extractAdditionalTools,
   generateCustomToolCallId,
   generateFunctionCallId,
   generateMessageId,
   generateResponseId,
   getCurrentTimestamp,
+  isMissingToolCallOutputError,
   openMessageOutputItem,
   plaintextFunctionCallMetadata,
   writeCustomToolCallOutputItem,
@@ -369,13 +371,76 @@ export function registerOpenaiResponsesRoutes(
       }
 
       // 8. Send request to VSCode LM
-      const response = await requestLifecycle.waitFor(
-        client.sendRequest(
-          vsCodeMessages,
-          configuredRequestOptions,
-          cancellationToken,
-        ),
-      );
+      let recoveryUsed = false;
+      let activeMessages = vsCodeMessages;
+      const recoverToolHistory = async (
+        error: unknown,
+      ): Promise<vscode.LanguageModelChatResponse | undefined> => {
+        const recoveredMessages =
+          !recoveryUsed && isMissingToolCallOutputError(error)
+            ? downgradeResponsesToolHistory(activeMessages)
+            : undefined;
+        if (!recoveredMessages) {
+          return undefined;
+        }
+
+        recoveryUsed = true;
+        activeMessages = recoveredMessages;
+        lmChatMessages = recoveredMessages;
+        logger.warn(
+          "Responses downstream tool pairing failed; retrying once with historical tool calls and results converted to ordinary context",
+        );
+        return requestLifecycle!.waitFor(
+          client.sendRequest(
+            recoveredMessages,
+            configuredRequestOptions,
+            cancellationToken,
+          ),
+        );
+      };
+
+      let response: vscode.LanguageModelChatResponse;
+      try {
+        response = await requestLifecycle.waitFor(
+          client.sendRequest(
+            vsCodeMessages,
+            configuredRequestOptions,
+            cancellationToken,
+          ),
+        );
+      } catch (error) {
+        const recoveredResponse = await recoverToolHistory(error);
+        if (!recoveredResponse) {
+          throw error;
+        }
+        response = recoveredResponse;
+      }
+
+      const responseStream = async function* () {
+        let emittedModelPart = false;
+        try {
+          for await (const chunk of interruptibleLanguageModelStream(
+            response.stream,
+            requestLifecycle!,
+          )) {
+            emittedModelPart = true;
+            yield chunk;
+          }
+        } catch (error) {
+          const recoveredResponse = !emittedModelPart
+            ? await recoverToolHistory(error)
+            : undefined;
+          if (!recoveredResponse) {
+            throw error;
+          }
+          for await (const chunk of interruptibleLanguageModelStream(
+            recoveredResponse.stream,
+            requestLifecycle!,
+          )) {
+            yield chunk;
+          }
+        }
+      };
 
       // 9. Handle non-streaming response
       if (!stream) {
@@ -384,10 +449,7 @@ export function registerOpenaiResponsesRoutes(
           [];
         let responseUsage: ResponseUsage | undefined;
 
-        for await (const chunk of interruptibleLanguageModelStream(
-          response.stream,
-          requestLifecycle,
-        )) {
+        for await (const chunk of responseStream()) {
           if (chunk instanceof vscode.LanguageModelTextPart) {
             accumulatedText += chunk.value;
           } else if (chunk instanceof vscode.LanguageModelToolCallPart) {
@@ -517,10 +579,7 @@ export function registerOpenaiResponsesRoutes(
           let responseUsage: ResponseUsage | undefined;
 
           for await (const chunk of withSseHeartbeat(
-            interruptibleLanguageModelStream(
-              response.stream,
-              requestLifecycle!,
-            ),
+            responseStream(),
             options.heartbeatIntervalMs,
           )) {
             if (chunk === SSE_HEARTBEAT) {

--- a/src/server/utils/openaiResponses.ts
+++ b/src/server/utils/openaiResponses.ts
@@ -831,6 +831,66 @@ export const convertResponsesInputToVSCode = (
   return messages;
 };
 
+export function isMissingToolCallOutputError(error: unknown): boolean {
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === "string"
+        ? error
+        : JSON.stringify(error);
+  return /No tool call found for function call output with call_id\b/i.test(
+    message ?? "",
+  );
+}
+
+export function downgradeResponsesToolHistory(
+  messages: readonly vscode.LanguageModelChatMessage[],
+): vscode.LanguageModelChatMessage[] | undefined {
+  let changed = false;
+  const downgraded = messages.map((message) => {
+    const content: vscode.LanguageModelInputPart[] = [];
+    for (const part of message.content) {
+      if (part instanceof vscode.LanguageModelToolCallPart) {
+        changed = true;
+        content.push(
+          new vscode.LanguageModelTextPart(
+            `[Historical tool call ${part.name} (${part.callId})]\n${JSON.stringify(part.input)}`,
+          ),
+        );
+        continue;
+      }
+
+      if (part instanceof vscode.LanguageModelToolResultPart) {
+        changed = true;
+        content.push(
+          new vscode.LanguageModelTextPart(
+            `[Historical tool result (${part.callId})]`,
+          ),
+        );
+        for (const resultPart of part.content) {
+          content.push(
+            resultPart instanceof vscode.LanguageModelTextPart ||
+              resultPart instanceof vscode.LanguageModelDataPart
+              ? resultPart
+              : new vscode.LanguageModelTextPart(
+                  JSON.stringify(resultPart) ?? String(resultPart),
+                ),
+          );
+        }
+        continue;
+      }
+
+      content.push(part);
+    }
+    return new vscode.LanguageModelChatMessage(
+      message.role,
+      content,
+      message.name,
+    );
+  });
+  return changed ? downgraded : undefined;
+}
+
 /**
  * Convert Responses API tools to VSCode LM tools.
  *

--- a/src/test/server/languageModelRequestLifecycle.test.ts
+++ b/src/test/server/languageModelRequestLifecycle.test.ts
@@ -383,6 +383,246 @@ suite("LanguageModelRequestLifecycle Test Suite", () => {
     assert.strictEqual(cancellationObserved, true);
   });
 
+  test("retries Responses once with tool history downgraded after a downstream pairing error", async () => {
+    const capturedRequests: Array<readonly vscode.LanguageModelChatMessage[]> =
+      [];
+    const model = {
+      id: "gpt-5.6-test",
+      name: "GPT 5.6 Test",
+      family: "gpt-5.6",
+      version: "test",
+      vendor: "copilot",
+      maxInputTokens: 200000,
+      capabilities: { supportsImageToText: true, supportsToolCalling: true },
+      sendRequest: async (
+        messages: readonly vscode.LanguageModelChatMessage[],
+      ) => {
+        capturedRequests.push(messages);
+        if (capturedRequests.length === 1) {
+          throw new Error(
+            "Request Failed: 400 No tool call found for function call output with call_id call_exec_1.",
+          );
+        }
+        return {
+          stream: (async function* () {
+            yield new vscode.LanguageModelTextPart("recovered");
+          })(),
+          text: (async function* () {
+            yield "recovered";
+          })(),
+        };
+      },
+      countTokens: async () => 1,
+    } as unknown as vscode.LanguageModelChat;
+    const app = createOpenaiResponsesTestApp(model);
+
+    const response = await app.request("/v1/responses", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-5.6-test",
+        input: [
+          {
+            type: "custom_tool_call",
+            id: "ctc_exec_1",
+            call_id: "call_exec_1",
+            name: "exec",
+            input: "git status",
+          },
+          {
+            type: "custom_tool_call_output",
+            call_id: "call_exec_1",
+            output: "working tree clean",
+          },
+        ],
+      }),
+    });
+
+    assert.strictEqual(response.status, 200);
+    assert.strictEqual(capturedRequests.length, 2);
+    assert.ok(
+      capturedRequests[0]
+        .flatMap((message) => message.content)
+        .some((part) => part instanceof vscode.LanguageModelToolCallPart),
+    );
+    const recoveredParts = capturedRequests[1].flatMap(
+      (message) => message.content,
+    );
+    assert.ok(
+      recoveredParts.every(
+        (part) =>
+          !(part instanceof vscode.LanguageModelToolCallPart) &&
+          !(part instanceof vscode.LanguageModelToolResultPart),
+      ),
+    );
+    assert.match(
+      recoveredParts
+        .filter((part) => part instanceof vscode.LanguageModelTextPart)
+        .map((part) => part.value)
+        .join("\n"),
+      /git status[\s\S]*working tree clean/,
+    );
+  });
+
+  test("retries Responses when downstream pairing fails before the first stream chunk", async () => {
+    const capturedRequests: Array<readonly vscode.LanguageModelChatMessage[]> =
+      [];
+    const model = {
+      id: "gpt-5.6-test",
+      name: "GPT 5.6 Test",
+      family: "gpt-5.6",
+      version: "test",
+      vendor: "copilot",
+      maxInputTokens: 200000,
+      capabilities: { supportsImageToText: true, supportsToolCalling: true },
+      sendRequest: async (
+        messages: readonly vscode.LanguageModelChatMessage[],
+      ) => {
+        capturedRequests.push(messages);
+        const requestNumber = capturedRequests.length;
+        return {
+          stream: (async function* () {
+            if (requestNumber === 1) {
+              throw new Error(
+                "No tool call found for function call output with call_id call_exec_1.",
+              );
+            }
+            yield new vscode.LanguageModelTextPart("recovered");
+          })(),
+          text: (async function* () {})(),
+        };
+      },
+      countTokens: async () => 1,
+    } as unknown as vscode.LanguageModelChat;
+    const app = createOpenaiResponsesTestApp(model);
+
+    const response = await app.request("/v1/responses", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-5.6-test",
+        stream: true,
+        input: [
+          {
+            type: "custom_tool_call",
+            id: "ctc_exec_1",
+            call_id: "call_exec_1",
+            name: "exec",
+            input: "git status",
+          },
+          {
+            type: "custom_tool_call_output",
+            call_id: "call_exec_1",
+            output: "working tree clean",
+          },
+        ],
+      }),
+    });
+    const body = await response.text();
+
+    assert.strictEqual(response.status, 200);
+    assert.strictEqual(capturedRequests.length, 2);
+    assert.ok(body.includes("recovered"));
+    assert.ok(body.includes("response.completed"));
+    assert.ok(!body.includes("response.failed"));
+  });
+
+  test("does not retry a downstream pairing error after model output starts", async () => {
+    let requestCount = 0;
+    const model = {
+      id: "gpt-5.6-test",
+      name: "GPT 5.6 Test",
+      family: "gpt-5.6",
+      version: "test",
+      vendor: "copilot",
+      maxInputTokens: 200000,
+      capabilities: { supportsImageToText: true, supportsToolCalling: true },
+      sendRequest: async () => {
+        requestCount++;
+        return {
+          stream: (async function* () {
+            yield new vscode.LanguageModelTextPart("partial");
+            throw new Error(
+              "No tool call found for function call output with call_id call_exec_1.",
+            );
+          })(),
+          text: (async function* () {})(),
+        };
+      },
+      countTokens: async () => 1,
+    } as unknown as vscode.LanguageModelChat;
+    const app = createOpenaiResponsesTestApp(model);
+
+    const response = await app.request("/v1/responses", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-5.6-test",
+        stream: true,
+        input: [
+          {
+            type: "custom_tool_call",
+            id: "ctc_exec_1",
+            call_id: "call_exec_1",
+            name: "exec",
+            input: "git status",
+          },
+          {
+            type: "custom_tool_call_output",
+            call_id: "call_exec_1",
+            output: "working tree clean",
+          },
+        ],
+      }),
+    });
+    const body = await response.text();
+
+    assert.strictEqual(response.status, 200);
+    assert.strictEqual(requestCount, 1);
+    assert.ok(body.includes("partial"));
+    assert.ok(body.includes("response.failed"));
+    assert.ok(!body.includes("response.completed"));
+  });
+
+  test("attempts downstream tool-history recovery only once", async () => {
+    let requestCount = 0;
+    const model = {
+      ...createSuccessfulModel(() => {}),
+      sendRequest: async () => {
+        requestCount++;
+        throw new Error(
+          "No tool call found for function call output with call_id call_exec_1.",
+        );
+      },
+    } as unknown as vscode.LanguageModelChat;
+    const app = createOpenaiResponsesTestApp(model);
+
+    const response = await app.request("/v1/responses", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "test-model",
+        input: [
+          {
+            type: "function_call",
+            id: "fc_exec_1",
+            call_id: "call_exec_1",
+            name: "exec",
+            arguments: "{}",
+          },
+          {
+            type: "function_call_output",
+            call_id: "call_exec_1",
+            output: "done",
+          },
+        ],
+      }),
+    });
+
+    assert.strictEqual(response.status, 500);
+    assert.strictEqual(requestCount, 2);
+  });
+
   test("passes tool-output images to Responses models as DataPart", async () => {
     let capturedMessages: readonly vscode.LanguageModelChatMessage[] = [];
     const model = {


### PR DESCRIPTION
## Summary

- recover Codex Responses sessions when Copilot rejects a correctly paired historical tool result downstream
- retry once with historical tool calls and results preserved as ordinary text/data context
- handle both direct `sendRequest()` rejection and failure before the first model stream chunk
- never retry after model output starts or after one recovery attempt

This is a follow-up to #235/#236. The existing pairing tracker correctly handles malformed incoming history; this change covers a valid pair that is rejected only after conversion and downstream replay/truncation.

Closes #245

## Test plan

- [x] direct downstream pairing rejection recovers
- [x] pre-first-chunk stream rejection recovers
- [x] post-output rejection does not retry
- [x] failed recovery is attempted only once
- [x] `corepack pnpm check-types`
- [x] `corepack pnpm lint`
- [x] production build (`node esbuild.js --production`)
- [x] full VS Code extension-host suite (`459 passing`)
- [x] `git diff --check`

## Privacy

The regression tests use synthetic tool IDs and content. No private conversation transcript or proprietary task data is included.
