### PR TITLE
fix(gemini): scope resumed tool result deduplication to call turns

### DIFF
--- a/.changeset/icy-donkeys-live.md
+++ b/.changeset/icy-donkeys-live.md
@@ -1,0 +1,5 @@
+---
+"agent-maestro": patch
+---
+
+fix(gemini): ignore repeated explicitly identified tool results within the same call turn when restoring CLI sessions

--- a/README.md
+++ b/README.md
@@ -397,6 +397,8 @@ Perfect for Gemini CLI integration:
 
 Streaming responses send blank-line heartbeats while waiting for the model, keeping long-running requests alive without interrupting Gemini CLI or Google Gen AI SDK stream parsing. These heartbeats do not produce extra response chunks or affect generated content and token usage.
 
+Gemini CLI session restoration can repeat results for a single tool-call turn. For a call with an explicit ID that appears once in that turn, Agent Maestro keeps its first explicitly identified result and ignores repeats in the following user messages. A later model turn starts a new scope, so replaying a complete call/result pair does not leave a call without its result.
+
 > **Thinking levels**: Not forwarded for Gemini. Copilot's Gemini path does not read the `thinkingConfig.thinkingLevel` parameter from the model configuration; it only applies a hardcoded `low` effort behind an internal experiment flag, so any forwarded value would be ignored.
 
 ### RooCode Agent Routes

--- a/src/server/utils/gemini.ts
+++ b/src/server/utils/gemini.ts
@@ -264,8 +264,43 @@ export const convertGeminiContentsToVSCode = (
     }
   }
 
-  return contents.map((content) => {
-    const parts = (content.parts || []).map((part) => {
+  const turnCallCounts = new Map<string, number>();
+  const turnResultIds = new Set<string>();
+  let previousWasModel = false;
+  let duplicateResultCount = 0;
+  const messages = contents.flatMap((content) => {
+    const isModel = content.role === "model";
+    if (isModel) {
+      if (!previousWasModel) {
+        turnCallCounts.clear();
+        turnResultIds.clear();
+      }
+      for (const part of content.parts || []) {
+        const call = part.functionCall;
+        if (call?.name && typeof call.id === "string" && call.id.length > 0) {
+          turnCallCounts.set(call.id, (turnCallCounts.get(call.id) || 0) + 1);
+        }
+      }
+    }
+    previousWasModel = isModel;
+
+    let droppedDuplicate = false;
+    const parts = (content.parts || []).flatMap((part) => {
+      // CLI restore can repeat results within a turn. A later call with the
+      // same ID needs its own result, and id-less results are not identifiable.
+      const resultId = part.functionResponse?.id;
+      if (
+        !isModel &&
+        typeof resultId === "string" &&
+        turnCallCounts.get(resultId) === 1
+      ) {
+        if (turnResultIds.has(resultId)) {
+          droppedDuplicate = true;
+          duplicateResultCount++;
+          return [];
+        }
+        turnResultIds.add(resultId);
+      }
       // For functionCall: use the pre-assigned callId so the tool-result side
       // has something to match against.
       if (part.functionCall?.name) {
@@ -302,6 +337,9 @@ export const convertGeminiContentsToVSCode = (
     });
 
     if (parts.length === 0) {
+      if (droppedDuplicate) {
+        return [];
+      }
       parts.push(new vscode.LanguageModelTextPart(""));
     }
 
@@ -327,6 +365,13 @@ export const convertGeminiContentsToVSCode = (
       >,
     );
   });
+
+  if (duplicateResultCount > 0) {
+    logger.warn(
+      `Gemini tool result recovery: dropped ${duplicateResultCount} duplicate result(s) within tool-call turns`,
+    );
+  }
+  return messages;
 };
 
 /**

--- a/src/test/server/gemini.test.ts
+++ b/src/test/server/gemini.test.ts
@@ -1,4 +1,8 @@
-import { FunctionCallingConfigMode } from "@google/genai";
+import {
+  type Content,
+  FunctionCallingConfigMode,
+  type Part,
+} from "@google/genai";
 import * as assert from "assert";
 import * as vscode from "vscode";
 
@@ -325,6 +329,251 @@ suite("Gemini Conversion Utils Test Suite", () => {
         "call_B",
         "id-less response must drain to call_B, not stale call_A",
       );
+    });
+  });
+
+  suite("Gemini resume result deduplication", () => {
+    const call = (id: string, name = "lookup"): Part => ({
+      functionCall: { id, name, args: {} },
+    });
+    const response = (id: string, output = "first", name = "lookup"): Part => ({
+      functionResponse: { id, name, response: { output } },
+    });
+    const toolResults = (messages: vscode.LanguageModelChatMessage[]) =>
+      messages
+        .flatMap((message) => message.content)
+        .filter((part) => part instanceof vscode.LanguageModelToolResultPart);
+    const toolCalls = (messages: vscode.LanguageModelChatMessage[]) =>
+      messages
+        .flatMap((message) => message.content)
+        .filter((part) => part instanceof vscode.LanguageModelToolCallPart);
+
+    for (const separateMessages of [false, true]) {
+      test(`drops repeated results within a call turn in ${separateMessages ? "separate user messages" : "one user message"}`, () => {
+        const contents: Content[] = [
+          { role: "model", parts: [call("x")] },
+          ...(separateMessages
+            ? [
+                { role: "user", parts: [response("x")] },
+                { role: "user", parts: [response("x", "replayed")] },
+              ]
+            : [
+                {
+                  role: "user",
+                  parts: [response("x"), response("x", "replayed")],
+                },
+              ]),
+          { role: "model", parts: [{ text: "Done" }] },
+        ];
+        const original = structuredClone(contents);
+        const converted = convertGeminiContentsToVSCode(contents);
+        const results = toolResults(converted);
+
+        assert.strictEqual(converted.length, 3);
+        assert.strictEqual(toolCalls(converted).length, 1);
+        assert.strictEqual(results.length, 1);
+        assert.strictEqual(results[0].callId, "x");
+        assert.strictEqual(
+          (results[0].content[0] as vscode.LanguageModelTextPart).value,
+          JSON.stringify({ output: "first" }),
+        );
+        assert.deepStrictEqual(contents, original);
+        assert.deepStrictEqual(
+          convertGeminiContentsToVSCode(contents),
+          converted,
+        );
+      });
+    }
+
+    for (const laterOutput of ["first", "later"]) {
+      test(`preserves a complete later call/result pair with the same ID and ${laterOutput} output`, () => {
+        const converted = convertGeminiContentsToVSCode([
+          { role: "model", parts: [call("x")] },
+          { role: "user", parts: [response("x"), response("x")] },
+          { role: "model", parts: [call("x")] },
+          {
+            role: "user",
+            parts: [response("x", laterOutput), response("x", laterOutput)],
+          },
+        ]);
+
+        assert.strictEqual(converted.length, 4);
+        assert.deepStrictEqual(
+          toolCalls(converted).map((part) => part.callId),
+          ["x", "x"],
+        );
+        const results = toolResults(converted);
+        assert.deepStrictEqual(
+          results.map((part) => part.callId),
+          ["x", "x"],
+        );
+        assert.deepStrictEqual(
+          results.map(
+            (part) => (part.content[0] as vscode.LanguageModelTextPart).value,
+          ),
+          [
+            JSON.stringify({ output: "first" }),
+            JSON.stringify({ output: laterOutput }),
+          ],
+        );
+      });
+    }
+
+    test("preserves parallel same-name calls across consecutive model messages", () => {
+      const converted = convertGeminiContentsToVSCode([
+        { role: "model", parts: [call("a")] },
+        { role: "model", parts: [call("b")] },
+        {
+          role: "user",
+          parts: [
+            response("b", "B"),
+            response("a", "A"),
+            response("b", "B"),
+            response("a", "A"),
+          ],
+        },
+      ]);
+      assert.deepStrictEqual(
+        toolCalls(converted).map((part) => part.callId),
+        ["a", "b"],
+      );
+      assert.deepStrictEqual(
+        toolResults(converted).map((part) => part.callId),
+        ["b", "a"],
+      );
+    });
+
+    test("preserves text and images next to repeated results", () => {
+      const image = {
+        mimeType: "image/png",
+        data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+aFE8AAAAASUVORK5CYII=",
+      };
+      const converted = convertGeminiContentsToVSCode([
+        { role: "model", parts: [call("x")] },
+        { role: "user", parts: [response("x")] },
+        {
+          role: "user",
+          parts: [
+            { text: "Keep context" },
+            response("x"),
+            { inlineData: image },
+          ],
+        },
+      ]);
+      assert.strictEqual(converted.length, 3);
+      assert.strictEqual(toolResults(converted).length, 1);
+      assert.strictEqual(converted[2].content.length, 2);
+      assert.deepStrictEqual(
+        converted[2].content[0],
+        new vscode.LanguageModelTextPart("Keep context"),
+      );
+      const data = converted[2].content[1];
+      assert.ok(data instanceof vscode.LanguageModelDataPart);
+      assert.strictEqual(data.mimeType, image.mimeType);
+      assert.deepStrictEqual(
+        Buffer.from(data.data),
+        Buffer.from(image.data, "base64"),
+      );
+    });
+
+    test("does not consume another FIFO match when dropping an explicit duplicate", () => {
+      const converted = convertGeminiContentsToVSCode([
+        { role: "model", parts: [call("a"), call("b")] },
+        {
+          role: "user",
+          parts: [
+            response("a"),
+            response("a"),
+            { functionResponse: { name: "lookup", response: { output: "B" } } },
+          ],
+        },
+      ]);
+      assert.deepStrictEqual(
+        toolResults(converted).map((part) => part.callId),
+        ["a", "b"],
+      );
+    });
+
+    test("does not infer duplicates for id-less results", () => {
+      const converted = convertGeminiContentsToVSCode([
+        {
+          role: "model",
+          parts: [
+            { functionCall: { name: "lookup", args: {} } },
+            { functionCall: { name: "lookup", args: {} } },
+          ],
+        },
+        {
+          role: "user",
+          parts: [
+            {
+              functionResponse: {
+                name: "lookup",
+                response: { output: "same" },
+              },
+            },
+            {
+              functionResponse: {
+                name: "lookup",
+                response: { output: "same" },
+              },
+            },
+          ],
+        },
+      ]);
+      const ids = toolCalls(converted).map((part) => part.callId);
+      assert.strictEqual(new Set(ids).size, 2);
+      assert.deepStrictEqual(
+        toolResults(converted).map((part) => part.callId),
+        ids,
+      );
+    });
+
+    test("leaves unmatched results unchanged without poisoning a later pair", () => {
+      const converted = convertGeminiContentsToVSCode([
+        {
+          role: "user",
+          parts: [response("x", "orphan"), response("x", "orphan")],
+        },
+        { role: "model", parts: [call("x")] },
+        {
+          role: "user",
+          parts: [response("x", "valid"), response("x", "valid")],
+        },
+      ]);
+      assert.strictEqual(converted[0].content.length, 2);
+      assert.ok(
+        converted[0].content.every(
+          (part) => part instanceof vscode.LanguageModelToolResultPart,
+        ),
+      );
+      assert.strictEqual(converted[2].content.length, 1);
+      const result = converted[2].content[0];
+      assert.ok(result instanceof vscode.LanguageModelToolResultPart);
+      assert.strictEqual(
+        (result.content[0] as vscode.LanguageModelTextPart).value,
+        JSON.stringify({ output: "valid" }),
+      );
+    });
+
+    test("does not match results against an earlier model turn", () => {
+      const converted = convertGeminiContentsToVSCode([
+        { role: "model", parts: [call("x")] },
+        { role: "user", parts: [response("x")] },
+        { role: "model", parts: [{ text: "Done" }] },
+        { role: "user", parts: [response("x"), response("x")] },
+      ]);
+      assert.strictEqual(converted[3].content.length, 2);
+      assert.strictEqual(toolResults(converted).length, 3);
+    });
+
+    test("does not deduplicate results when the call ID is ambiguous within one turn", () => {
+      const converted = convertGeminiContentsToVSCode([
+        { role: "model", parts: [call("x"), call("x")] },
+        { role: "user", parts: [response("x"), response("x")] },
+      ]);
+      assert.strictEqual(toolCalls(converted).length, 2);
+      assert.strictEqual(toolResults(converted).length, 2);
     });
   });
 


### PR DESCRIPTION
## Summary

Resuming a Gemini CLI session can replay each tool result twice, causing upstream `invalid_tool_call_format` errors. Deduplicate explicitly identified results within the corresponding tool-call turn, only when the call ID appears once in that turn. Reset deduplication at the next model turn so complete call/result pair replays remain paired. Preserve surrounding text and images.

Scope is limited to Gemini resume compatibility. Shared tracker, Anthropic/OpenAI behavior, and existing unmatched/ID-less history handling are unchanged. Includes README guidance and patch changeset `.changeset/icy-donkeys-live.md`.

## Test plan

- [x] Type-check, ESLint, development build, Prettier, and `git diff --check`.
- [x] Full extension suite: 531 passing using installed VS Code Insiders and a temporary test configuration (the default cached host launcher failed with ENOENT).
- [x] Converter regressions for repeated results across one or multiple user messages, complete pair replay, same-ID reuse across turns, parallel same-name calls, and mixed text/image content.
- [x] Live `gemini-3.8-flash` tests through AM on port 33333: duplicate-result and complete-pair replay succeed; the original 30-call/60-result failing transcript is accepted with STOP and a next tool call.
- [x] Real Gemini CLI `--resume` succeeds with the expected saved result and no AM request error.
