### PR TITLE
fix(openai): keep Responses streams alive for Codex

### DIFF
--- a/.changeset/twenty-zoos-go.md
+++ b/.changeset/twenty-zoos-go.md
@@ -1,0 +1,5 @@
+---
+"agent-maestro": patch
+---
+
+Fix Codex Responses SSE idle timeouts by sending JSON keepalive events during model startup, generation, web search, and token counting without replacing the OpenAI SDK's accumulated response.

--- a/README.md
+++ b/README.md
@@ -381,6 +381,12 @@ Perfect for Codex and OpenAI model integration:
 
 Anthropic Messages and both OpenAI endpoints cancel the upstream language model request when the client disconnects or when the request remains unfinished for 10 minutes. Non-streaming timeouts return HTTP 504; streaming timeouts use each protocol's error event instead of a successful completion event.
 
+Responses streams send JSON `keepalive` events every 10 seconds
+without downstream events, including while waiting for the model, web search,
+or final token counts. These events reset Codex's SSE idle timer without replacing
+the OpenAI SDK's accumulated response; SSE comments alone do not reset the timer.
+Heartbeats do not extend the 10-minute request limit.
+
 ### Gemini-Compatible Endpoints
 
 Perfect for Gemini CLI integration:

--- a/docs/2026-08-11-sse-heartbeats.md
+++ b/docs/2026-08-11-sse-heartbeats.md
@@ -13,21 +13,35 @@ connection active while that request is still within the allowed lifetime.
 
 ## Design
 
-Wrap the upstream async iterable with a small `withSseHeartbeat()` helper. While
-one `iterator.next()` is pending, the helper yields a heartbeat marker every 10
-seconds. Routes handle that marker using their protocol's wire format:
+Anthropic, Chat Completions, and Gemini wrap the upstream async iterable with
+`withSseHeartbeat()`. While one `iterator.next()` is pending, it yields a heartbeat
+marker every 10 seconds. Responses wraps its streaming operation with
+`withOpenAIResponsesHeartbeat()` to track time since the last downstream write.
+Each route uses its protocol's wire format:
 
 | Route                        | Heartbeat frame                      |
 | ---------------------------- | ------------------------------------ |
 | Anthropic Messages           | `event: ping` with `{"type":"ping"}` |
-| OpenAI Chat/Responses        | SSE comment `: keep-alive`           |
+| OpenAI Chat                  | SSE comment `: keep-alive`           |
+| OpenAI Responses             | `keepalive` JSON event               |
 | Gemini streamGenerateContent | SSE comment `: keep-alive`           |
 
 SSE comments produce network traffic but are ignored by compliant parsers, so
-they do not introduce non-JSON data events into OpenAI or Gemini streams.
+they do not introduce non-JSON data events into Chat Completions or Gemini streams.
+Codex measures idle time between parsed SSE events, so comments do not reset its
+idle timer. Responses uses JSON `keepalive` events with increasing sequence
+numbers instead. These events carry no response snapshot. Repeating
+`response.in_progress` with an empty output would replace the OpenAI SDK's
+accumulated response and break subsequent indexed events.
 
-The helper does not own a background interval and never calls `next()`
-concurrently. Heartbeats and model chunks are therefore written in order.
+Responses heartbeats track downstream writes independently of upstream chunks.
+They cover model startup, ignored model data, the buffered search loop, and final
+token counting. The heartbeat timer is stopped and any pending heartbeat write
+is settled before emitting a terminal event, including on failure or cancellation.
+
+Neither helper owns a background interval. The iterable helper never calls
+`next()` concurrently; the Responses helper writes complete SSE events in
+sequence alongside the operation and awaits heartbeat writes before returning.
 Request timeout, client cancellation, and route error handling remain
 authoritative and are not reset by heartbeats. Gemini's streaming route uses
 the same request lifecycle as Anthropic and OpenAI so either condition also
@@ -36,5 +50,9 @@ cancels its VS Code LM request.
 ## Verification
 
 Unit tests cover repeated heartbeats during a stalled `next()`, normal chunk
-ordering, and timer cleanup. Route tests verify the Anthropic ping frame and the
-OpenAI/Gemini comment frame.
+ordering, and timer cleanup. Route tests verify Anthropic ping events,
+Chat Completions/Gemini comments, and Responses JSON heartbeats during model
+startup, ignored chunks, search, and token counting, plus terminal event ordering
+and cancellation. Tests also consume route streams through the official OpenAI
+SDK's `responses.stream()` accumulator, checking that heartbeats preserve text
+and web-search output items before subsequent deltas or completion events.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -17,23 +17,23 @@ pnpm run watch-tests
 
 ## Test Coverage Summary
 
-| Test File                                      | Tests | What It Covers                                            |
-| ---------------------------------------------- | ----- | --------------------------------------------------------- |
-| `extension.test.ts`                            | 12    | Extension activation, command registration, configuration |
-| `utils/config.test.ts`                         | 5     | Configuration defaults and reading                        |
-| `utils/mimeTypes.test.ts`                      | 12    | MIME type detection for file extensions                   |
-| `utils/rooSettingsFilter.test.ts`              | 5     | API key filtering from settings                           |
-| `utils/updateEnvFile.test.ts`                  | 13    | .env file creation/update logic                           |
-| `schemas/cline.test.ts`                        | 6     | Cline API request/response validation                     |
-| `schemas/roo.test.ts`                          | 7     | Roo API request/response validation                       |
-| `schemas/common.test.ts`                       | 7     | Common schemas (file ops, extension info, OS info)        |
-| `server/anthropic.test.ts`                     | 23    | Anthropic → VS Code message conversion                    |
-| `server/languageModelRequestLifecycle.test.ts` | 14    | LM request timeout and disconnect cancellation            |
-| `server/modelResolution.test.ts`               | 17    | Model matching and Copilot model configuration            |
-| `server/openaiChat.test.ts`                    | 15    | OpenAI → VS Code message conversion                       |
-| `server/openaiResponses.test.ts`               | 52    | OpenAI Responses → VS Code conversion                     |
-| `server/gemini.test.ts`                        | 27    | Gemini → VS Code message conversion                       |
-| `server/sseHeartbeat.test.ts`                  | 8     | SSE heartbeat scheduling, lifecycle, and protocol frames  |
+| Test File                                      | Tests | What It Covers                                                                                         |
+| ---------------------------------------------- | ----- | ------------------------------------------------------------------------------------------------------ |
+| `extension.test.ts`                            | 12    | Extension activation, command registration, configuration                                              |
+| `utils/config.test.ts`                         | 5     | Configuration defaults and reading                                                                     |
+| `utils/mimeTypes.test.ts`                      | 12    | MIME type detection for file extensions                                                                |
+| `utils/rooSettingsFilter.test.ts`              | 5     | API key filtering from settings                                                                        |
+| `utils/updateEnvFile.test.ts`                  | 13    | .env file creation/update logic                                                                        |
+| `schemas/cline.test.ts`                        | 6     | Cline API request/response validation                                                                  |
+| `schemas/roo.test.ts`                          | 7     | Roo API request/response validation                                                                    |
+| `schemas/common.test.ts`                       | 7     | Common schemas (file ops, extension info, OS info)                                                     |
+| `server/anthropic.test.ts`                     | 23    | Anthropic → VS Code message conversion                                                                 |
+| `server/languageModelRequestLifecycle.test.ts` | 14    | LM request timeout and disconnect cancellation                                                         |
+| `server/modelResolution.test.ts`               | 17    | Model matching and Copilot model configuration                                                         |
+| `server/openaiChat.test.ts`                    | 15    | OpenAI → VS Code message conversion                                                                    |
+| `server/openaiResponses.test.ts`               | 52    | OpenAI Responses → VS Code conversion                                                                  |
+| `server/gemini.test.ts`                        | 27    | Gemini → VS Code message conversion                                                                    |
+| `server/sseHeartbeat.test.ts`                  | 13    | SSE frames, startup/token-counting heartbeats, OpenAI SDK snapshot preservation, and lifecycle cleanup |
 
 ## How Tests Prevent Regressions
 

--- a/src/server/routes/openai/openaiResponsesRoutes.ts
+++ b/src/server/routes/openai/openaiResponsesRoutes.ts
@@ -41,6 +41,7 @@ import {
   getCurrentTimestamp,
   openMessageOutputItem,
   plaintextFunctionCallMetadata,
+  withOpenAIResponsesHeartbeat,
   writeCustomToolCallOutputItem,
   writeFunctionToolCallOutputItem,
   writeMessageOutputTextDelta,
@@ -49,7 +50,6 @@ import {
   OpenAIResponsesRequestValidationError,
   prepareOpenAIResponsesTools,
 } from "../../utils/openaiResponsesWebSearch";
-import { SSE_HEARTBEAT, withSseHeartbeat } from "../../utils/sseHeartbeat";
 import {
   WEB_SEARCH_PROVIDER_TIMEOUT_MS,
   WebSearchProvider,
@@ -368,17 +368,15 @@ export function registerOpenaiResponsesRoutes(
         });
       }
 
-      // 8. Send request to VSCode LM
-      const response = await requestLifecycle.waitFor(
-        client.sendRequest(
-          vsCodeMessages,
-          configuredRequestOptions,
-          cancellationToken,
-        ),
-      );
-
       // 9. Handle non-streaming response
       if (!stream) {
+        const response = await requestLifecycle.waitFor(
+          client.sendRequest(
+            vsCodeMessages,
+            configuredRequestOptions,
+            cancellationToken,
+          ),
+        );
         let accumulatedText = "";
         const toolCalls: { callId: string; name: string; input: unknown }[] =
           [];
@@ -457,12 +455,12 @@ export function registerOpenaiResponsesRoutes(
       }
 
       // 10. Handle streaming response
+      const responseId = generateResponseId();
+      const createdAt = getCurrentTimestamp();
+      const sequenceNumberRef = { value: 0 };
       return streamSSE(
         c,
         async (sseStream) => {
-          const responseId = generateResponseId();
-          const createdAt = getCurrentTimestamp();
-          const sequenceNumberRef = { value: 0 };
           const writeSSE = (
             message: Parameters<typeof sseStream.writeSSE>[0],
           ) => requestLifecycle!.waitFor(sseStream.writeSSE(message));
@@ -507,54 +505,127 @@ export function registerOpenaiResponsesRoutes(
             }),
           });
 
-          // Process stream
-          const output: OutputItem[] = [];
-          let outputIndex = 0;
-          let contentIndex = 0;
-          let currentMessageId: string | null = null;
-          let accumulatedText = "";
-          let totalOutputText = ""; // Track all output for token counting
-          let responseUsage: ResponseUsage | undefined;
-
-          for await (const chunk of withSseHeartbeat(
-            interruptibleLanguageModelStream(
-              response.stream,
-              requestLifecycle!,
-            ),
-            options.heartbeatIntervalMs,
-          )) {
-            if (chunk === SSE_HEARTBEAT) {
-              await requestLifecycle!.waitFor(
-                sseStream.write(": keep-alive\n\n"),
+          const { output, responseUsage } = await withOpenAIResponsesHeartbeat(
+            writeSSE,
+            sequenceNumberRef,
+            async (writeSSE) => {
+              const response = await requestLifecycle!.waitFor(
+                client.sendRequest(
+                  vsCodeMessages,
+                  configuredRequestOptions,
+                  cancellationToken,
+                ),
               );
-              continue;
-            }
+              // Process stream
+              const output: OutputItem[] = [];
+              let outputIndex = 0;
+              let contentIndex = 0;
+              let currentMessageId: string | null = null;
+              let accumulatedText = "";
+              let totalOutputText = ""; // Track all output for token counting
+              let responseUsage: ResponseUsage | undefined;
 
-            if (chunk instanceof vscode.LanguageModelTextPart) {
-              if (!currentMessageId) {
-                currentMessageId = generateMessageId();
-                contentIndex = 0;
-                await openMessageOutputItem(
-                  writeSSE,
-                  currentMessageId,
-                  outputIndex,
-                  contentIndex,
-                  sequenceNumberRef,
-                );
+              for await (const chunk of interruptibleLanguageModelStream(
+                response.stream,
+                requestLifecycle!,
+              )) {
+                if (chunk instanceof vscode.LanguageModelTextPart) {
+                  if (!currentMessageId) {
+                    currentMessageId = generateMessageId();
+                    contentIndex = 0;
+                    await openMessageOutputItem(
+                      writeSSE,
+                      currentMessageId,
+                      outputIndex,
+                      contentIndex,
+                      sequenceNumberRef,
+                    );
+                  }
+
+                  accumulatedText += chunk.value;
+                  totalOutputText += chunk.value;
+                  await writeMessageOutputTextDelta(
+                    writeSSE,
+                    currentMessageId,
+                    outputIndex,
+                    contentIndex,
+                    chunk.value,
+                    sequenceNumberRef,
+                  );
+                } else if (chunk instanceof vscode.LanguageModelToolCallPart) {
+                  // Close current message if open
+                  if (currentMessageId) {
+                    const outputItem = await closeMessageOutputItem(
+                      writeSSE,
+                      currentMessageId,
+                      outputIndex,
+                      contentIndex,
+                      accumulatedText,
+                      sequenceNumberRef,
+                    );
+                    output.push(outputItem);
+                    outputIndex++;
+                    currentMessageId = null;
+                    accumulatedText = "";
+                  }
+
+                  totalOutputText += JSON.stringify(chunk);
+
+                  const toolInfo = preparedTools.toolMap.get(chunk.name);
+                  const toolName = toolInfo?.name ?? chunk.name;
+                  const toolNamespace = toolInfo?.namespace;
+
+                  if (toolInfo?.isCustom) {
+                    const ctcId = generateCustomToolCallId();
+                    const callId = chunk.callId;
+                    const inputStr = customToolCallInput(chunk.input);
+                    const customItem: ResponseCustomToolCall = {
+                      type: "custom_tool_call",
+                      id: ctcId,
+                      call_id: callId,
+                      name: toolName,
+                      input: inputStr,
+                      ...(toolNamespace ? { namespace: toolNamespace } : {}),
+                    };
+                    output.push(customItem);
+                    await writeCustomToolCallOutputItem(
+                      writeSSE,
+                      customItem,
+                      outputIndex,
+                      sequenceNumberRef,
+                    );
+                    outputIndex++;
+                    continue;
+                  }
+
+                  const fcId = generateFunctionCallId();
+                  const callId = chunk.callId;
+                  const argsStr = JSON.stringify(chunk.input ?? {});
+                  const functionItem: PlaintextResponseFunctionToolCall = {
+                    type: "function_call",
+                    id: fcId,
+                    call_id: callId,
+                    name: toolName,
+                    arguments: argsStr,
+                    status: "completed",
+                    ...(toolNamespace ? { namespace: toolNamespace } : {}),
+                    ...plaintextFunctionCallMetadata(toolInfo),
+                  };
+                  output.push(functionItem);
+                  await writeFunctionToolCallOutputItem(
+                    writeSSE,
+                    functionItem,
+                    outputIndex,
+                    sequenceNumberRef,
+                  );
+                  outputIndex++;
+                } else if (chunk instanceof vscode.LanguageModelDataPart) {
+                  responseUsage =
+                    extractOpenAIResponsesUsage(chunk) ?? responseUsage;
+                }
               }
 
-              accumulatedText += chunk.value;
-              totalOutputText += chunk.value;
-              await writeMessageOutputTextDelta(
-                writeSSE,
-                currentMessageId,
-                outputIndex,
-                contentIndex,
-                chunk.value,
-                sequenceNumberRef,
-              );
-            } else if (chunk instanceof vscode.LanguageModelToolCallPart) {
-              // Close current message if open
+              // Close any remaining message
               if (currentMessageId) {
                 const outputItem = await closeMessageOutputItem(
                   writeSSE,
@@ -566,100 +637,36 @@ export function registerOpenaiResponsesRoutes(
                 );
                 output.push(outputItem);
                 outputIndex++;
-                currentMessageId = null;
-                accumulatedText = "";
               }
 
-              totalOutputText += JSON.stringify(chunk);
-
-              const toolInfo = preparedTools.toolMap.get(chunk.name);
-              const toolName = toolInfo?.name ?? chunk.name;
-              const toolNamespace = toolInfo?.namespace;
-
-              if (toolInfo?.isCustom) {
-                const ctcId = generateCustomToolCallId();
-                const callId = chunk.callId;
-                const inputStr = customToolCallInput(chunk.input);
-                const customItem: ResponseCustomToolCall = {
-                  type: "custom_tool_call",
-                  id: ctcId,
-                  call_id: callId,
-                  name: toolName,
-                  input: inputStr,
-                  ...(toolNamespace ? { namespace: toolNamespace } : {}),
+              if (!responseUsage) {
+                const [fallbackInputTokens, outputTokens] =
+                  await requestLifecycle!.waitFor(
+                    Promise.all([
+                      client.countTokens(
+                        JSON.stringify(requestBody),
+                        cancellationToken,
+                      ),
+                      client.countTokens(totalOutputText, cancellationToken),
+                    ]),
+                  );
+                inputTokens = fallbackInputTokens;
+                responseUsage = {
+                  input_tokens: fallbackInputTokens,
+                  input_tokens_details: {
+                    cached_tokens: 0,
+                    cache_write_tokens: 0,
+                  },
+                  output_tokens: outputTokens,
+                  output_tokens_details: { reasoning_tokens: 0 },
+                  total_tokens: fallbackInputTokens + outputTokens,
                 };
-                output.push(customItem);
-                await writeCustomToolCallOutputItem(
-                  writeSSE,
-                  customItem,
-                  outputIndex,
-                  sequenceNumberRef,
-                );
-                outputIndex++;
-                continue;
               }
 
-              const fcId = generateFunctionCallId();
-              const callId = chunk.callId;
-              const argsStr = JSON.stringify(chunk.input ?? {});
-              const functionItem: PlaintextResponseFunctionToolCall = {
-                type: "function_call",
-                id: fcId,
-                call_id: callId,
-                name: toolName,
-                arguments: argsStr,
-                status: "completed",
-                ...(toolNamespace ? { namespace: toolNamespace } : {}),
-                ...plaintextFunctionCallMetadata(toolInfo),
-              };
-              output.push(functionItem);
-              await writeFunctionToolCallOutputItem(
-                writeSSE,
-                functionItem,
-                outputIndex,
-                sequenceNumberRef,
-              );
-              outputIndex++;
-            } else if (chunk instanceof vscode.LanguageModelDataPart) {
-              responseUsage =
-                extractOpenAIResponsesUsage(chunk) ?? responseUsage;
-            }
-          }
-
-          // Close any remaining message
-          if (currentMessageId) {
-            const outputItem = await closeMessageOutputItem(
-              writeSSE,
-              currentMessageId,
-              outputIndex,
-              contentIndex,
-              accumulatedText,
-              sequenceNumberRef,
-            );
-            output.push(outputItem);
-            outputIndex++;
-          }
-
-          if (!responseUsage) {
-            const [fallbackInputTokens, outputTokens] =
-              await requestLifecycle!.waitFor(
-                Promise.all([
-                  client.countTokens(
-                    JSON.stringify(requestBody),
-                    cancellationToken,
-                  ),
-                  client.countTokens(totalOutputText, cancellationToken),
-                ]),
-              );
-            inputTokens = fallbackInputTokens;
-            responseUsage = {
-              input_tokens: fallbackInputTokens,
-              input_tokens_details: { cached_tokens: 0, cache_write_tokens: 0 },
-              output_tokens: outputTokens,
-              output_tokens_details: { reasoning_tokens: 0 },
-              total_tokens: fallbackInputTokens + outputTokens,
-            };
-          }
+              return { output, responseUsage };
+            },
+            options.heartbeatIntervalMs,
+          );
 
           // Emit response.completed
           await writeSSE({
@@ -691,14 +698,12 @@ export function registerOpenaiResponsesRoutes(
 
           logger.error("✕ /v1/responses (stream) |", error);
 
-          const responseId = generateResponseId();
-          const createdAt = getCurrentTimestamp();
-
           try {
             await sseStream.writeSSE({
               event: "response.failed",
               data: JSON.stringify({
                 type: "response.failed",
+                sequence_number: sequenceNumberRef.value++,
                 response: {
                   id: responseId,
                   object: "response",

--- a/src/server/routes/openai/openaiResponsesWebSearchHandler.ts
+++ b/src/server/routes/openai/openaiResponsesWebSearchHandler.ts
@@ -21,6 +21,7 @@ import {
   generateResponseId,
   getCurrentTimestamp,
   openMessageOutputItem,
+  withOpenAIResponsesHeartbeat,
   writeCustomToolCallOutputItem,
   writeFunctionToolCallOutputItem,
   writeMessageOutputTextDelta,
@@ -30,7 +31,6 @@ import {
   PreparedOpenAIResponsesTools,
   runOpenAIResponsesWebSearchLoop,
 } from "../../utils/openaiResponsesWebSearch";
-import { SSE_HEARTBEAT, withSseHeartbeat } from "../../utils/sseHeartbeat";
 import { WebSearchProvider } from "../../webSearch/webSearchProvider";
 
 interface OpenAIResponsesWebSearchHandlerOptions {
@@ -172,123 +172,122 @@ export async function handleOpenAIResponsesWebSearch({
         response: buildResponseEnvelope("in_progress", [], null, null),
       });
 
-      let searchOutputEmitted = false;
-      const callbacks: OpenAIResponsesSearchLoopCallbacks = {
-        onSearchCallStarted: async (item) => {
-          searchOutputEmitted = true;
-          await writeEvent("response.output_item.added", {
-            type: "response.output_item.added",
-            output_index: 0,
-            item,
-          });
-          await writeEvent("response.web_search_call.in_progress", {
-            type: "response.web_search_call.in_progress",
-            output_index: 0,
-            item_id: item.id,
-          });
-        },
-        onProviderStarted: async (itemId) => {
-          await writeEvent("response.web_search_call.searching", {
-            type: "response.web_search_call.searching",
-            output_index: 0,
-            item_id: itemId,
-          });
-        },
-        onSearchCallCompleted: async (item) => {
-          await writeEvent("response.web_search_call.completed", {
-            type: "response.web_search_call.completed",
-            output_index: 0,
-            item_id: item.id,
-          });
-          await writeEvent("response.output_item.done", {
-            type: "response.output_item.done",
-            output_index: 0,
-            item,
-          });
-        },
-      };
-
-      const resultStream = (async function* () {
-        yield await runSearchLoop(callbacks);
-      })();
-      let result:
-        | Awaited<ReturnType<typeof runOpenAIResponsesWebSearchLoop>>
-        | undefined;
-      for await (const item of withSseHeartbeat(
-        resultStream,
-        heartbeatIntervalMs,
-      )) {
-        if (item === SSE_HEARTBEAT) {
-          await lifecycle.waitFor(sseStream.write(": keep-alive\n\n"));
-        } else {
-          result = item;
-        }
-      }
-      if (!result) {
-        throw new Error("OpenAI Responses web search loop returned no result");
-      }
-
-      let outputIndex = searchOutputEmitted ? 1 : 0;
-      for (const item of result.output) {
-        if (item.type === "web_search_call") {
-          continue;
-        }
-
-        if (item.type === "message") {
-          const part = outputTextPart(item);
-          if (!part) {
-            continue;
-          }
-          await openMessageOutputItem(
-            writeSSE,
-            item.id,
-            outputIndex,
-            0,
-            sequenceNumberRef,
-          );
-          await writeMessageOutputTextDelta(
-            writeSSE,
-            item.id,
-            outputIndex,
-            0,
-            part.text,
-            sequenceNumberRef,
-          );
-          await closeMessageOutputItem(
-            writeSSE,
-            item.id,
-            outputIndex,
-            0,
-            part.text,
-            sequenceNumberRef,
-            {
-              annotations: part.annotations,
-              status: item.status,
+      const result = await withOpenAIResponsesHeartbeat(
+        writeSSE,
+        sequenceNumberRef,
+        async (writeSSE) => {
+          const writeEvent = (event: string, data: Record<string, unknown>) =>
+            writeSSE({
+              event,
+              data: JSON.stringify({
+                ...data,
+                sequence_number: sequenceNumberRef.value++,
+              }),
+            });
+          let searchOutputEmitted = false;
+          const callbacks: OpenAIResponsesSearchLoopCallbacks = {
+            onSearchCallStarted: async (item) => {
+              searchOutputEmitted = true;
+              await writeEvent("response.output_item.added", {
+                type: "response.output_item.added",
+                output_index: 0,
+                item,
+              });
+              await writeEvent("response.web_search_call.in_progress", {
+                type: "response.web_search_call.in_progress",
+                output_index: 0,
+                item_id: item.id,
+              });
             },
-          );
-          outputIndex++;
-          continue;
-        }
+            onProviderStarted: async (itemId) => {
+              await writeEvent("response.web_search_call.searching", {
+                type: "response.web_search_call.searching",
+                output_index: 0,
+                item_id: itemId,
+              });
+            },
+            onSearchCallCompleted: async (item) => {
+              await writeEvent("response.web_search_call.completed", {
+                type: "response.web_search_call.completed",
+                output_index: 0,
+                item_id: item.id,
+              });
+              await writeEvent("response.output_item.done", {
+                type: "response.output_item.done",
+                output_index: 0,
+                item,
+              });
+            },
+          };
 
-        if (item.type === "custom_tool_call") {
-          await writeCustomToolCallOutputItem(
-            writeSSE,
-            item,
-            outputIndex,
-            sequenceNumberRef,
-          );
-          outputIndex++;
-          continue;
-        }
+          const result = await runSearchLoop(callbacks);
 
-        await writeFunctionToolCallOutputItem(
-          writeSSE,
-          item,
-          outputIndex,
-          sequenceNumberRef,
-        );
-        outputIndex++;
-      }
+          let outputIndex = searchOutputEmitted ? 1 : 0;
+          for (const item of result.output) {
+            if (item.type === "web_search_call") {
+              continue;
+            }
+
+            if (item.type === "message") {
+              const part = outputTextPart(item);
+              if (!part) {
+                continue;
+              }
+              await openMessageOutputItem(
+                writeSSE,
+                item.id,
+                outputIndex,
+                0,
+                sequenceNumberRef,
+              );
+              await writeMessageOutputTextDelta(
+                writeSSE,
+                item.id,
+                outputIndex,
+                0,
+                part.text,
+                sequenceNumberRef,
+              );
+              await closeMessageOutputItem(
+                writeSSE,
+                item.id,
+                outputIndex,
+                0,
+                part.text,
+                sequenceNumberRef,
+                {
+                  annotations: part.annotations,
+                  status: item.status,
+                },
+              );
+              outputIndex++;
+              continue;
+            }
+
+            if (item.type === "custom_tool_call") {
+              await writeCustomToolCallOutputItem(
+                writeSSE,
+                item,
+                outputIndex,
+                sequenceNumberRef,
+              );
+              outputIndex++;
+              continue;
+            }
+
+            await writeFunctionToolCallOutputItem(
+              writeSSE,
+              item,
+              outputIndex,
+              sequenceNumberRef,
+            );
+            outputIndex++;
+          }
+
+          return result;
+        },
+        heartbeatIntervalMs,
+      );
 
       const terminalStatus = result.incomplete ? "incomplete" : "completed";
       await writeEvent(`response.${terminalStatus}`, {

--- a/src/server/utils/openaiResponses.ts
+++ b/src/server/utils/openaiResponses.ts
@@ -29,6 +29,7 @@ import * as vscode from "vscode";
 
 import { logger } from "../../utils/logger";
 import { mimeForVscodeLm } from "./imageMime";
+import { SSE_HEARTBEAT_INTERVAL_MS } from "./sseHeartbeat";
 import {
   ToolResultPairingTracker,
   logToolResultRecovery,
@@ -136,6 +137,57 @@ export const buildOpenAIResponsesEnvelope = ({
 type ResponseSSEWriter = (
   message: Parameters<SSEStreamingApi["writeSSE"]>[0],
 ) => Promise<void>;
+
+export async function withOpenAIResponsesHeartbeat<T>(
+  writeSSE: ResponseSSEWriter,
+  sequenceNumberRef: { value: number },
+  operation: (writeSSE: ResponseSSEWriter) => Promise<T>,
+  intervalMs: number = SSE_HEARTBEAT_INTERVAL_MS,
+): Promise<T> {
+  if (!Number.isFinite(intervalMs) || intervalMs <= 0) {
+    throw new RangeError("SSE heartbeat interval must be greater than zero");
+  }
+
+  let lastWrite = performance.now();
+  const trackedWrite: ResponseSSEWriter = async (message) => {
+    await writeSSE(message);
+    lastWrite = performance.now();
+  };
+  const pendingResult = operation(trackedWrite).then((value) => ({ value }));
+
+  while (true) {
+    let timeout: NodeJS.Timeout | undefined;
+    try {
+      const outcome = await Promise.race([
+        pendingResult,
+        new Promise<undefined>((resolve) => {
+          timeout = setTimeout(
+            () => resolve(undefined),
+            Math.max(1, intervalMs - (performance.now() - lastWrite)),
+          );
+          timeout.unref();
+        }),
+      ]);
+      if (outcome) {
+        return outcome.value;
+      }
+      if (performance.now() - lastWrite < intervalMs) {
+        continue;
+      }
+
+      // Codex needs a parsed event; lifecycle events replace SDK response state.
+      await trackedWrite({
+        event: "keepalive",
+        data: JSON.stringify({
+          type: "keepalive",
+          sequence_number: sequenceNumberRef.value++,
+        }),
+      });
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}
 
 export const openMessageOutputItem = async (
   writeSSE: ResponseSSEWriter,

--- a/src/test/server/openaiResponsesWebSearch.test.ts
+++ b/src/test/server/openaiResponsesWebSearch.test.ts
@@ -1,5 +1,6 @@
 import { OpenAPIHono } from "@hono/zod-openapi";
 import * as assert from "assert";
+import OpenAI from "openai";
 import * as vscode from "vscode";
 
 import { registerOpenaiResponsesRoutes } from "../../server/routes/openai/openaiResponsesRoutes";
@@ -1503,6 +1504,94 @@ suite("OpenAI Responses Server Web Search Test Suite", () => {
       assert.doesNotMatch(body, /response\.web_search_call/);
       assert.match(body, /No search needed/);
       assert.match(body, /response\.completed/);
+    });
+
+    test("preserves OpenAI SDK search items across provider-wait heartbeats", async () => {
+      let releaseSearch!: () => void;
+      const searchReleased = new Promise<void>((resolve) => {
+        releaseSearch = resolve;
+      });
+      const app = createTestApp({
+        rounds: [
+          {
+            chunks: [
+              new vscode.LanguageModelToolCallPart(
+                "search-1",
+                "agent_maestro_web_search",
+                { query: "latest result" },
+              ),
+              usagePart(),
+            ],
+          },
+          {
+            chunks: [new vscode.LanguageModelTextPart("Done."), usagePart()],
+          },
+        ],
+        provider: createProvider(async () => {
+          await searchReleased;
+          return [];
+        }),
+      });
+      const client = new OpenAI({
+        apiKey: "test",
+        baseURL: "http://localhost/v1",
+        maxRetries: 0,
+        fetch: async (input, init) => app.request(new Request(input, init)),
+      });
+      const stream = client.responses.stream({
+        model: "gpt-5.6-test",
+        input: "Search",
+        tools: [{ type: "web_search" }],
+      });
+      const events: Record<string, any>[] = [];
+      let searchPending = false;
+      stream.on("event", (event) => {
+        events.push(event);
+        if (event.type === "response.web_search_call.searching") {
+          searchPending = true;
+        }
+        if (searchPending && (event as { type: string }).type === "keepalive") {
+          releaseSearch();
+        }
+      });
+      try {
+        const response = await stream.finalResponse();
+        assert.strictEqual(response.output_text, "Done.");
+        assert.strictEqual(response.output.length, 2);
+        assert.strictEqual(response.output[0].type, "web_search_call");
+        assert.strictEqual(response.output[0].status, "completed");
+      } finally {
+        releaseSearch();
+        stream.abort();
+      }
+      const searching = events.findIndex(
+        ({ type }) => type === "response.web_search_call.searching",
+      );
+      const searchCompleted = events.findIndex(
+        ({ type }) => type === "response.web_search_call.completed",
+      );
+      assert.ok(searching > 0);
+      assert.ok(searchCompleted > searching);
+      assert.ok(
+        events
+          .slice(searching + 1, searchCompleted)
+          .some(({ type }) => type === "keepalive"),
+      );
+      assert.deepStrictEqual(
+        events.map(({ sequence_number }) => sequence_number),
+        events.map((_, index) => index),
+      );
+      assert.ok(
+        events
+          .filter(({ response }) => response)
+          .every(({ response }) => response.id === events[0].response.id),
+      );
+      assert.strictEqual(events.at(-1)?.type, "response.completed");
+      assert.ok(
+        events
+          .filter(({ type }) => type === "keepalive")
+          .every((event) => !("response" in event)),
+      );
     });
 
     test("echoes parallel_tool_calls false on the disabled-search fallback stream", async () => {

--- a/src/test/server/sseHeartbeat.test.ts
+++ b/src/test/server/sseHeartbeat.test.ts
@@ -1,11 +1,13 @@
 import { OpenAPIHono } from "@hono/zod-openapi";
 import * as assert from "assert";
+import OpenAI from "openai";
 import * as vscode from "vscode";
 
 import { registerAnthropicRoutes } from "../../server/routes/anthropicRoutes";
 import { registerGeminiRoutes } from "../../server/routes/geminiRoutes";
 import { registerOpenaiChatRoutes } from "../../server/routes/openai/openaiChatRoutes";
 import { registerOpenaiResponsesRoutes } from "../../server/routes/openai/openaiResponsesRoutes";
+import { withOpenAIResponsesHeartbeat } from "../../server/utils/openaiResponses";
 import {
   SSE_HEARTBEAT,
   withSseHeartbeat,
@@ -13,6 +15,60 @@ import {
 
 suite("SSE Heartbeat Test Suite", () => {
   const heartbeatIntervalMs = 5;
+
+  const parseResponsesEvents = (body: string): Record<string, any>[] =>
+    body
+      .split("\n")
+      .filter((line) => line.startsWith("data: "))
+      .map((line) => JSON.parse(line.slice(6)));
+
+  const assertResponseSequence = (
+    events: Record<string, any>[],
+    terminalType: string,
+  ) => {
+    assert.strictEqual(events[0].type, "response.created");
+    assert.strictEqual(events.at(-1)?.type, terminalType);
+    assert.deepStrictEqual(
+      events.map(({ sequence_number }) => sequence_number),
+      events.map((_, index) => index),
+    );
+    assert.ok(
+      events
+        .filter(({ response }) => response)
+        .every(({ response }) => response.id === events[0].response.id),
+    );
+  };
+
+  const deferred = () => {
+    let resolve!: () => void;
+    const promise = new Promise<void>((done) => {
+      resolve = done;
+    });
+    return { promise, resolve };
+  };
+
+  const responsesRequest = (
+    model: vscode.LanguageModelChat,
+    signal?: AbortSignal,
+    requestTimeoutMs = 1000,
+  ) => {
+    const app = new OpenAPIHono();
+    registerOpenaiResponsesRoutes(app, {
+      heartbeatIntervalMs,
+      requestTimeoutMs,
+      resolveChatModelClient: async () => ({ client: model }),
+    });
+    return app.request("/v1/responses", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: model.id,
+        input: "Hello",
+        stream: true,
+      }),
+      signal,
+    });
+  };
 
   const createDelayedModel = (): vscode.LanguageModelChat =>
     ({
@@ -169,7 +225,7 @@ suite("SSE Heartbeat Test Suite", () => {
     assert.ok(body.includes("data: [DONE]"));
   });
 
-  test("writes SSE comments for OpenAI Responses", async () => {
+  test("writes parsed JSON heartbeats for OpenAI Responses", async () => {
     const app = new OpenAPIHono();
     registerOpenaiResponsesRoutes(app, {
       heartbeatIntervalMs,
@@ -190,8 +246,242 @@ suite("SSE Heartbeat Test Suite", () => {
     });
     const body = await response.text();
 
-    assert.ok(body.includes(": keep-alive\n\n"));
-    assert.ok(body.includes("event: response.completed"));
+    const events = parseResponsesEvents(body);
+    const heartbeats = events.filter(({ type }) => type === "keepalive");
+    assert.ok(heartbeats.length > 0);
+    assert.ok(heartbeats.every((event) => !("response" in event)));
+    assert.strictEqual(
+      events.filter(({ type }) => type === "response.in_progress").length,
+      1,
+    );
+    assert.ok(body.includes("event: keepalive\n"));
+    assertResponseSequence(events, "response.completed");
+    assert.ok(!body.includes(": keep-alive"));
+  });
+
+  test("keeps Responses alive during startup, ignored chunks, and token counting", async () => {
+    const startup = deferred();
+    const counting = deferred();
+    const controller = new AbortController();
+    let stage = "startup";
+    let ignoredChunks = 0;
+    const model: vscode.LanguageModelChat = {
+      ...createDelayedModel(),
+      sendRequest: async () => {
+        await startup.promise;
+        return {
+          stream: (async function* () {
+            stage = "ignored";
+            while (stage === "ignored") {
+              await new Promise((resolve) => setTimeout(resolve, 1));
+              ignoredChunks++;
+              yield new vscode.LanguageModelDataPart(
+                new Uint8Array(),
+                "ignored",
+              );
+            }
+            yield new vscode.LanguageModelTextPart("Hello");
+          })(),
+          text: (async function* () {})(),
+        };
+      },
+      countTokens: async () => {
+        stage = "counting";
+        await counting.promise;
+        return 1;
+      },
+    };
+    // A missing heartbeat leaves a stage blocked until the request fails.
+    const response = await responsesRequest(model, controller.signal);
+    const reader = response.body!.getReader();
+    const decoder = new TextDecoder();
+    const heartbeatStages = new Set<string>();
+    let body = "";
+    let pending = "";
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) {
+          break;
+        }
+        const text = decoder.decode(value, { stream: true });
+        body += text;
+        pending += text;
+        let boundary: number;
+        while ((boundary = pending.indexOf("\n\n")) !== -1) {
+          const [event] = parseResponsesEvents(pending.slice(0, boundary));
+          pending = pending.slice(boundary + 2);
+          if (event?.type !== "keepalive") {
+            continue;
+          }
+          heartbeatStages.add(stage);
+          if (stage === "startup") {
+            startup.resolve();
+          } else if (stage === "ignored" && ignoredChunks > 0) {
+            stage = "output";
+          } else if (stage === "counting") {
+            counting.resolve();
+          }
+        }
+      }
+      assert.deepStrictEqual(
+        [...heartbeatStages],
+        ["startup", "ignored", "counting"],
+      );
+      assert.ok(ignoredChunks > 0);
+      assertResponseSequence(parseResponsesEvents(body), "response.completed");
+    } finally {
+      controller.abort();
+      stage = "done";
+      startup.resolve();
+      counting.resolve();
+      reader.releaseLock();
+    }
+  });
+
+  test("preserves OpenAI SDK text snapshots across heartbeats between deltas", async () => {
+    const nextDelta = deferred();
+    const tokenCounts = deferred();
+    const controller = new AbortController();
+    let stage = "text";
+    const model: vscode.LanguageModelChat = {
+      ...createDelayedModel(),
+      sendRequest: async () => ({
+        stream: (async function* () {
+          yield new vscode.LanguageModelTextPart("Hello ");
+          await nextDelta.promise;
+          yield new vscode.LanguageModelTextPart("world");
+        })(),
+        text: (async function* () {})(),
+      }),
+      countTokens: async () => {
+        stage = "counting";
+        await tokenCounts.promise;
+        return 1;
+      },
+    };
+    const client = new OpenAI({
+      apiKey: "test",
+      maxRetries: 0,
+      fetch: async () => responsesRequest(model, controller.signal),
+    });
+    const stream = client.responses.stream({ model: model.id, input: "Hello" });
+    const events: Record<string, any>[] = [];
+    const snapshots: string[] = [];
+    const heartbeatStages = new Set<string>();
+    stream.on("response.output_text.delta", ({ snapshot }) => {
+      snapshots.push(snapshot);
+    });
+    stream.on("event", (event) => {
+      events.push(event);
+      if ((event as { type: string }).type !== "keepalive") {
+        return;
+      }
+      heartbeatStages.add(stage);
+      if (stage === "text" && snapshots.length > 0) {
+        nextDelta.resolve();
+      } else if (stage === "counting") {
+        tokenCounts.resolve();
+      }
+    });
+    try {
+      const response = await stream.finalResponse();
+      assert.deepStrictEqual(snapshots, ["Hello ", "Hello world"]);
+      assert.deepStrictEqual([...heartbeatStages], ["text", "counting"]);
+      assert.strictEqual(response.output_text, "Hello world");
+      assert.strictEqual(response.output.length, 1);
+      assertResponseSequence(events, "response.completed");
+      const firstDelta = events.findIndex(
+        ({ type }) => type === "response.output_text.delta",
+      );
+      const nextDeltaIndex = events.findIndex(
+        ({ type }, index) =>
+          index > firstDelta && type === "response.output_text.delta",
+      );
+      assert.ok(
+        events
+          .slice(firstDelta + 1, nextDeltaIndex)
+          .some(({ type }) => type === "keepalive"),
+      );
+    } finally {
+      controller.abort();
+      nextDelta.resolve();
+      tokenCounts.resolve();
+    }
+  });
+
+  test("stops Responses heartbeats on a startup timeout", async () => {
+    let cancelled = false;
+    const model: vscode.LanguageModelChat = {
+      ...createDelayedModel(),
+      sendRequest: async (_messages, _options, token) => {
+        token?.onCancellationRequested(() => {
+          cancelled = true;
+        });
+        return new Promise(() => {});
+      },
+    };
+    const response = await responsesRequest(model, undefined, 40);
+    const events = parseResponsesEvents(await response.text());
+    assert.strictEqual(response.status, 200);
+    assert.ok(cancelled);
+    assertResponseSequence(events, "response.failed");
+    assert.strictEqual(events.at(-1)?.response.error.code, "request_timeout");
+    assert.ok(events.some(({ type }) => type === "keepalive"));
+  });
+
+  test("cancels Responses startup when the streaming client disconnects", async () => {
+    const cancellation = deferred();
+    const controller = new AbortController();
+    const model: vscode.LanguageModelChat = {
+      ...createDelayedModel(),
+      sendRequest: async (_messages, _options, token) => {
+        token?.onCancellationRequested(cancellation.resolve);
+        return new Promise(() => {});
+      },
+    };
+    const response = await responsesRequest(model, controller.signal);
+    const reader = response.body!.getReader();
+    let body = "";
+    const decoder = new TextDecoder();
+    while (!body.includes('"sequence_number":2')) {
+      const { done, value } = await reader.read();
+      assert.ok(!done, "expected a heartbeat before stream closure");
+      body += decoder.decode(value);
+    }
+    controller.abort();
+    await cancellation.promise;
+    assert.strictEqual((await reader.read()).done, true);
+    reader.releaseLock();
+    assert.ok(!body.includes("response.completed"));
+  });
+
+  test("waits for an in-flight heartbeat before finishing the operation", async () => {
+    const heartbeatStarted = deferred();
+    const heartbeatFinished = deferred();
+    const operationFinished = deferred();
+    let finished = false;
+    let writes = 0;
+    const running = withOpenAIResponsesHeartbeat(
+      async () => {
+        writes++;
+        heartbeatStarted.resolve();
+        await heartbeatFinished.promise;
+      },
+      { value: 0 },
+      async () => operationFinished.promise,
+      heartbeatIntervalMs,
+    ).then(() => {
+      finished = true;
+    });
+    await heartbeatStarted.promise;
+    operationFinished.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    assert.strictEqual(finished, false);
+    heartbeatFinished.resolve();
+    await running;
+    await new Promise((resolve) => setTimeout(resolve, 15));
+    assert.strictEqual(writes, 1);
   });
 
   test("writes SSE comments for Gemini streamGenerateContent", async () => {


### PR DESCRIPTION
## Summary

Codex times out while a Responses stream sends only SSE comments because its idle timer waits for parsed events. Send JSON `keepalive` events after 10 seconds without downstream events, covering model startup, generation, web search, and final token counting. These heartbeats preserve the OpenAI SDK's accumulated response and the existing 10-minute request limit.

Responses writers accept only pre-serialized string data, preventing deferred payloads from reordering before Hono queues complete frames. Includes SDK snapshot tests, slow-reader backpressure tests for both writer orderings, lifecycle coverage, updated documentation, and patch changeset `.changeset/twenty-zoos-go.md`.

## Test plan

- [x] `pnpm check-types`
- [x] `pnpm lint` and pre-commit ESLint/Prettier hooks
- [x] Full extension-host suite using a local VS Code Insiders configuration: 520 passing
- [x] Hono slow-reader tests preserve complete frames, consecutive sequence numbers, and the final terminal event when operation or heartbeat writes block first
- [x] Type-level check accepts string data and rejects `Promise<string>`
- [x] Official OpenAI SDK 6.46.0 streaming accumulator preserves text and search output across heartbeats
- [x] Installed Codex 0.152.1 against the updated local route with a mock model: startup, gaps between text deltas, and token counting each exceed a 500 ms idle limit without reconnecting
