### PR TITLE
fix(gemini): keep SSE heartbeats invisible to SDK consumers

### DIFF
--- a/.changeset/dry-sheep-stick.md
+++ b/.changeset/dry-sheep-stick.md
@@ -1,0 +1,5 @@
+---
+"agent-maestro": patch
+---
+
+fix(gemini): prevent CLI stream parsing failures during long-running requests by sending SDK-compatible heartbeats

--- a/README.md
+++ b/README.md
@@ -389,6 +389,8 @@ Perfect for Gemini CLI integration:
 - **`POST /api/gemini/v1beta/models/{model}:streamGenerateContent`** - Streaming support for Gemini API
 - **`POST /api/gemini/v1beta/models/{model}:countTokens`** - Token counting for Gemini-compatible messages
 
+Streaming responses send blank-line heartbeats while waiting for the model, keeping long-running requests alive without interrupting Gemini CLI or Google Gen AI SDK stream parsing. These heartbeats do not produce extra response chunks or affect generated content and token usage.
+
 > **Thinking levels**: Not forwarded for Gemini. Copilot's Gemini path does not read the `thinkingConfig.thinkingLevel` parameter from the model configuration; it only applies a hardcoded `low` effort behind an internal experiment flag, so any forwarded value would be ignored.
 
 ### RooCode Agent Routes

--- a/docs/2026-08-11-sse-heartbeats.md
+++ b/docs/2026-08-11-sse-heartbeats.md
@@ -21,10 +21,14 @@ seconds. Routes handle that marker using their protocol's wire format:
 | ---------------------------- | ------------------------------------ |
 | Anthropic Messages           | `event: ping` with `{"type":"ping"}` |
 | OpenAI Chat/Responses        | SSE comment `: keep-alive`           |
-| Gemini streamGenerateContent | SSE comment `: keep-alive`           |
+| Gemini streamGenerateContent | Blank line `\n`                      |
 
-SSE comments produce network traffic but are ignored by compliant parsers, so
-they do not introduce non-JSON data events into OpenAI or Gemini streams.
+OpenAI streams use SSE comments, which produce network traffic without
+introducing data events. The Google Gen AI SDK parser stalls on comment frames
+and reports `Incomplete JSON segment at the end`. Gemini therefore sends blank
+lines, which the SDK accepts as whitespace before the next `data:` frame. Unlike
+`data: {}`, blank lines do not yield extra response chunks or trigger additional
+per-chunk processing such as Gemini CLI `AfterModel` hooks.
 
 The helper does not own a background interval and never calls `next()`
 concurrently. Heartbeats and model chunks are therefore written in order.
@@ -37,4 +41,7 @@ cancels its VS Code LM request.
 
 Unit tests cover repeated heartbeats during a stalled `next()`, normal chunk
 ordering, and timer cleanup. Route tests verify the Anthropic ping frame and the
-OpenAI/Gemini comment frame.
+OpenAI comment frame. Gemini tests verify that an HTTP client receives blank-line
+heartbeats before the model responds and that the real Google Gen AI SDK ignores
+those heartbeats while preserving text, tool calls, completion status, and token
+usage. Timeout and client-disconnect tests verify upstream cancellation.

--- a/src/server/routes/geminiRoutes.ts
+++ b/src/server/routes/geminiRoutes.ts
@@ -538,9 +538,8 @@ export function registerGeminiRoutes(
               options.heartbeatIntervalMs,
             )) {
               if (chunk === SSE_HEARTBEAT) {
-                await requestLifecycle!.waitFor(
-                  stream.write(": keep-alive\n\n"),
-                );
+                // The Google Gen AI SDK ignores blank lines but stalls on SSE comments.
+                await requestLifecycle!.waitFor(stream.write("\n"));
                 continue;
               }
 

--- a/src/test/server/sseHeartbeat.test.ts
+++ b/src/test/server/sseHeartbeat.test.ts
@@ -1,5 +1,9 @@
+import { FinishReason, GoogleGenAI } from "@google/genai";
+import { getRequestListener } from "@hono/node-server";
 import { OpenAPIHono } from "@hono/zod-openapi";
 import * as assert from "assert";
+import { once } from "node:events";
+import { createServer } from "node:http";
 import * as vscode from "vscode";
 
 import { registerAnthropicRoutes } from "../../server/routes/anthropicRoutes";
@@ -194,29 +198,173 @@ suite("SSE Heartbeat Test Suite", () => {
     assert.ok(body.includes("event: response.completed"));
   });
 
-  test("writes SSE comments for Gemini streamGenerateContent", async () => {
+  test("delivers blank-line Gemini heartbeats before the model responds", async () => {
+    let releaseModel!: () => void;
+    const modelReady = new Promise<void>((resolve) => {
+      releaseModel = resolve;
+    });
     const app = new OpenAPIHono();
     registerGeminiRoutes(app, {
       heartbeatIntervalMs,
+      requestTimeoutMs: 1000,
       resolveChatModelClient: async () => ({
-        client: createDelayedModel(),
+        client: {
+          ...createDelayedModel(),
+          sendRequest: async () => ({
+            stream: (async function* () {
+              await modelReady;
+              yield new vscode.LanguageModelTextPart("Hello");
+            })(),
+            text: (async function* () {})(),
+          }),
+        },
       }),
     });
+    const server = createServer(getRequestListener(app.fetch));
+    server.listen(0, "127.0.0.1");
 
-    const response = await app.request(
-      "/v1beta/models/claude-opus-test:streamGenerateContent",
-      {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({
-          contents: [{ role: "user", parts: [{ text: "Hello" }] }],
-        }),
-      },
+    try {
+      await once(server, "listening");
+      const address = server.address();
+      assert.ok(address && typeof address !== "string");
+      const response = await fetch(
+        `http://127.0.0.1:${address.port}/v1beta/models/claude-opus-test:streamGenerateContent`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            contents: [{ role: "user", parts: [{ text: "Hello" }] }],
+          }),
+          signal: AbortSignal.timeout(2000),
+        },
+      );
+      const reader = response.body!.getReader();
+      const decoder = new TextDecoder();
+      let body = "";
+      for (let index = 0; index < 2; index++) {
+        const heartbeat = await reader.read();
+        assert.strictEqual(heartbeat.done, false);
+        const text = decoder.decode(heartbeat.value);
+        assert.match(text, /^\n+$/);
+        body += text;
+      }
+      releaseModel();
+      while (true) {
+        const chunk = await reader.read();
+        if (chunk.done) {
+          break;
+        }
+        body += decoder.decode(chunk.value, { stream: true });
+      }
+
+      assert.strictEqual(response.status, 200);
+      assert.ok(!body.includes(": keep-alive"));
+      assert.ok(!body.includes("data: {}"));
+      assert.ok(body.includes('"text":"Hello"'));
+      assert.ok(body.includes('"finishReason":"STOP"'));
+    } finally {
+      releaseModel();
+      server.closeAllConnections();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+
+  test("Google Gen AI SDK ignores Gemini heartbeats and preserves text, tools, and usage", async () => {
+    const app = new OpenAPIHono();
+    const toolCall = new vscode.LanguageModelToolCallPart(
+      "write-report",
+      "write_file",
+      { file_path: "tmp/report.md", content: '# 调研\n\n"quoted" text' },
     );
-    const body = await response.text();
+    const tokenInputs: unknown[] = [];
+    registerGeminiRoutes(app, {
+      heartbeatIntervalMs,
+      requestTimeoutMs: 1000,
+      resolveChatModelClient: async () => ({
+        client: {
+          ...createDelayedModel(),
+          sendRequest: async () => ({
+            stream: (async function* () {
+              await new Promise((resolve) => setTimeout(resolve, 25));
+              yield new vscode.LanguageModelTextPart("Hello");
+              await new Promise((resolve) => setTimeout(resolve, 25));
+              yield toolCall;
+              await new Promise((resolve) => setTimeout(resolve, 25));
+            })(),
+            text: (async function* () {})(),
+          }),
+          countTokens: async (input) => {
+            tokenInputs.push(input);
+            return 1;
+          },
+        },
+      }),
+    });
+    const server = createServer(getRequestListener(app.fetch));
+    server.listen(0, "127.0.0.1");
 
-    assert.ok(body.includes(": keep-alive\n\n"));
-    assert.ok(body.includes('"finishReason":"STOP"'));
+    try {
+      await once(server, "listening");
+      const address = server.address();
+      assert.ok(address && typeof address !== "string");
+      const sdk = new GoogleGenAI({
+        apiKey: "test-key",
+        vertexai: false,
+        httpOptions: {
+          baseUrl: `http://127.0.0.1:${address.port}`,
+          apiVersion: "v1beta",
+          timeout: 1000,
+        },
+      });
+      const stream = await sdk.models.generateContentStream({
+        model: "claude-opus-test",
+        contents: "Hello",
+      });
+      const chunks = [];
+      for await (const chunk of stream) {
+        chunks.push(chunk);
+      }
+
+      assert.strictEqual(
+        chunks.length,
+        3,
+        "Heartbeats must not yield SDK responses",
+      );
+      assert.strictEqual(chunks[0].text, "Hello");
+      assert.strictEqual(chunks[1].functionCalls?.length, 1);
+      assert.strictEqual(
+        chunks.map((chunk) => chunk.text ?? "").join(""),
+        "Hello",
+      );
+      assert.deepStrictEqual(
+        chunks.flatMap((chunk) => chunk.functionCalls ?? []),
+        [{ id: toolCall.callId, name: toolCall.name, args: toolCall.input }],
+      );
+      const finalChunk = chunks.at(-1)!;
+      assert.deepStrictEqual(finalChunk.candidates, [
+        { finishReason: FinishReason.STOP, index: 0 },
+      ]);
+      assert.deepStrictEqual(finalChunk.usageMetadata, {
+        cachedContentTokenCount: 0,
+        candidatesTokenCount: 1,
+        promptTokenCount: 1,
+        thoughtsTokenCount: 0,
+        totalTokenCount: 2,
+      });
+      assert.strictEqual(
+        chunks.filter((chunk) => chunk.usageMetadata).length,
+        1,
+      );
+      assert.strictEqual(tokenInputs.length, 2);
+      assert.strictEqual(tokenInputs[1], `Hello${JSON.stringify(toolCall)}`);
+    } finally {
+      server.closeAllConnections();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
   });
 
   test("cancels a stalled Gemini stream when its total timeout expires", async () => {

--- a/src/test/server/sseHeartbeat.test.ts
+++ b/src/test/server/sseHeartbeat.test.ts
@@ -241,7 +241,7 @@ suite("SSE Heartbeat Test Suite", () => {
       const reader = response.body!.getReader();
       const decoder = new TextDecoder();
       let body = "";
-      for (let index = 0; index < 2; index++) {
+      while (body.length < 2) {
         const heartbeat = await reader.read();
         assert.strictEqual(heartbeat.done, false);
         const text = decoder.decode(heartbeat.value);


### PR DESCRIPTION
## Summary

Gemini CLI and the Google Gen AI SDK fail with `Incomplete JSON segment at the end` when a long-running response includes an SSE comment heartbeat. Send blank-line heartbeats instead, keeping the connection active without yielding synthetic model-response chunks or triggering extra per-chunk hooks.

Add HTTP and real SDK regression coverage for heartbeat delivery, text/tool-call integrity, completion and usage; update the README. Includes patch changeset `.changeset/dry-sheep-stick.md`.

## Test plan

- [x] Type-check, ESLint, build, Prettier and `git diff --check`.
- [x] Full suite: 512 passing, using a temporary test configuration selecting installed VS Code Insiders 1.137.0 (the downloaded host launcher failed with ENOENT).
- [x] Existing request timeout and disconnect cancellation tests pass.
- [x] Gemini CLI long-task test through AM on port 33333 using `gemini-3.8-flash`: about 7m 6s of execution and 140 tool calls across research and completion sessions. An upstream network interruption required continuing from saved research; both report files were written and read back successfully.
- [x] Passive response observation captured a successful 47.8-second request with four blank-line heartbeats, followed by a complete tool call and STOP. No empty JSON heartbeat frames or stream parsing errors occurred.
