### PR TITLE
fix(openai): preserve parallel tool replay

### DIFF
--- a/.changeset/quick-tools-replay.md
+++ b/.changeset/quick-tools-replay.md
@@ -1,0 +1,5 @@
+---
+"agent-maestro": patch
+---
+
+fix(openai): preserve parallel tool-call turns when replaying Responses history

--- a/src/server/utils/openaiResponses.ts
+++ b/src/server/utils/openaiResponses.ts
@@ -785,6 +785,48 @@ const invalidToolCallToVSCodeMessage = (
     ),
   ]);
 
+type ToolCallMessage = vscode.LanguageModelChatMessage & {
+  content: vscode.LanguageModelToolCallPart[];
+};
+
+type ToolResultMessage = vscode.LanguageModelChatMessage & {
+  content: vscode.LanguageModelToolResultPart[];
+};
+
+const isToolCallMessage = (
+  message: vscode.LanguageModelChatMessage,
+): message is ToolCallMessage =>
+  message.role === vscode.LanguageModelChatMessageRole.Assistant &&
+  message.content.length > 0 &&
+  message.content.every(
+    (part) => part instanceof vscode.LanguageModelToolCallPart,
+  );
+
+const isToolResultMessage = (
+  message: vscode.LanguageModelChatMessage,
+): message is ToolResultMessage =>
+  message.role === vscode.LanguageModelChatMessageRole.User &&
+  message.content.length > 0 &&
+  message.content.every(
+    (part) => part instanceof vscode.LanguageModelToolResultPart,
+  );
+
+const appendResponsesMessage = (
+  messages: vscode.LanguageModelChatMessage[],
+  message: vscode.LanguageModelChatMessage,
+): void => {
+  const previous = messages.at(-1);
+  if (
+    previous &&
+    ((isToolCallMessage(previous) && isToolCallMessage(message)) ||
+      (isToolResultMessage(previous) && isToolResultMessage(message)))
+  ) {
+    previous.content.push(...message.content);
+    return;
+  }
+  messages.push(message);
+};
+
 /**
  * Convert Responses API input to VSCode LM messages
  */
@@ -806,7 +848,7 @@ export const convertResponsesInputToVSCode = (
       for (const item of instruction) {
         const converted = convertResponsesItemWithPairing(item, pairing);
         if (converted) {
-          messages.push(converted);
+          appendResponsesMessage(messages, converted);
         }
       }
     }
@@ -819,7 +861,7 @@ export const convertResponsesInputToVSCode = (
     for (const item of input) {
       const converted = convertResponsesItemWithPairing(item, pairing);
       if (converted) {
-        messages.push(converted);
+        appendResponsesMessage(messages, converted);
       }
     }
   }

--- a/src/server/utils/openaiResponses.ts
+++ b/src/server/utils/openaiResponses.ts
@@ -814,9 +814,11 @@ const isToolResultMessage = (
 const appendResponsesMessage = (
   messages: vscode.LanguageModelChatMessage[],
   message: vscode.LanguageModelChatMessage,
+  mergeStartIndex = 0,
 ): void => {
   const previous = messages.at(-1);
   if (
+    messages.length > mergeStartIndex &&
     previous &&
     ((isToolCallMessage(previous) && isToolCallMessage(message)) ||
       (isToolResultMessage(previous) && isToolResultMessage(message)))
@@ -854,6 +856,8 @@ export const convertResponsesInputToVSCode = (
     }
   }
 
+  const inputMessageStart = messages.length;
+
   // Handle string input
   if (typeof input === "string") {
     messages.push(vscode.LanguageModelChatMessage.User(input));
@@ -861,7 +865,7 @@ export const convertResponsesInputToVSCode = (
     for (const item of input) {
       const converted = convertResponsesItemWithPairing(item, pairing);
       if (converted) {
-        appendResponsesMessage(messages, converted);
+        appendResponsesMessage(messages, converted, inputMessageStart);
       }
     }
   }

--- a/src/test/server/openaiResponses.test.ts
+++ b/src/test/server/openaiResponses.test.ts
@@ -446,6 +446,16 @@ suite("OpenAI Responses Conversion Utils Test Suite", () => {
   });
 
   suite("convertResponsesInputToVSCode", () => {
+    const toolCallParts = (
+      message: vscode.LanguageModelChatMessage,
+    ): vscode.LanguageModelToolCallPart[] =>
+      message.content as vscode.LanguageModelToolCallPart[];
+
+    const toolResultParts = (
+      message: vscode.LanguageModelChatMessage,
+    ): vscode.LanguageModelToolResultPart[] =>
+      message.content as vscode.LanguageModelToolResultPart[];
+
     test("should handle string input", () => {
       const result = convertResponsesInputToVSCode("Hello world");
       assert.strictEqual(result.length, 1);
@@ -595,8 +605,12 @@ suite("OpenAI Responses Conversion Utils Test Suite", () => {
           },
         ] as any);
 
-        assert.strictEqual(result.length, 5);
-        const orphanedParts = result[2].content;
+        assert.strictEqual(result.length, 3);
+        assert.deepStrictEqual(
+          toolCallParts(result[0]).map((part) => part.callId),
+          ["call_known", "call_custom"],
+        );
+        const orphanedParts = result[1].content;
         assert.ok(orphanedParts[0] instanceof vscode.LanguageModelTextPart);
         assert.match(
           (orphanedParts[0] as vscode.LanguageModelTextPart).value,
@@ -669,6 +683,179 @@ suite("OpenAI Responses Conversion Utils Test Suite", () => {
       } finally {
         logger.warn = originalWarn;
       }
+    });
+
+    test("should preserve a single custom tool call and output as paired turns", () => {
+      const input = [
+        {
+          type: "custom_tool_call" as const,
+          id: "ctc_1",
+          call_id: "call_1",
+          name: "exec",
+          input: "pwd",
+        },
+        {
+          type: "custom_tool_call_output" as const,
+          call_id: "call_1",
+          output: "/workspace",
+        },
+      ];
+
+      const result = convertResponsesInputToVSCode(input);
+
+      assert.strictEqual(result.length, 2);
+      assert.deepStrictEqual(
+        toolCallParts(result[0]).map((part) => part.callId),
+        ["call_1"],
+      );
+      assert.deepStrictEqual(
+        toolResultParts(result[1]).map((part) => part.callId),
+        ["call_1"],
+      );
+    });
+
+    test("should group parallel custom tool calls and outputs into paired turns", () => {
+      const calls = Array.from({ length: 4 }, (_, index) => ({
+        type: "custom_tool_call" as const,
+        id: `ctc_${index}`,
+        call_id: `call_${index}`,
+        name: "exec",
+        input: `command ${index}`,
+      }));
+      const outputs = Array.from({ length: 4 }, (_, index) => ({
+        type: "custom_tool_call_output" as const,
+        call_id: `call_${index}`,
+        output: `result ${index}`,
+      }));
+
+      const result = convertResponsesInputToVSCode([...calls, ...outputs]);
+
+      assert.strictEqual(result.length, 2);
+      assert.strictEqual(
+        result[0].role,
+        vscode.LanguageModelChatMessageRole.Assistant,
+      );
+      assert.deepStrictEqual(
+        toolCallParts(result[0]).map((part) => part.callId),
+        ["call_0", "call_1", "call_2", "call_3"],
+      );
+      assert.strictEqual(
+        result[1].role,
+        vscode.LanguageModelChatMessageRole.User,
+      );
+      assert.deepStrictEqual(
+        toolResultParts(result[1]).map((part) => part.callId),
+        ["call_0", "call_1", "call_2", "call_3"],
+      );
+    });
+
+    test("should group parallel function calls and outputs into paired turns", () => {
+      const input = [
+        {
+          type: "function_call" as const,
+          id: "fc_1",
+          call_id: "call_weather",
+          name: "get_weather",
+          arguments: '{"city":"Seattle"}',
+          status: "completed" as const,
+        },
+        {
+          type: "function_call" as const,
+          id: "fc_2",
+          call_id: "call_time",
+          name: "get_time",
+          arguments: '{"timezone":"UTC"}',
+          status: "completed" as const,
+        },
+        {
+          type: "function_call_output" as const,
+          call_id: "call_weather",
+          output: "rainy",
+        },
+        {
+          type: "function_call_output" as const,
+          call_id: "call_time",
+          output: "12:00",
+        },
+      ];
+
+      const result = convertResponsesInputToVSCode(input);
+
+      assert.strictEqual(result.length, 2);
+      assert.deepStrictEqual(
+        toolCallParts(result[0]).map((part) => part.callId),
+        ["call_weather", "call_time"],
+      );
+      assert.deepStrictEqual(
+        toolResultParts(result[1]).map((part) => part.callId),
+        ["call_weather", "call_time"],
+      );
+    });
+
+    test("should only group compatible tool turns across mixed input boundaries", () => {
+      const input = [
+        { role: "user" as const, content: "Run both tools" },
+        {
+          type: "function_call" as const,
+          id: "fc_1",
+          call_id: "call_function",
+          namespace: "utilities",
+          name: "lookup",
+          arguments: "{}",
+          status: "completed" as const,
+        },
+        {
+          type: "additional_tools" as const,
+          role: "developer" as const,
+          tools: [{ type: "custom" as const, name: "exec" }],
+        },
+        {
+          type: "custom_tool_call" as const,
+          id: "ctc_1",
+          call_id: "call_custom",
+          name: "exec",
+          input: "pwd",
+        },
+        {
+          type: "function_call_output" as const,
+          call_id: "call_function",
+          output: "found",
+        },
+        {
+          type: "custom_tool_call_output" as const,
+          call_id: "call_custom",
+          output: "/workspace",
+        },
+        { role: "assistant" as const, content: "Both tools completed" },
+        { role: "user" as const, content: "Thanks" },
+      ];
+
+      const result = convertResponsesInputToVSCode(input as any);
+
+      assert.strictEqual(result.length, 5);
+      assert.strictEqual(
+        result[0].role,
+        vscode.LanguageModelChatMessageRole.User,
+      );
+      assert.deepStrictEqual(
+        toolCallParts(result[1]).map((part) => [part.callId, part.name]),
+        [
+          ["call_function", "utilities__lookup"],
+          ["call_custom", "exec"],
+        ],
+      );
+      assert.deepStrictEqual(
+        toolResultParts(result[2]).map((part) => part.callId),
+        ["call_function", "call_custom"],
+      );
+      assert.strictEqual(
+        result[3].role,
+        vscode.LanguageModelChatMessageRole.Assistant,
+      );
+      assert.strictEqual(
+        result[4].role,
+        vscode.LanguageModelChatMessageRole.User,
+      );
     });
   });
 

--- a/src/test/server/openaiResponses.test.ts
+++ b/src/test/server/openaiResponses.test.ts
@@ -857,6 +857,39 @@ suite("OpenAI Responses Conversion Utils Test Suite", () => {
         vscode.LanguageModelChatMessageRole.User,
       );
     });
+
+    test("should not group tool calls across instruction and input", () => {
+      const instruction = [
+        {
+          type: "custom_tool_call" as const,
+          id: "ctc_instruction",
+          call_id: "call_instruction",
+          name: "exec",
+          input: "first",
+        },
+      ];
+      const input = [
+        {
+          type: "custom_tool_call" as const,
+          id: "ctc_input",
+          call_id: "call_input",
+          name: "exec",
+          input: "second",
+        },
+      ];
+
+      const result = convertResponsesInputToVSCode(input, instruction);
+
+      assert.strictEqual(result.length, 2);
+      assert.deepStrictEqual(
+        toolCallParts(result[0]).map((part) => part.callId),
+        ["call_instruction"],
+      );
+      assert.deepStrictEqual(
+        toolCallParts(result[1]).map((part) => part.callId),
+        ["call_input"],
+      );
+    });
   });
 
   suite("convertResponsesToolsToVSCode", () => {


### PR DESCRIPTION
## Summary

- group consecutive Responses function/custom tool calls into one VS Code Assistant turn
- group consecutive paired tool outputs into one User turn while preserving ordinary message and top-level field boundaries
- retain namespace, `additional_tools`, image output, and malformed-history recovery behavior

## Impact

This bug can make an existing Codex session persistently unusable after it performs parallel tool calls through the OpenAI Responses API.

A valid history can contain several consecutive `custom_tool_call` items followed by their consecutive `custom_tool_call_output` items. Agent Maestro previously converted every item into a separate VS Code chat message. For four parallel calls and four outputs, the valid two-turn exchange became eight separate turns.

When Copilot replays that malformed turn structure, the first result may be accepted but a later result is rejected with:

```text
No tool call found for function call output with call_id ...
```

The original rollout still contains both the call and its matching output, so the error is misleading. Once this exchange is stored in the thread, every subsequent request replays the same malformed history and fails at the same output. Restarting or retrying does not recover the thread; the user must abandon or fork the affected session from an earlier healthy turn.

## Root cause

VS Code represents one parallel tool invocation turn as a single Assistant `LanguageModelChatMessage` containing multiple `LanguageModelToolCallPart`s. Its results belong in a single User message containing the matching `LanguageModelToolResultPart`s.

`convertResponsesItemToVSCode` correctly produced each individual part, but `convertResponsesInputToVSCode` appended every converted item as a new message. This preserved each `call_id` in isolation while losing the parallel turn boundary required by the VS Code LM/Copilot replay path.

The fix only combines adjacent messages whose content consists entirely of compatible tool-call parts or tool-result parts. Ordinary messages and malformed-history recovery output remain boundaries, and the optional array-form instruction compatibility path cannot merge into the separate input field.

Unlike #246, this does not retry requests or downgrade structured tool history based on a downstream error string. It corrects the transcript before it crosses Agent Maestro's conversion boundary.

Related to #245

## Test plan

- [x] single custom tool call and output
- [x] four parallel custom tool calls and outputs
- [x] parallel function calls and outputs
- [x] mixed ordinary messages, namespace tools, and `additional_tools` boundaries
- [x] no merging across array-form instruction and input fields
- [x] OpenAI Responses utility suite (`95 passing`)
- [x] `pnpm check-types`
- [x] `pnpm lint`
- [x] `git diff --check`

## Changeset

- `.changeset/quick-tools-replay.md`