### PR TITLE
fix(proxy): normalize tool histories across API adapters

### DIFF
--- a/.changeset/real-plums-tan.md
+++ b/.changeset/real-plums-tan.md
@@ -1,0 +1,5 @@
+---
+"agent-maestro": patch
+---
+
+fix(proxy): normalize incomplete and replayed tool histories across API adapters

--- a/README.md
+++ b/README.md
@@ -232,7 +232,9 @@ Agent Maestro reports real Copilot usage metadata for Anthropic responses when V
 
 - **Codex:** When you run **Agent Maestro: Configure Codex Settings**, Agent Maestro writes `model_context_window` into Codex's `config.toml` using the selected model's reported `maxInputTokens`. This tells Codex the effective context window size upfront so it manages its own conversation history accordingly. To customize it, edit `model_context_window` in `~/.codex/config.toml` directly.
 
-If compaction or replay leaves a tool result without its original call, Agent Maestro preserves the result as ordinary context instead of forwarding an invalid tool transcript. Repeated results for the same call ID are ignored after the first result.
+Agent Maestro normalizes inbound tool history across Anthropic, OpenAI Chat Completions/Responses, and Gemini. Calls with no recorded result become short execution-status-unknown notes; results without a matching call remain ordinary context. Within a call turn, identical duplicates are merged and conflicting calls/results are preserved as conflict context. Complete pairs in later turns are retained with unique upstream IDs when needed. Normalization does not execute tools, summarize result bodies, or change client session files and newly generated response IDs.
+
+Anthropic tool blocks supplied under the wrong message role remain ordinary context: calls retain an execution-status-unknown note, and results retain their content, error status, and supported media.
 
 ### Prompt Cache Compatibility
 
@@ -397,7 +399,7 @@ Perfect for Gemini CLI integration:
 
 Streaming responses send blank-line heartbeats while waiting for the model, keeping long-running requests alive without interrupting Gemini CLI or Google Gen AI SDK stream parsing. These heartbeats do not produce extra response chunks or affect generated content and token usage.
 
-Gemini CLI session restoration can repeat results for a single tool-call turn. For a call with an explicit ID that appears once in that turn, Agent Maestro keeps its first explicitly identified result and ignores repeats in the following user messages. A later model turn starts a new scope, so replaying a complete call/result pair does not leave a call without its result.
+Gemini results without IDs are paired with unmatched calls to the same tool within the current turn, after explicit IDs have been matched. Excess or ambiguous results remain context instead of being matched to future calls. Restored results with different bodies, including masked versus full output, remain visible as conflict context; only structurally equal results with the same explicit identity are deduplicated.
 
 > **Thinking levels**: Not forwarded for Gemini. Copilot's Gemini path does not read the `thinkingConfig.thinkingLevel` parameter from the model configuration; it only applies a hardcoded `low` effort behind an internal experiment flag, so any forwarded value would be ignored.
 

--- a/docs/2026-09-04-tool-history-normalization-design.md
+++ b/docs/2026-09-04-tool-history-normalization-design.md
@@ -1,0 +1,157 @@
+# Tool History Normalization Design
+
+## Status and Scope
+
+Implemented and validated on 2026-09-05. Baseline recorded on 2026-09-04: `main` at `f041fe1`, which includes [#251](https://github.com/Joouis/agent-maestro/pull/251).
+
+Unify **inbound history normalization** across Anthropic Messages, OpenAI Chat Completions / Responses (including custom tools), and Gemini GenerateContent. The goal is to send complete tool-call/result pairs to VS Code LM while preserving useful task progress.
+
+Normalize only the history supplied in the current request. Do not execute tools, modify client session files, or process tool calls that the model is still generating. SSE, retries, authentication, and model selection are outside this scope. Gemini Live / NON_BLOCKING incremental results do not fit this finite-history model and must not be treated as replay duplicates.
+
+Normalization runs on a decoded history snapshot before an upstream model request, never on the outbound response stream. End-of-request finalization means the end of that input snapshot, not completion of a live tool execution.
+
+## Core Decisions
+
+**Identify complete tool-call turns and pairs before deciding what to preserve, convert to context, or deduplicate.** Replace the global `seenResultIds` approach that deletes results as they arrive. The following rules are proposed defaults for the first version.
+
+| Situation                                                                     | Content sent to the model                                                               | Rationale                                                                                      |
+| ----------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| Unambiguously matched call and result                                         | Preserve the complete pair; error results and explicitly empty results count as results | Tool failure is different from a missing result                                                |
+| Call without a result                                                         | Remove the formal tool call and retain a short execution-status-unknown note            | A missing result does not prove the tool did not execute; avoid repeated submissions or writes |
+| Result without a call                                                         | Preserve the result as ordinary context with a provenance marker                        | Retrieved information, file locations, and computed values may still be useful                 |
+| Same turn, same ID, identical results                                         | Keep one result                                                                         | The information is identical and does not require multiple tool results                        |
+| Same turn, same ID, different results                                         | Convert the associated calls and results to ordinary context with a conflict note       | Do not infer the final result from ordering or length, or invent an unambiguous pair           |
+| Complete call/result pairs replayed across turns                              | Preserve each pair, remapping upstream IDs when necessary                               | Matching IDs and content do not prove that these were not separate executions                  |
+| Repeated calls within a turn with the same ID, tool name, type, and arguments | Merge the calls and handle their results together under the rules above                 | Calls and results must be evaluated as a group                                                 |
+| Repeated ID within a turn with different tool names, types, or arguments      | Convert the related calls and results to conflict context                               | The ID does not uniquely identify a call; do not choose arbitrarily                            |
+
+Ordinary context remains historical data with explicit provenance. It is not a new user instruction and must never be promoted to system/developer instructions. Preserve unrelated text/images and their relative order. The output renderer combines same-turn call/result messages and keeps parallel formal tool parts contiguous, followed by ordinary content from that message group: Copilot rejects text interleaved between parallel results. Nothing moves across a turn boundary. Omit a message only when all its content has been explicitly removed.
+
+### Calls Without Results: What to Retain
+
+AM cannot reliably determine whether an arbitrary third-party tool has side effects, nor does it have a reliable not-executed marker. The first version therefore does not infer whether a call can be discarded from names such as `read_*`.
+
+- Remove the formal `ToolCallPart` and full arguments to avoid dangling calls and large inputs with no result.
+- Combine missing results into one short note per tool-call turn, for example: `[Incomplete tool history: submit_expense has no recorded result. Execution status is unknown; verify before retrying.]`
+- Count repeated tool names rather than listing them repeatedly. Retain only bounded tool names/call references, excluding credentials, request bodies, and full arguments. The note asserts neither that execution occurred nor that it did not.
+- A content-free call with no tool name, valid ID, usable arguments, or other interpretable information may be omitted. If reliable not-executed/cancelled status becomes available later, define separate conditions for omitting the note.
+
+### Results Without Calls: Preservation and Compression
+
+The first version **preserves information while reducing wrapper overhead**, without another LLM summarization step:
+
+- Preserve text, structured output, error details, and images/media already supported by the adapters. Do not automatically discard `0`, `false`, explicitly empty containers, or status strings as noise.
+- Identify the known tool name, original call reference, and missing match. Do not infer the original arguments or synthesize a tool execution that is absent from history.
+- Remove redundant protocol wrappers. Identical orphaned results with the same explicit source ID within one turn may be merged. Without an ID, do not deduplicate by content or tool name.
+- Reuse existing media converters and limits; do not serialize base64 into ordinary text. Adding format support is outside scope. Preserve existing masked/truncated text and acknowledge its incompleteness.
+- Do not truncate result bodies by default or claim to identify useful passages automatically. Existing context limits still apply to the whole request. Lossy summaries, cross-task caching, and additional automatic truncation policies require separate evaluation.
+
+Orphaned results may therefore still consume substantial tokens. This avoids trading an unverified compression rule for silent information loss.
+
+This is not a reversal of #251: that fix already preserves complete pairs across turns and removes repeated results within a call turn. Preserving conflicting result bodies as context can, however, increase input size compared with its first-result-wins behavior. Compare serialized size and input token counts on the retained resume fixtures; do not assume every resume becomes larger or claim universal token savings.
+
+## Pairing, Turns, and IDs
+
+### Turn Boundaries
+
+Adapters identify tool-call turns before role conversion or message merging: a group of consecutive assistant/model call messages followed by their result messages. Consecutive OpenAI Responses call items belong to one group; function and custom tools use separate matching types.
+
+- A new assistant/model turn, independent user input without tool results, an instruction boundary, or the end of the request closes the current turn.
+- When a user message mixes results with text or images, its results still belong to the current turn. Other content is neither deleted nor moved.
+- Results can match only calls already encountered in the current turn. They cannot cross boundaries, match future calls, or connect separate turns merely because tool names match. Late results become orphaned context.
+- Finalize missing results only when the turn closes. Receiving the first result does not mean other parallel calls are missing their results.
+- Do not attach a result across a subsequent assistant message, even if that message contains only text. Without reliable turn information, preserve context rather than moving historical messages to manufacture a pair.
+
+### Explicit IDs and Missing IDs
+
+Use `(turn index, tool type, call occurrence index)` as the internal identity. The original protocol ID is a matching hint. Typed Responses function/custom outputs distinguish their respective namespaces; if an untyped result could refer to calls of both types, treat the group as conflicting rather than selecting one.
+
+1. Match valid explicit IDs within the current turn first. If a result includes a tool name, the name must also match. Unknown/conflicting IDs must not fall back to forced name matching.
+2. Gemini permits omitted IDs. Explicit results reserve their matching calls first; then assign ID-less results in FIFO order to unmatched calls with the same name. This is a deterministic recovery rule for mixed formats, not proof of execution provenance.
+3. Two ID-less calls to the same tool remain separate pairs even when their arguments/results are identical. Excess ID-less results become orphaned context. Do not infer that an unknown explicit result ID belongs to an ID-less call solely from the tool name.
+4. Do not add name-based missing-ID recovery for Anthropic or OpenAI. Content that cannot be located unambiguously is handled as missing or conflicting.
+5. Every retained pair receives a unique ID in the upstream request. Preserve the original ID when it is usable and globally unique within that request. For ID reuse, cross-tool-type collisions, or Gemini calls without IDs, generate deterministic local IDs and rewrite both sides of each pair. Reserve all explicit input IDs to avoid collisions with generated IDs.
+
+Historical ID remapping applies only to the normalized copy sent in the current upstream request. The normalizer does not mutate client input or session files, and its mapping is not used by response serializers. Newly generated tool-call IDs follow the existing outbound conversion and are persisted by the client as usual; the next request is normalized independently. No reverse mapping or persistent ID registry is introduced.
+
+**Do not deduplicate content across turns.** Identical IDs and content may represent a replay or another execution. Without sufficient execution identity, preserving complete pairs is more reliable than deleting one side or guessing which occurrence is authoritative.
+
+Conflict context includes the tool name and necessary call information, states that the relationship cannot be determined, and avoids repeating large arguments. Unknown or invalid IDs must not create state that affects later turns. These rules do not claim to recover the true execution semantics of damaged history; they prevent normalization from inventing a successful pairing.
+
+## Required Examples
+
+`C` denotes a call, `R` a result, and `→` the original order. Brackets identify turns; a call after a result starts a new turn. Ordinary context stays in its original turn and retains its relative order, subject to grouping parallel formal parts for the upstream serializer.
+
+| Input history                                            | Expected output                                                                             |
+| -------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `C(x) → R(x)`                                            | One complete pair                                                                           |
+| `C(x)` followed by the end of the request                | One result-unknown note, no formal tool call                                                |
+| `R(x)`                                                   | Result context with a provenance marker                                                     |
+| `R(x) → C(x) → R(x)`                                     | Earlier result becomes context; later pair remains valid, without orphan state poisoning it |
+| `C(x) → R(x) → R(x)`, identical results                  | One complete pair within the turn                                                           |
+| `C(x) → R(x, a) → R(x, b)`, different results            | Conflict note and both results as context, no formal pair; no first/last-wins rule          |
+| `[C(x) → R(x)] → [C(x) → R(x)]`                          | Two complete pairs in different turns; use distinct upstream IDs                            |
+| `[C(x), C(x) → R(x), R(x)]`, identical calls and results | One complete pair in the same turn                                                          |
+| `[C(x), C(x) → R(x, a), R(x, b)]`, different results     | Conflict context for the whole group, no formal pair                                        |
+| Parallel `C(a), C(b)` followed by `R(b), R(a)`           | Pair by ID and preserve both results                                                        |
+| `C(a), C(b)` followed only by `R(a)`                     | Preserve pair a; replace call b with a result-unknown note                                  |
+| Two ID-less `C(f), C(f)` followed by one `R(f)`          | Pair the first call by FIFO; replace the second with a result-unknown note                  |
+| ID-less `C(f) → R(f), R(f) → C(f) → R(f)`                | First turn has one pair plus orphaned context; second turn still pairs normally             |
+
+## Implementation Design
+
+Replace the tracker's global seen-set decisions with a **pure, request-local history normalization stage**, rather than reusing the incremental state-machine patches from the earlier unmerged work.
+
+Pipeline: `protocol decoding and turn annotation → pairing and group decisions → VS Code message generation`.
+
+### Responsibilities
+
+| Layer             | Responsibilities                                                                                                                                                                                |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Protocol adapter  | Preserve source positions, original roles, turn boundaries, tool type/name/original ID, arguments, and result parts. Protocol-specific media, custom input, and thinking conversion remain here |
+| Shared normalizer | Analyze complete turns; classify groups as `paired / missing-result / orphaned-result / duplicate / conflict`; assign unique upstream IDs and produce preservation/conversion decisions         |
+| Output generator  | Generate formal tool messages or ordinary context from the plan, retain surrounding content, and omit genuinely empty messages. Do not run a second independent deduplication policy            |
+
+The shared layer retains **source references and occurrences** for calls and results rather than only `Set<id>`. A proposed interface is `normalizeToolHistory(events) -> { decisions, diagnostics }`, with `call/result/content/boundary` events and decisions referring to specific input positions. Input is immutable; there is no cross-request cache.
+
+Diagnostics are per-request counts of retained pairs, missing results, orphaned results, removed duplicate calls/results, conflict groups, and remapped IDs. The adapter logs one summary from this result rather than aggregating mutable trackers. Model-visible provenance may retain bounded names/references from the supplied history; logs contain counts, not those values or result content.
+
+Emit decisions only when `finalizeTurn()` closes a turn. This allows the normalizer to:
+
+- Examine all parallel calls and conflicting results before deleting anything that could affect pairing.
+- Preserve distinct occurrences of reused IDs instead of resetting a global seen bit.
+- Generate messages in source order, grouping parallel formal parts as required by the upstream serializer within the same turn. ID remapping changes only formal call/result references, not result bodies.
+
+Compare content structurally: object key order is irrelevant, array order is preserved, and media is compared using actual content or existing references. Do not use semantic similarity. If hashes are used as an index, confirm equal hashes with structural comparison; a hash match alone never authorizes deletion. Do not write content fingerprints to logs.
+
+Validate invariants over the final emitted formal tool parts only: every formal result corresponds to exactly one earlier call in the request, and every formal call has exactly one result, with matching type and turn. Calls/results converted to ordinary context are excluded from this check. If the implementation violates an invariant, stop before sending upstream and report an internal normalization error. Do not hide it by deleting an arbitrary side.
+
+### Integration Points
+
+- Redesign the shared implementation and diagnostics interface in `src/server/utils/toolResultPairing.ts`.
+- Integrate at the four array conversion entry points using the migration paths below. Preserve protocol representation conversion and boundaries between instruction arrays and history input.
+- Remove superseded pairing/deduplication at each migrated entry point to avoid double processing. Single-message helpers must not decide that a result is missing; only entry points with the complete history make that decision.
+- Server-generated web-search turns are checked only as completed snapshots when preparing the next upstream request. Do not run finalization over the live execution loop or newly generated calls awaiting results. Existing server-tool handling remains distinct from client function/custom-tool identities.
+- Preserve the current public counting behavior of `/api/anthropic/v1/messages/count_tokens` and `/api/gemini/v1beta/models/{model}:countTokens`: both currently estimate the serialized request body. Changing these endpoint contracts or existing usage-estimation rules is outside v1. Fixture measurements of normalized input are separate from client-visible counts and provider-reported usage.
+- Log only reason/count summaries, without adding raw arguments, results, or sensitive IDs. Track recoveries per request. HTTP 200 and CLI exit 0 are not sufficient success criteria.
+
+| Entry point          | Current implementation                                                 | Migration and regression focus                                                                       |
+| -------------------- | ---------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `anthropic.ts`       | Uses the shared tracker                                                | Replace tracker decisions; preserve mixed content and orphan-context conversion                      |
+| `openaiResponses.ts` | Uses separate shared trackers for function/custom tools                | Replace tracker decisions; preserve tool types, parallel item grouping, and instruction boundaries   |
+| `openaiChat.ts`      | Converts tool messages directly, without pairing checks                | Introduce normalization; verify valid chat histories remain unchanged                                |
+| `gemini.ts`          | Uses an inline name-based FIFO queue and #251 turn-local deduplication | Replace both with shared decisions while preserving Gemini ID-less matching and resume compatibility |
+
+Valid histories should retain their existing behavior. This work adds no dependencies and does not change response protocols.
+
+## Validation and Delivery Boundaries
+
+Start with shared pure-logic tests from the example table, then run equivalent semantic scenarios through all four entry points to verify roles, media, and tool-type conversion. Check idempotence, input immutability, generated-ID uniqueness, and the absence of dangling formal tool messages.
+
+Additional cases must cover parallel results split across messages, ambiguous IDs within a turn, reused IDs across turns, mixed explicit/omitted IDs, conflicting result content including masking, empty/error results, large text or media in orphaned results, non-tool content ordering, and state isolation between requests.
+
+Retain the original input of the real Gemini CLI resume failure fixture from #251. Review and update its expected normalized output under these rules: structurally equal objects remain equal despite key order, but genuinely different or masked/full result bodies become conflict context. Do not require byte-for-byte output parity with #251; require upstream acceptance, information preservation, and complete emitted pairs. Cover recovery requests for Anthropic and both OpenAI endpoints, server web-search turns, and official SDK behavior. Run type-checking, lint, and the full extension suite; live verification must inspect AM logs and response contents.
+
+Integrate and validate one entry point at a time, then run cross-adapter regressions before release. Observe recovery counts, upstream transcript errors, and fixture input-size changes. Rollback uses the normal release/revert process; v1 does not add a runtime feature flag, parallel legacy normalizer, or automatic fallback that could conceal a broken invariant.
+
+Implementation updates the README and includes a changeset. Lossy result compression, cross-turn inference of execution identity, tool execution/retry policies, and Live API support are outside the first version.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -34,6 +34,8 @@ pnpm run watch-tests
 | `server/openaiResponses.test.ts`               | 52    | OpenAI Responses → VS Code conversion                                                                   |
 | `server/gemini.test.ts`                        | 27    | Gemini → VS Code message conversion                                                                     |
 | `server/sseHeartbeat.test.ts`                  | 16    | Startup/token-counting heartbeats, SDK snapshots, lifecycle cleanup, and frame order under backpressure |
+| `server/toolHistory.test.ts`                   | 65    | Shared normalization, replay, IDs, media, skipped tool types, and wrong-role Anthropic tool blocks      |
+| `server/toolHistoryRoutes.test.ts`             | 1     | Official SDK requests and streaming responses preserve new IDs after historical remapping               |
 
 ## How Tests Prevent Regressions
 

--- a/src/server/utils/anthropic.ts
+++ b/src/server/utils/anthropic.ts
@@ -4,10 +4,7 @@ import * as vscode from "vscode";
 import { logger } from "../../utils/logger";
 import { extractCopilotUsagePayload } from "./copilotUsage";
 import { mimeForVscodeLm } from "./imageMime";
-import {
-  ToolResultPairingTracker,
-  logToolResultRecovery,
-} from "./toolResultPairing";
+import { type ToolHistoryPart, toolHistoryToVSCode } from "./toolResultPairing";
 
 const textBlockParamToVSCodePart = (param: Anthropic.Messages.TextBlockParam) =>
   new vscode.LanguageModelTextPart(param.text);
@@ -76,19 +73,6 @@ const webSearchToolResultBlockParamToVSCodePart = (
   param: Anthropic.Messages.WebSearchToolResultBlockParam,
 ) => new vscode.LanguageModelTextPart(JSON.stringify(param));
 
-const orphanedToolResultToVSCodeParts = (
-  callId: unknown,
-  content: Array<vscode.LanguageModelTextPart | vscode.LanguageModelDataPart>,
-  invalid = false,
-) => [
-  new vscode.LanguageModelTextPart(
-    invalid
-      ? `[Tool result with an invalid call ID: ${JSON.stringify(callId) ?? String(callId)}]`
-      : `[Tool result without a matching tool call: ${JSON.stringify(callId)}]`,
-  ),
-  ...content,
-];
-
 const searchResultBlockParamToVSCodePart = (
   param: Anthropic.Messages.SearchResultBlockParam,
 ) => {
@@ -103,7 +87,6 @@ const searchResultBlockParamToVSCodePart = (
  */
 const convertContentToVSCodeParts = (
   content: string | Array<Anthropic.Messages.ContentBlockParam>,
-  pairing?: ToolResultPairingTracker,
 ): Array<
   | vscode.LanguageModelTextPart
   | vscode.LanguageModelToolResultPart
@@ -120,7 +103,6 @@ const convertContentToVSCodeParts = (
     | vscode.LanguageModelToolCallPart
     | vscode.LanguageModelDataPart
   > = [];
-  let droppedDuplicate = false;
 
   for (const block of content) {
     switch (block.type) {
@@ -143,35 +125,11 @@ const convertContentToVSCodeParts = (
         parts.push(redactedThinkingBlockParamToVSCodePart(block));
         break;
       case "tool_use":
-        if (pairing && !pairing.recordCall(block.id)) {
-          parts.push(
-            new vscode.LanguageModelTextPart(
-              `[Tool call with an invalid call ID]\n${JSON.stringify(block)}`,
-            ),
-          );
-          break;
-        }
         parts.push(toolUseBlockParamToVSCodePart(block));
         break;
-      case "tool_result": {
-        const result = pairing?.recordResult(block.tool_use_id);
-        if (result === "duplicate") {
-          droppedDuplicate = true;
-          break;
-        }
-        if (result === "invalid" || result === "orphaned") {
-          parts.push(
-            ...orphanedToolResultToVSCodeParts(
-              block.tool_use_id,
-              toolResultBlockParamToVSCodeContent(block),
-              result === "invalid",
-            ),
-          );
-          break;
-        }
+      case "tool_result":
         parts.push(toolResultBlockParamToVSCodePart(block));
         break;
-      }
       case "server_tool_use":
         parts.push(new vscode.LanguageModelTextPart(JSON.stringify(block)));
         break;
@@ -187,7 +145,7 @@ const convertContentToVSCodeParts = (
   if (parts.length > 0) {
     return parts;
   }
-  return droppedDuplicate ? [] : [new vscode.LanguageModelTextPart("")];
+  return [new vscode.LanguageModelTextPart("")];
 };
 
 const createVSCodeMessage = (
@@ -241,18 +199,88 @@ export const convertAnthropicMessageToVSCode = (
 export const convertAnthropicMessagesToVSCode = (
   messages: Array<Anthropic.Messages.MessageParam>,
 ): vscode.LanguageModelChatMessage[] => {
-  const results: vscode.LanguageModelChatMessage[] = [];
-  const pairing = new ToolResultPairingTracker();
-
-  for (const message of messages) {
-    const contentParts = convertContentToVSCodeParts(message.content, pairing);
-    if (contentParts.length > 0) {
-      results.push(createVSCodeMessage(message.role, contentParts));
-    }
-  }
-
-  logToolResultRecovery("Anthropic", [pairing]);
-  return results;
+  return toolHistoryToVSCode(
+    messages.map((message) => ({
+      role: message.role,
+      parts:
+        typeof message.content === "string"
+          ? [
+              {
+                kind: "content",
+                parts: [new vscode.LanguageModelTextPart(message.content)],
+              },
+            ]
+          : message.content.map((block): ToolHistoryPart => {
+              if (block.type === "tool_use" && message.role === "assistant") {
+                return {
+                  kind: "call",
+                  id: block.id,
+                  name: block.name,
+                  toolType: "function",
+                  input: block.input as object,
+                  value: block.input,
+                };
+              }
+              if (block.type === "tool_result" && message.role === "user") {
+                return {
+                  kind: "result",
+                  id: block.tool_use_id,
+                  toolType: "function",
+                  parts: toolResultBlockParamToVSCodeContent(block),
+                  value: {
+                    content: block.content,
+                    isError: block.is_error ?? false,
+                  },
+                  isError: block.is_error,
+                };
+              }
+              if (block.type === "tool_use" || block.type === "tool_result") {
+                // A misplaced block is historical context, never a pairing candidate.
+                const reference = JSON.stringify(
+                  block.type === "tool_use"
+                    ? { name: block.name, id: block.id }
+                    : { id: block.tool_use_id },
+                ).slice(0, 200);
+                return {
+                  kind: "content",
+                  parts:
+                    block.type === "tool_use"
+                      ? [
+                          new vscode.LanguageModelTextPart(
+                            `[Tool call in user message: ${reference}. Arguments omitted. Execution status is unknown; verify before retrying.]`,
+                          ),
+                        ]
+                      : [
+                          new vscode.LanguageModelTextPart(
+                            `[Tool result in assistant message: ${reference}; pairing is uncertain.]`,
+                          ),
+                          ...(block.is_error
+                            ? [
+                                new vscode.LanguageModelTextPart(
+                                  "[Tool reported an error]",
+                                ),
+                              ]
+                            : []),
+                          ...toolResultBlockParamToVSCodeContent(block),
+                        ],
+                };
+              }
+              return {
+                kind: "content",
+                parts: convertContentToVSCodeParts([block]).filter(
+                  (
+                    part,
+                  ): part is
+                    | vscode.LanguageModelTextPart
+                    | vscode.LanguageModelDataPart =>
+                    part instanceof vscode.LanguageModelTextPart ||
+                    part instanceof vscode.LanguageModelDataPart,
+                ),
+              };
+            }),
+    })),
+    "Anthropic",
+  );
 };
 
 /**

--- a/src/server/utils/gemini.ts
+++ b/src/server/utils/gemini.ts
@@ -11,6 +11,7 @@ import * as vscode from "vscode";
 import { logger } from "../../utils/logger";
 import { extractCopilotUsagePayload } from "./copilotUsage";
 import { mimeForVscodeLm } from "./imageMime";
+import { type ToolHistoryPart, toolHistoryToVSCode } from "./toolResultPairing";
 
 /**
  * Map of uppercase/mixed-case type values to lowercase JSON Schema types.
@@ -222,157 +223,55 @@ export const convertGeminiContentToVSCode = (
   );
 };
 
-/**
- * Convert Gemini Contents array to VSCode LanguageModelChatMessages.
- *
- * Why this isn't just `contents.map(convertGeminiContentToVSCode)`: Gemini's
- * API allows clients to send `functionCall`/`functionResponse` parts WITHOUT
- * an explicit `id`, relying on positional pairing within the `contents` array
- * (langchain-google-genai 4.x does this). VSCode's LanguageModel API on the
- * other hand REQUIRES a callId on every tool result and matches it against
- * the preceding tool-call. Without pairing here, every tool-using Gemini
- * conversation through this proxy fails with
- *   "Please ensure that the number of function response parts is equal to
- *    the number of function call parts of the function call turn."
- *
- * Strategy: walk all parts in document order, assigning a stable callId to
- * each functionCall (using its `id` when present, else a synthetic id), and
- * push that callId onto a per-name FIFO queue. When we then encounter a
- * functionResponse without an `id`, we drain the queue for that name to
- * recover the matching callId.
- */
+/** Normalize complete inbound Gemini history before producing VS Code parts. */
 export const convertGeminiContentsToVSCode = (
   contents: Content[],
-): vscode.LanguageModelChatMessage[] => {
-  // Pre-walk: assign a callId to every functionCall and remember it on the
-  // part itself (via WeakMap), and build a per-name FIFO queue we'll drain
-  // during the conversion pass.
-  const callIdByPart = new WeakMap<object, string>();
-  const pendingByName = new Map<string, string[]>();
-  let synthCounter = 0;
-  for (const content of contents) {
-    for (const part of content.parts || []) {
-      if (part.functionCall?.name) {
-        const callId =
-          part.functionCall.id ||
-          `function_call_synth_${synthCounter++}_${part.functionCall.name}`;
-        callIdByPart.set(part as unknown as object, callId);
-        const queue = pendingByName.get(part.functionCall.name) || [];
-        queue.push(callId);
-        pendingByName.set(part.functionCall.name, queue);
-      }
-    }
-  }
-
-  const turnCallCounts = new Map<string, number>();
-  const turnResultIds = new Set<string>();
-  let previousWasModel = false;
-  let duplicateResultCount = 0;
-  const messages = contents.flatMap((content) => {
-    const isModel = content.role === "model";
-    if (isModel) {
-      if (!previousWasModel) {
-        turnCallCounts.clear();
-        turnResultIds.clear();
-      }
-      for (const part of content.parts || []) {
-        const call = part.functionCall;
-        if (call?.name && typeof call.id === "string" && call.id.length > 0) {
-          turnCallCounts.set(call.id, (turnCallCounts.get(call.id) || 0) + 1);
+): vscode.LanguageModelChatMessage[] =>
+  toolHistoryToVSCode(
+    contents.map((content) => ({
+      role: content.role === "model" ? "assistant" : "user",
+      parts: (content.parts || []).map((part): ToolHistoryPart => {
+        if (part.functionCall && content.role === "model") {
+          const call = part.functionCall;
+          return {
+            kind: "call",
+            id: call.id,
+            name: call.name || "",
+            toolType: "function",
+            input: (call.args || {}) as object,
+            value: call.args || {},
+            allowMissingId: true,
+          };
         }
-      }
-    }
-    previousWasModel = isModel;
-
-    let droppedDuplicate = false;
-    const parts = (content.parts || []).flatMap((part) => {
-      // CLI restore can repeat results within a turn. A later call with the
-      // same ID needs its own result, and id-less results are not identifiable.
-      const resultId = part.functionResponse?.id;
-      if (
-        !isModel &&
-        typeof resultId === "string" &&
-        turnCallCounts.get(resultId) === 1
-      ) {
-        if (turnResultIds.has(resultId)) {
-          droppedDuplicate = true;
-          duplicateResultCount++;
-          return [];
+        if (part.functionResponse && content.role !== "model") {
+          const result = part.functionResponse;
+          return {
+            kind: "result",
+            id: result.id,
+            name: result.name,
+            toolType: "function",
+            parts: [
+              new vscode.LanguageModelTextPart(
+                JSON.stringify(result.response ?? {}) ?? "",
+              ),
+            ],
+            value: result.response ?? {},
+            allowMissingId: true,
+          };
         }
-        turnResultIds.add(resultId);
-      }
-      // For functionCall: use the pre-assigned callId so the tool-result side
-      // has something to match against.
-      if (part.functionCall?.name) {
-        const callId = callIdByPart.get(part as unknown as object);
-        if (callId) {
-          return new vscode.LanguageModelToolCallPart(
-            callId,
-            part.functionCall.name,
-            (part.functionCall.args || {}) as object,
-          );
-        }
-      }
-      // For functionResponse: keep the per-name pending queue in sync.
-      // If an explicit id is present, remove that matched callId so it cannot
-      // later be reused by an id-less response for the same function name.
-      // Otherwise, drain the FIFO queue for the matching name and pass that
-      // callId into the part converter so it produces a properly-paired
-      // LanguageModelToolResultPart.
-      let resolvedCallId: string | undefined;
-      if (part.functionResponse?.name) {
-        const queue = pendingByName.get(part.functionResponse.name);
-        if (queue && queue.length > 0) {
-          if (part.functionResponse.id) {
-            const matchedIndex = queue.indexOf(part.functionResponse.id);
-            if (matchedIndex !== -1) {
-              queue.splice(matchedIndex, 1);
-            }
-          } else {
-            resolvedCallId = queue.shift();
-          }
-        }
-      }
-      return convertGeminiPartToVSCodePart(part, resolvedCallId);
-    });
-
-    if (parts.length === 0) {
-      if (droppedDuplicate) {
-        return [];
-      }
-      parts.push(new vscode.LanguageModelTextPart(""));
-    }
-
-    const role = content.role || "user";
-    if (role === "model") {
-      return vscode.LanguageModelChatMessage.Assistant(
-        parts.filter(
-          (p) => !(p instanceof vscode.LanguageModelToolResultPart),
-        ) as Array<
-          | vscode.LanguageModelTextPart
-          | vscode.LanguageModelToolCallPart
-          | vscode.LanguageModelDataPart
-        >,
-      );
-    }
-    return vscode.LanguageModelChatMessage.User(
-      parts.filter(
-        (p) => !(p instanceof vscode.LanguageModelToolCallPart),
-      ) as Array<
-        | vscode.LanguageModelTextPart
-        | vscode.LanguageModelToolResultPart
-        | vscode.LanguageModelDataPart
-      >,
-    );
-  });
-
-  if (duplicateResultCount > 0) {
-    logger.warn(
-      `Gemini tool result recovery: dropped ${duplicateResultCount} duplicate result(s) within tool-call turns`,
-    );
-  }
-  return messages;
-};
+        const converted = convertGeminiPartToVSCodePart(part);
+        return {
+          kind: "content",
+          parts:
+            converted instanceof vscode.LanguageModelTextPart ||
+            converted instanceof vscode.LanguageModelDataPart
+              ? [converted]
+              : [],
+        };
+      }),
+    })),
+    "Gemini",
+  );
 
 /**
  * Convert Gemini systemInstruction to VSCode LanguageModelChatMessages

--- a/src/server/utils/openaiChat.ts
+++ b/src/server/utils/openaiChat.ts
@@ -3,6 +3,11 @@ import * as vscode from "vscode";
 
 import { logger } from "../../utils/logger";
 import { mimeForVscodeLm } from "./imageMime";
+import {
+  type ToolHistoryMessage,
+  type ToolHistoryPart,
+  toolHistoryToVSCode,
+} from "./toolResultPairing";
 
 const convertOpenAIChatCompletionContentPartToUserContent = (
   part: OpenAI.ChatCompletionContentPart,
@@ -48,7 +53,11 @@ const convertOpenAIChatCompletionContentPartToUserContent = (
 export const convertOpenAIMessagesToVSCode = (
   messages: OpenAI.ChatCompletionMessageParam[],
 ): vscode.LanguageModelChatMessage[] => {
-  return messages.map((msg) => {
+  const sourceCalls = new Map<
+    vscode.LanguageModelToolCallPart,
+    OpenAI.ChatCompletionMessageToolCall
+  >();
+  const converted = messages.map((msg) => {
     // Handle different content formats
     let content;
 
@@ -103,27 +112,23 @@ export const convertOpenAIMessagesToVSCode = (
             } catch (e) {
               logger.error("Failed to parse function tool call input", e);
             }
-            content.push(
-              new vscode.LanguageModelToolCallPart(
-                toolCall.id,
-                toolCall.function.name,
-                input,
-              ),
+            const part = new vscode.LanguageModelToolCallPart(
+              toolCall.id,
+              toolCall.function.name,
+              input,
             );
+            sourceCalls.set(part, toolCall);
+            content.push(part);
           } else if (toolCall.type === "custom") {
-            // ChatCompletionMessageCustomToolCall
-            try {
-              input = JSON.parse(toolCall.custom.input);
-            } catch (e) {
-              logger.error("Failed to parse custom tool call input", e);
-            }
-            content.push(
-              new vscode.LanguageModelToolCallPart(
-                toolCall.id,
-                toolCall.custom.name,
-                input,
-              ),
+            // Custom tools carry free-form input, not JSON arguments.
+            input = { input: toolCall.custom.input };
+            const part = new vscode.LanguageModelToolCallPart(
+              toolCall.id,
+              toolCall.custom.name,
+              input,
             );
+            sourceCalls.set(part, toolCall);
+            content.push(part);
           }
         });
         return vscode.LanguageModelChatMessage.Assistant(content);
@@ -133,7 +138,9 @@ export const convertOpenAIMessagesToVSCode = (
         content =
           typeof msg.content === "string"
             ? [new vscode.LanguageModelTextPart(msg.content)]
-            : msg.content;
+            : msg.content.map(
+                (part) => new vscode.LanguageModelTextPart(part.text),
+              );
         return vscode.LanguageModelChatMessage.User([
           new vscode.LanguageModelToolResultPart(msg.tool_call_id, content),
         ]);
@@ -144,6 +151,63 @@ export const convertOpenAIMessagesToVSCode = (
         );
     }
   });
+  const history = converted.map((message, index): ToolHistoryMessage => {
+    const raw = messages[index];
+    return {
+      role:
+        message.role === vscode.LanguageModelChatMessageRole.Assistant
+          ? "assistant"
+          : "user",
+      boundary: raw.role === "system" || raw.role === "developer",
+      parts: message.content.map((part): ToolHistoryPart => {
+        if (
+          part instanceof vscode.LanguageModelToolCallPart &&
+          raw.role === "assistant"
+        ) {
+          // Skipped tool types make raw array positions differ from emitted parts.
+          const call = sourceCalls.get(part)!;
+          let value: unknown;
+          if (call.type === "function") {
+            try {
+              value = JSON.parse(call.function.arguments);
+            } catch {
+              value = call.function.arguments;
+            }
+          } else {
+            value = call.custom.input;
+          }
+          return {
+            kind: "call",
+            id: call.id,
+            name: part.name,
+            toolType: call.type,
+            input: part.input,
+            value,
+          };
+        }
+        if (
+          part instanceof vscode.LanguageModelToolResultPart &&
+          raw.role === "tool"
+        ) {
+          return {
+            kind: "result",
+            id: raw.tool_call_id,
+            parts: part.content as Array<
+              vscode.LanguageModelTextPart | vscode.LanguageModelDataPart
+            >,
+            value: raw.content,
+          };
+        }
+        return {
+          kind: "content",
+          parts: [
+            part as vscode.LanguageModelTextPart | vscode.LanguageModelDataPart,
+          ],
+        };
+      }),
+    };
+  });
+  return toolHistoryToVSCode(history, "Chat Completions");
 };
 
 export const convertOpenAIChatCompletionToolToVSCode = (

--- a/src/server/utils/openaiResponses.ts
+++ b/src/server/utils/openaiResponses.ts
@@ -31,8 +31,9 @@ import { logger } from "../../utils/logger";
 import { mimeForVscodeLm } from "./imageMime";
 import { SSE_HEARTBEAT_INTERVAL_MS } from "./sseHeartbeat";
 import {
-  ToolResultPairingTracker,
-  logToolResultRecovery,
+  type ToolHistoryMessage,
+  type ToolHistoryPart,
+  toolHistoryToVSCode,
 } from "./toolResultPairing";
 
 /**
@@ -775,111 +776,61 @@ export const convertResponsesItemToVSCode = (
   return null;
 };
 
-const convertResponsesItemWithPairing = (
+const responseItemToHistory = (
   item: ResponseInputItem,
-  pairing: {
-    customTools: ToolResultPairingTracker;
-    functionTools: ToolResultPairingTracker;
-  },
-): vscode.LanguageModelChatMessage | null => {
-  const type = (item as unknown as { type?: string })?.type;
-  if (type === "function_call") {
-    if (
-      !pairing.functionTools.recordCall(
-        (item as ResponseFunctionToolCall).call_id,
-      )
-    ) {
-      return invalidToolCallToVSCodeMessage(item);
-    }
-  } else if (type === "custom_tool_call") {
-    if (
-      !pairing.customTools.recordCall(
-        (item as unknown as ResponseCustomToolCall).call_id,
-      )
-    ) {
-      return invalidToolCallToVSCodeMessage(item);
-    }
-  } else if (
-    type === "function_call_output" ||
-    type === "custom_tool_call_output"
-  ) {
-    const output = item as unknown as
-      | ResponseInputItem.FunctionCallOutput
-      | ResponseCustomToolCallOutput;
-    const tracker =
-      type === "function_call_output"
-        ? pairing.functionTools
-        : pairing.customTools;
-    const result = tracker.recordResult(output.call_id);
-    if (result === "duplicate") {
-      return null;
-    }
-    if (result === "invalid" || result === "orphaned") {
-      return vscode.LanguageModelChatMessage.User([
-        new vscode.LanguageModelTextPart(
-          result === "invalid"
-            ? `[Tool result with an invalid call ID: ${JSON.stringify(output.call_id) ?? String(output.call_id)}]`
-            : `[Tool result without a matching tool call: ${JSON.stringify(output.call_id)}]`,
-        ),
-        ...convertToolOutputToVSCodeParts(output.output),
-      ]);
-    }
+): ToolHistoryMessage | null => {
+  const converted = convertResponsesItemToVSCode(item);
+  if (!converted) {
+    return null;
   }
-
-  return convertResponsesItemToVSCode(item);
-};
-
-const invalidToolCallToVSCodeMessage = (
-  item: ResponseInputItem,
-): vscode.LanguageModelChatMessage =>
-  vscode.LanguageModelChatMessage.Assistant([
-    new vscode.LanguageModelTextPart(
-      `[Tool call with an invalid call ID]\n${JSON.stringify(item)}`,
-    ),
-  ]);
-
-type ToolCallMessage = vscode.LanguageModelChatMessage & {
-  content: vscode.LanguageModelToolCallPart[];
-};
-
-type ToolResultMessage = vscode.LanguageModelChatMessage & {
-  content: vscode.LanguageModelToolResultPart[];
-};
-
-const isToolCallMessage = (
-  message: vscode.LanguageModelChatMessage,
-): message is ToolCallMessage =>
-  message.role === vscode.LanguageModelChatMessageRole.Assistant &&
-  message.content.length > 0 &&
-  message.content.every(
-    (part) => part instanceof vscode.LanguageModelToolCallPart,
-  );
-
-const isToolResultMessage = (
-  message: vscode.LanguageModelChatMessage,
-): message is ToolResultMessage =>
-  message.role === vscode.LanguageModelChatMessageRole.User &&
-  message.content.length > 0 &&
-  message.content.every(
-    (part) => part instanceof vscode.LanguageModelToolResultPart,
-  );
-
-const appendResponsesMessage = (
-  messages: vscode.LanguageModelChatMessage[],
-  message: vscode.LanguageModelChatMessage,
-  mergeStartIndex = 0,
-): void => {
-  const previous = messages.at(-1);
-  if (
-    messages.length > mergeStartIndex &&
-    previous &&
-    ((isToolCallMessage(previous) && isToolCallMessage(message)) ||
-      (isToolResultMessage(previous) && isToolResultMessage(message)))
-  ) {
-    previous.content.push(...message.content);
-    return;
-  }
-  messages.push(message);
+  const raw = item as unknown as {
+    type?: string;
+    role?: string;
+    arguments?: string;
+    input?: string;
+    call_id?: string;
+    output?: unknown;
+  };
+  const toolType = raw.type?.startsWith("custom_tool") ? "custom" : "function";
+  return {
+    role:
+      converted.role === vscode.LanguageModelChatMessageRole.Assistant
+        ? "assistant"
+        : "user",
+    boundary: raw.role === "system" || raw.role === "developer",
+    parts: converted.content.map((part): ToolHistoryPart => {
+      if (part instanceof vscode.LanguageModelToolCallPart) {
+        let value: unknown = raw.input;
+        if (toolType === "function") {
+          try {
+            value = JSON.parse(raw.arguments!);
+          } catch {
+            value = raw.arguments;
+          }
+        }
+        return {
+          kind: "call",
+          id: raw.call_id,
+          name: part.name,
+          toolType,
+          input: part.input,
+          value,
+        };
+      }
+      if (part instanceof vscode.LanguageModelToolResultPart) {
+        return {
+          kind: "result",
+          id: raw.call_id,
+          toolType,
+          parts: part.content as Array<
+            vscode.LanguageModelTextPart | vscode.LanguageModelDataPart
+          >,
+          value: raw.output,
+        };
+      }
+      return { kind: "content", parts: [part] };
+    }),
+  };
 };
 
 /**
@@ -889,45 +840,30 @@ export const convertResponsesInputToVSCode = (
   input: string | ResponseInput | undefined,
   instruction?: string | ResponseInput | null,
 ): vscode.LanguageModelChatMessage[] => {
-  const messages: vscode.LanguageModelChatMessage[] = [];
-  const pairing = {
-    customTools: new ToolResultPairingTracker(),
-    functionTools: new ToolResultPairingTracker(),
-  };
-
-  // Add instruction as first user message if present
-  if (instruction) {
-    if (typeof instruction === "string") {
-      messages.push(vscode.LanguageModelChatMessage.User(instruction));
-    } else if (Array.isArray(instruction)) {
-      for (const item of instruction) {
-        const converted = convertResponsesItemWithPairing(item, pairing);
-        if (converted) {
-          appendResponsesMessage(messages, converted);
+  const history: ToolHistoryMessage[] = [];
+  const appendInput = (value: string | ResponseInput | undefined | null) => {
+    if (typeof value === "string") {
+      history.push({
+        role: "user",
+        parts: [
+          { kind: "content", parts: [new vscode.LanguageModelTextPart(value)] },
+        ],
+      });
+    } else if (Array.isArray(value)) {
+      for (const item of value) {
+        const message = responseItemToHistory(item);
+        if (message) {
+          history.push(message);
         }
       }
     }
+  };
+  if (instruction) {
+    appendInput(instruction);
+    history.push({ role: "user", parts: [], boundary: true });
   }
-
-  const inputMessageStart = messages.length;
-
-  // Handle string input
-  if (typeof input === "string") {
-    messages.push(vscode.LanguageModelChatMessage.User(input));
-  } else if (Array.isArray(input)) {
-    for (const item of input) {
-      const converted = convertResponsesItemWithPairing(item, pairing);
-      if (converted) {
-        appendResponsesMessage(messages, converted, inputMessageStart);
-      }
-    }
-  }
-
-  logToolResultRecovery("Responses", [
-    pairing.functionTools,
-    pairing.customTools,
-  ]);
-  return messages;
+  appendInput(input);
+  return toolHistoryToVSCode(history, "Responses");
 };
 
 /**

--- a/src/server/utils/toolResultPairing.ts
+++ b/src/server/utils/toolResultPairing.ts
@@ -1,158 +1,492 @@
+import { isDeepStrictEqual } from "node:util";
+import * as vscode from "vscode";
+
 import { logger } from "../../utils/logger";
 
-export type ToolResultPairing = "duplicate" | "invalid" | "orphaned" | "paired";
-
-const SAMPLE_LIMIT = 5;
-const MAX_LOGGED_ID_LENGTH = 80;
-
-export class ToolResultPairingTracker {
-  private readonly pendingCallIds = new Set<string>();
-  private readonly seenResultIds = new Set<string>();
-  private readonly duplicateResultIds: string[] = [];
-  private readonly invalidCallIds: unknown[] = [];
-  private readonly invalidResultIds: unknown[] = [];
-  private readonly orphanedResultIds: string[] = [];
-  private duplicateResultCount = 0;
-  private invalidCallIdCount = 0;
-  private invalidResultIdCount = 0;
-  private orphanedResultCount = 0;
-
-  recordCall(callId: unknown): boolean {
-    if (!isValidToolCallId(callId)) {
-      this.invalidCallIdCount++;
-      this.recordSample(this.invalidCallIds, callId);
-      return false;
+export type ToolHistoryContent =
+  | vscode.LanguageModelTextPart
+  | vscode.LanguageModelDataPart;
+export type ToolHistoryPart =
+  | { kind: "content"; parts: ToolHistoryContent[] }
+  | {
+      kind: "call";
+      id?: unknown;
+      name: string;
+      toolType: string;
+      input: object;
+      value: unknown;
+      allowMissingId?: boolean;
     }
+  | {
+      kind: "result";
+      id?: unknown;
+      name?: string;
+      toolType?: string;
+      parts: ToolHistoryContent[];
+      value: unknown;
+      allowMissingId?: boolean;
+      isError?: boolean;
+    };
 
-    this.pendingCallIds.add(callId);
-    return true;
-  }
-
-  recordResult(callId: unknown): ToolResultPairing {
-    if (!isValidToolCallId(callId)) {
-      this.invalidResultIdCount++;
-      this.recordSample(this.invalidResultIds, callId);
-      return "invalid";
-    }
-
-    if (this.seenResultIds.has(callId)) {
-      this.duplicateResultCount++;
-      this.recordSample(this.duplicateResultIds, callId);
-      return "duplicate";
-    }
-
-    this.seenResultIds.add(callId);
-    if (this.pendingCallIds.delete(callId)) {
-      return "paired";
-    }
-
-    this.orphanedResultCount++;
-    this.recordSample(this.orphanedResultIds, callId);
-    return "orphaned";
-  }
-
-  get duplicateCount(): number {
-    return this.duplicateResultCount;
-  }
-
-  get duplicateSamples(): readonly string[] {
-    return this.duplicateResultIds;
-  }
-
-  get invalidCallCount(): number {
-    return this.invalidCallIdCount;
-  }
-
-  get invalidCallSamples(): readonly unknown[] {
-    return this.invalidCallIds;
-  }
-
-  get invalidResultCount(): number {
-    return this.invalidResultIdCount;
-  }
-
-  get invalidResultSamples(): readonly unknown[] {
-    return this.invalidResultIds;
-  }
-
-  get orphanedCount(): number {
-    return this.orphanedResultCount;
-  }
-
-  get orphanedSamples(): readonly string[] {
-    return this.orphanedResultIds;
-  }
-
-  private recordSample(samples: unknown[], callId: unknown): void {
-    if (samples.length < SAMPLE_LIMIT) {
-      samples.push(callId);
-    }
-  }
+export interface ToolHistoryMessage {
+  role: "assistant" | "user";
+  parts: ToolHistoryPart[];
+  /** Instructions and independent request sections cannot share a call turn. */
+  boundary?: boolean;
 }
 
-export function logToolResultRecovery(
+export interface ToolHistoryDiagnostics {
+  retainedPairs: number;
+  missingResults: number;
+  orphanedResults: number;
+  duplicateCalls: number;
+  duplicateResults: number;
+  conflictGroups: number;
+  remappedIds: number;
+}
+
+type Call = Extract<ToolHistoryPart, { kind: "call" }>;
+type Result = Extract<ToolHistoryPart, { kind: "result" }>;
+type Occurrence<T extends ToolHistoryPart = ToolHistoryPart> = {
+  index: number;
+  part: T;
+};
+type Group = {
+  calls: Occurrence<Call>[];
+  results: Occurrence<Result>[];
+  conflict: boolean;
+};
+type Decision =
+  | { kind: "call"; id: string; turn: number; call: Call }
+  | {
+      kind: "result";
+      id: string;
+      turn: number;
+      toolType: string;
+      result: Result;
+    }
+  | { kind: "context"; parts: ToolHistoryContent[] }
+  | { kind: "drop" };
+
+const validId = (id: unknown): id is string =>
+  typeof id === "string" && id.length > 0;
+const bounded = (value: unknown): string =>
+  JSON.stringify(value)?.slice(0, 100) ?? "unknown";
+const sameResult = (a: Result, b: Result): boolean =>
+  a.name === b.name &&
+  a.toolType === b.toolType &&
+  isDeepStrictEqual(a.value, b.value);
+
+/** Analyze a complete request snapshot; no decisions depend on another request. */
+export function normalizeToolHistory(messages: readonly ToolHistoryMessage[]): {
+  decisions: Map<number, Decision>;
+  diagnostics: ToolHistoryDiagnostics;
+} {
+  const decisions = new Map<number, Decision>();
+  const diagnostics: ToolHistoryDiagnostics = {
+    retainedPairs: 0,
+    missingResults: 0,
+    orphanedResults: 0,
+    duplicateCalls: 0,
+    duplicateResults: 0,
+    conflictGroups: 0,
+    remappedIds: 0,
+  };
+  const reservedIds = new Set<string>();
+  for (const message of messages) {
+    for (const part of message.parts) {
+      if (part.kind !== "content" && validId(part.id)) {
+        reservedIds.add(part.id);
+      }
+    }
+  }
+  const usedIds = new Set<string>();
+  let turn = 0;
+  let calls: Occurrence<Call>[] = [];
+  let results: Occurrence<Result>[] = [];
+  let phase: "calls" | "results" | undefined;
+
+  const resultContext = (entry: Occurrence<Result>, conflict = false) => {
+    const { part } = entry;
+    decisions.set(entry.index, {
+      kind: "context",
+      parts: [
+        new vscode.LanguageModelTextPart(
+          conflict
+            ? "[Conflicting tool history: result for " +
+              bounded(part.name) +
+              " (call " +
+              bounded(part.id) +
+              "); pairing is uncertain.]"
+            : "[Tool result without a matching tool call: " +
+              bounded(part.id) +
+              "; tool " +
+              bounded(part.name) +
+              "]",
+        ),
+        ...(part.isError
+          ? [new vscode.LanguageModelTextPart("[Tool reported an error]")]
+          : []),
+        ...part.parts,
+      ],
+    });
+  };
+
+  const finalizeTurn = () => {
+    if (!calls.length && !results.length) {
+      phase = undefined;
+      return;
+    }
+    const groups: Group[] = [];
+    for (const entry of calls) {
+      const call = entry.part;
+      let group = validId(call.id)
+        ? groups.find(
+            (g) =>
+              g.calls[0].part.id === call.id &&
+              g.calls[0].part.toolType === call.toolType,
+          )
+        : undefined;
+      if (!group) {
+        group = {
+          calls: [],
+          results: [],
+          conflict:
+            !call.name ||
+            (!validId(call.id) &&
+              !(call.id === undefined && call.allowMissingId)),
+        };
+        groups.push(group);
+      } else if (
+        group.calls[0].part.name !== call.name ||
+        !isDeepStrictEqual(group.calls[0].part.value, call.value)
+      ) {
+        group.conflict = true;
+      }
+      group.calls.push(entry);
+    }
+
+    const orphans: Occurrence<Result>[] = [];
+    // Explicit results reserve their calls before positional results consume FIFO slots.
+    for (const entry of results.filter((r) => r.part.id !== undefined)) {
+      const result = entry.part;
+      const matches = validId(result.id)
+        ? groups.filter(
+            (g) =>
+              g.calls[0].part.id === result.id &&
+              (result.toolType === undefined ||
+                g.calls[0].part.toolType === result.toolType),
+          )
+        : [];
+      if (!matches.length) {
+        orphans.push(entry);
+        continue;
+      }
+      if (matches.length > 1) {
+        matches.forEach((g) => {
+          g.conflict = true;
+        });
+      }
+      const group = matches[0];
+      if (
+        result.name !== undefined &&
+        result.name !== group.calls[0].part.name
+      ) {
+        group.conflict = true;
+      }
+      group.results.push(entry);
+    }
+    for (const entry of results.filter((r) => r.part.id === undefined)) {
+      const group =
+        entry.part.allowMissingId && entry.part.name
+          ? groups.find(
+              (g) =>
+                !g.conflict &&
+                !g.results.length &&
+                g.calls[0].part.name === entry.part.name &&
+                (entry.part.toolType === undefined ||
+                  g.calls[0].part.toolType === entry.part.toolType),
+            )
+          : undefined;
+      if (group) {
+        group.results.push(entry);
+      } else {
+        orphans.push(entry);
+      }
+    }
+
+    const missing: Occurrence<Call>[] = [];
+    for (const [groupIndex, group] of groups.entries()) {
+      group.results.sort((a, b) => a.index - b.index);
+      const firstCall = group.calls[0];
+      const firstResult = group.results[0];
+      if (
+        firstResult &&
+        group.results.some(
+          (r) => !isDeepStrictEqual(r.part.value, firstResult.part.value),
+        )
+      ) {
+        group.conflict = true;
+      }
+      group.calls.forEach((c) => decisions.set(c.index, { kind: "drop" }));
+      if (group.conflict) {
+        diagnostics.conflictGroups++;
+        for (const entry of group.calls) {
+          decisions.set(entry.index, {
+            kind: "context",
+            parts: [
+              new vscode.LanguageModelTextPart(
+                "[Conflicting tool history: " +
+                  bounded(entry.part.name) +
+                  " (" +
+                  bounded(entry.part.toolType) +
+                  ", call " +
+                  bounded(entry.part.id) +
+                  "); pairing is uncertain. Arguments omitted.]",
+              ),
+            ],
+          });
+        }
+        group.results.forEach((r) => resultContext(r, true));
+        continue;
+      }
+      diagnostics.duplicateCalls += group.calls.length - 1;
+      if (!firstResult) {
+        missing.push(firstCall);
+        diagnostics.missingResults++;
+        continue;
+      }
+      let upstreamId = validId(firstCall.part.id) ? firstCall.part.id : "";
+      if (!upstreamId || usedIds.has(upstreamId)) {
+        const prefix = "am_history_" + turn + "_" + groupIndex;
+        upstreamId = prefix;
+        let suffix = 0;
+        while (reservedIds.has(upstreamId) || usedIds.has(upstreamId)) {
+          upstreamId = prefix + "_" + ++suffix;
+        }
+        diagnostics.remappedIds++;
+      }
+      usedIds.add(upstreamId);
+      decisions.set(firstCall.index, {
+        kind: "call",
+        id: upstreamId,
+        turn,
+        call: firstCall.part,
+      });
+      decisions.set(firstResult.index, {
+        kind: "result",
+        id: upstreamId,
+        turn,
+        toolType: firstCall.part.toolType,
+        result: firstResult.part,
+      });
+      group.results
+        .slice(1)
+        .forEach((r) => decisions.set(r.index, { kind: "drop" }));
+      diagnostics.duplicateResults += group.results.length - 1;
+      diagnostics.retainedPairs++;
+    }
+    if (missing.length) {
+      const names = new Map<string, number>();
+      for (const c of missing) {
+        names.set(c.part.name, (names.get(c.part.name) ?? 0) + 1);
+      }
+      const label = [...names]
+        .slice(0, 5)
+        .map(([name, count]) => bounded(name) + " (" + count + ")")
+        .join(", ");
+      decisions.set(missing[0].index, {
+        kind: "context",
+        parts: [
+          new vscode.LanguageModelTextPart(
+            "[Incomplete tool history: " +
+              missing.length +
+              " call(s) have no recorded result: " +
+              label +
+              (names.size > 5 ? ", ..." : "") +
+              ". Execution status is unknown; verify before retrying.]",
+          ),
+        ],
+      });
+    }
+    const keptOrphans: Result[] = [];
+    for (const entry of orphans.sort((a, b) => a.index - b.index)) {
+      if (
+        validId(entry.part.id) &&
+        keptOrphans.some(
+          (r) => r.id === entry.part.id && sameResult(r, entry.part),
+        )
+      ) {
+        decisions.set(entry.index, { kind: "drop" });
+        diagnostics.duplicateResults++;
+      } else {
+        resultContext(entry);
+        keptOrphans.push(entry.part);
+        diagnostics.orphanedResults++;
+      }
+    }
+    calls = [];
+    results = [];
+    phase = undefined;
+    turn++;
+  };
+
+  let index = 0;
+  for (const message of messages) {
+    const hasCalls =
+      message.role === "assistant" &&
+      message.parts.some((p) => p.kind === "call");
+    const hasResults =
+      message.role === "user" && message.parts.some((p) => p.kind === "result");
+    if (
+      message.boundary ||
+      (!hasCalls && !hasResults) ||
+      (hasCalls && phase === "results")
+    ) {
+      finalizeTurn();
+    }
+    if (hasCalls) {
+      phase = "calls";
+    }
+    if (hasResults) {
+      phase = "results";
+    }
+    for (const part of message.parts) {
+      if (part.kind === "call") {
+        calls.push({ index, part });
+      } else if (part.kind === "result") {
+        results.push({ index, part });
+      }
+      index++;
+    }
+    if (message.boundary) {
+      finalizeTurn();
+    }
+  }
+  finalizeTurn();
+
+  const pending = new Map<string, { turn: number; toolType: string }>();
+  const emittedIds = new Set<string>();
+  for (let i = 0; i < index; i++) {
+    const decision = decisions.get(i);
+    if (decision?.kind === "call") {
+      if (emittedIds.has(decision.id)) {
+        throw new Error("Duplicate normalized tool call ID");
+      }
+      emittedIds.add(decision.id);
+      pending.set(decision.id, {
+        turn: decision.turn,
+        toolType: decision.call.toolType,
+      });
+    } else if (decision?.kind === "result") {
+      const call = pending.get(decision.id);
+      if (call?.turn !== decision.turn || call.toolType !== decision.toolType) {
+        throw new Error("Unpaired normalized tool result");
+      }
+      pending.delete(decision.id);
+    }
+  }
+  if (pending.size) {
+    throw new Error("Unpaired normalized tool call");
+  }
+  return { decisions, diagnostics };
+}
+
+/** Render a plan for the upstream request without rewriting the source history. */
+export function toolHistoryToVSCode(
+  messages: readonly ToolHistoryMessage[],
   adapter: string,
-  trackers: readonly ToolResultPairingTracker[],
-): void {
-  const orphanedCount = trackers.reduce(
-    (total, tracker) => total + tracker.orphanedCount,
-    0,
-  );
-  const duplicateCount = trackers.reduce(
-    (total, tracker) => total + tracker.duplicateCount,
-    0,
-  );
-  const invalidCallCount = trackers.reduce(
-    (total, tracker) => total + tracker.invalidCallCount,
-    0,
-  );
-  const invalidResultCount = trackers.reduce(
-    (total, tracker) => total + tracker.invalidResultCount,
-    0,
-  );
-  if (
-    orphanedCount === 0 &&
-    duplicateCount === 0 &&
-    invalidCallCount === 0 &&
-    invalidResultCount === 0
-  ) {
-    return;
+): vscode.LanguageModelChatMessage[] {
+  const { decisions, diagnostics } = normalizeToolHistory(messages);
+  const output: vscode.LanguageModelChatMessage[] = [];
+  let index = 0;
+  let previousHadResults = false;
+  let previousHadCalls = false;
+  for (const message of messages) {
+    const hasCalls =
+      message.role === "assistant" &&
+      message.parts.some((part) => part.kind === "call");
+    const hasResults =
+      message.role === "user" &&
+      message.parts.some((part) => part.kind === "result");
+    const parts: Array<
+      | ToolHistoryContent
+      | vscode.LanguageModelToolCallPart
+      | vscode.LanguageModelToolResultPart
+    > = [];
+    for (const part of message.parts) {
+      const decision = decisions.get(index++);
+      if (part.kind === "content") {
+        parts.push(...part.parts);
+      } else if (decision?.kind === "context") {
+        parts.push(...decision.parts);
+      } else if (decision?.kind === "call") {
+        parts.push(
+          new vscode.LanguageModelToolCallPart(
+            decision.id,
+            decision.call.name,
+            decision.call.input,
+          ),
+        );
+      } else if (decision?.kind === "result") {
+        parts.push(
+          new vscode.LanguageModelToolResultPart(
+            decision.id,
+            decision.result.parts,
+          ),
+        );
+      }
+    }
+    if (parts.length) {
+      // Keep a result turn together when an orphan/conflict becomes text.
+      // Otherwise that text-only message can split a surviving call/result pair.
+      if (
+        ((hasResults && previousHadResults) ||
+          (hasCalls && previousHadCalls)) &&
+        !message.boundary
+      ) {
+        output.at(-1)!.content.push(...parts);
+      } else {
+        output.push(
+          message.role === "assistant"
+            ? vscode.LanguageModelChatMessage.Assistant(
+                parts as Array<
+                  ToolHistoryContent | vscode.LanguageModelToolCallPart
+                >,
+              )
+            : vscode.LanguageModelChatMessage.User(
+                parts as Array<
+                  ToolHistoryContent | vscode.LanguageModelToolResultPart
+                >,
+              ),
+        );
+      }
+    }
+    previousHadResults = hasResults && !message.boundary;
+    previousHadCalls = hasCalls && !message.boundary;
   }
-
-  const orphanedSamples = trackers
-    .flatMap((tracker) => tracker.orphanedSamples)
-    .slice(0, SAMPLE_LIMIT);
-  const duplicateSamples = trackers
-    .flatMap((tracker) => tracker.duplicateSamples)
-    .slice(0, SAMPLE_LIMIT);
-  const invalidSamples = trackers
-    .flatMap((tracker) => [
-      ...tracker.invalidCallSamples,
-      ...tracker.invalidResultSamples,
-    ])
-    .slice(0, SAMPLE_LIMIT);
-
-  logger.warn(
-    `${adapter} tool result recovery: converted ${orphanedCount} orphaned result(s) to ordinary content${formatSamples(orphanedSamples)}; converted ${invalidCallCount} call(s) and ${invalidResultCount} result(s) with invalid IDs to ordinary content${formatSamples(invalidSamples)}; dropped ${duplicateCount} duplicate result(s)${formatSamples(duplicateSamples)}`,
-  );
-}
-
-function isValidToolCallId(callId: unknown): callId is string {
-  return typeof callId === "string" && callId.length > 0;
-}
-
-function formatSamples(callIds: readonly unknown[]): string {
-  if (callIds.length === 0) {
-    return "";
+  const { retainedPairs: _pairs, ...recoveries } = diagnostics;
+  // Copilot rejects ordinary content interleaved between parallel tool results.
+  // Keep formal parts contiguous within each role message, preserving both orders.
+  for (const message of output) {
+    const tools = message.content.filter(
+      (part) =>
+        part instanceof vscode.LanguageModelToolCallPart ||
+        part instanceof vscode.LanguageModelToolResultPart,
+    );
+    if (tools.length > 1) {
+      const context = message.content.filter(
+        (part) =>
+          !(part instanceof vscode.LanguageModelToolCallPart) &&
+          !(part instanceof vscode.LanguageModelToolResultPart),
+      );
+      message.content.splice(0, message.content.length, ...tools, ...context);
+    }
   }
-
-  const samples = callIds.map((callId) => {
-    const value = JSON.stringify(callId) ?? String(callId);
-    const truncated =
-      value.length > MAX_LOGGED_ID_LENGTH
-        ? `${value.slice(0, MAX_LOGGED_ID_LENGTH)}...`
-        : value;
-    return truncated;
-  });
-  return ` (sample call IDs: ${samples.join(", ")})`;
+  if (Object.values(recoveries).some((count) => count > 0)) {
+    logger.warn(
+      adapter + " tool history normalization: " + JSON.stringify(diagnostics),
+    );
+  }
+  return output;
 }

--- a/src/test/server/anthropic.test.ts
+++ b/src/test/server/anthropic.test.ts
@@ -580,12 +580,12 @@ suite("Anthropic Conversion Utils Test Suite", () => {
               {
                 type: "tool_result",
                 tool_use_id: "tool-known",
-                content: "duplicate output",
+                content: "first output",
               },
               {
                 type: "tool_result",
                 tool_use_id: "tool-missing",
-                content: "duplicate orphaned output",
+                content: "orphaned output",
               },
             ],
           },
@@ -612,8 +612,8 @@ suite("Anthropic Conversion Utils Test Suite", () => {
           "first output",
         );
         assert.strictEqual(warnings.length, 1);
-        assert.match(warnings[0], /converted 1 orphaned result/);
-        assert.match(warnings[0], /dropped 2 duplicate result/);
+        assert.match(warnings[0], /"orphanedResults":1/);
+        assert.match(warnings[0], /"duplicateResults":2/);
       } finally {
         logger.warn = originalWarn;
       }
@@ -655,10 +655,7 @@ suite("Anthropic Conversion Utils Test Suite", () => {
             .every((part) => part instanceof vscode.LanguageModelTextPart),
         );
         assert.strictEqual(warnings.length, 1);
-        assert.match(
-          warnings[0],
-          /converted 1 call\(s\) and 1 result\(s\) with invalid IDs/,
-        );
+        assert.match(warnings[0], /"conflictGroups":1/);
       } finally {
         logger.warn = originalWarn;
       }

--- a/src/test/server/gemini.test.ts
+++ b/src/test/server/gemini.test.ts
@@ -355,12 +355,12 @@ suite("Gemini Conversion Utils Test Suite", () => {
           ...(separateMessages
             ? [
                 { role: "user", parts: [response("x")] },
-                { role: "user", parts: [response("x", "replayed")] },
+                { role: "user", parts: [response("x")] },
               ]
             : [
                 {
                   role: "user",
-                  parts: [response("x"), response("x", "replayed")],
+                  parts: [response("x"), response("x")],
                 },
               ]),
           { role: "model", parts: [{ text: "Done" }] },
@@ -398,14 +398,13 @@ suite("Gemini Conversion Utils Test Suite", () => {
         ]);
 
         assert.strictEqual(converted.length, 4);
-        assert.deepStrictEqual(
-          toolCalls(converted).map((part) => part.callId),
-          ["x", "x"],
-        );
+        const ids = toolCalls(converted).map((part) => part.callId);
+        assert.strictEqual(ids[0], "x");
+        assert.strictEqual(new Set(ids).size, 2);
         const results = toolResults(converted);
         assert.deepStrictEqual(
           results.map((part) => part.callId),
-          ["x", "x"],
+          ids,
         );
         assert.deepStrictEqual(
           results.map(
@@ -460,14 +459,14 @@ suite("Gemini Conversion Utils Test Suite", () => {
           ],
         },
       ]);
-      assert.strictEqual(converted.length, 3);
+      assert.strictEqual(converted.length, 2);
       assert.strictEqual(toolResults(converted).length, 1);
-      assert.strictEqual(converted[2].content.length, 2);
+      assert.strictEqual(converted[1].content.length, 3);
       assert.deepStrictEqual(
-        converted[2].content[0],
+        converted[1].content[1],
         new vscode.LanguageModelTextPart("Keep context"),
       );
-      const data = converted[2].content[1];
+      const data = converted[1].content[2];
       assert.ok(data instanceof vscode.LanguageModelDataPart);
       assert.strictEqual(data.mimeType, image.mimeType);
       assert.deepStrictEqual(
@@ -529,7 +528,7 @@ suite("Gemini Conversion Utils Test Suite", () => {
       );
     });
 
-    test("leaves unmatched results unchanged without poisoning a later pair", () => {
+    test("preserves unmatched results as context without poisoning a later pair", () => {
       const converted = convertGeminiContentsToVSCode([
         {
           role: "user",
@@ -544,7 +543,7 @@ suite("Gemini Conversion Utils Test Suite", () => {
       assert.strictEqual(converted[0].content.length, 2);
       assert.ok(
         converted[0].content.every(
-          (part) => part instanceof vscode.LanguageModelToolResultPart,
+          (part) => part instanceof vscode.LanguageModelTextPart,
         ),
       );
       assert.strictEqual(converted[2].content.length, 1);
@@ -564,16 +563,16 @@ suite("Gemini Conversion Utils Test Suite", () => {
         { role: "user", parts: [response("x"), response("x")] },
       ]);
       assert.strictEqual(converted[3].content.length, 2);
-      assert.strictEqual(toolResults(converted).length, 3);
+      assert.strictEqual(toolResults(converted).length, 1);
     });
 
-    test("does not deduplicate results when the call ID is ambiguous within one turn", () => {
+    test("deduplicates identical complete pairs within one turn", () => {
       const converted = convertGeminiContentsToVSCode([
         { role: "model", parts: [call("x"), call("x")] },
         { role: "user", parts: [response("x"), response("x")] },
       ]);
-      assert.strictEqual(toolCalls(converted).length, 2);
-      assert.strictEqual(toolResults(converted).length, 2);
+      assert.strictEqual(toolCalls(converted).length, 1);
+      assert.strictEqual(toolResults(converted).length, 1);
     });
   });
 

--- a/src/test/server/openaiResponses.test.ts
+++ b/src/test/server/openaiResponses.test.ts
@@ -586,12 +586,12 @@ suite("OpenAI Responses Conversion Utils Test Suite", () => {
           {
             type: "function_call_output",
             call_id: "call_known",
-            output: "duplicate output",
+            output: "first output",
           },
           {
             type: "function_call_output",
             call_id: "call_missing",
-            output: "duplicate orphaned output",
+            output: "orphaned output",
           },
           {
             type: "custom_tool_call_output",
@@ -601,16 +601,18 @@ suite("OpenAI Responses Conversion Utils Test Suite", () => {
           {
             type: "custom_tool_call_output",
             call_id: "call_custom",
-            output: "duplicate custom output",
+            output: "custom output",
           },
         ] as any);
 
-        assert.strictEqual(result.length, 3);
+        assert.strictEqual(result.length, 2);
         assert.deepStrictEqual(
           toolCallParts(result[0]).map((part) => part.callId),
           ["call_known", "call_custom"],
         );
-        const orphanedParts = result[1].content;
+        const orphanedParts = result[1].content.filter(
+          (part) => part instanceof vscode.LanguageModelTextPart,
+        );
         assert.ok(orphanedParts[0] instanceof vscode.LanguageModelTextPart);
         assert.match(
           (orphanedParts[0] as vscode.LanguageModelTextPart).value,
@@ -630,8 +632,8 @@ suite("OpenAI Responses Conversion Utils Test Suite", () => {
           ["call_known", "call_custom"],
         );
         assert.strictEqual(warnings.length, 1);
-        assert.match(warnings[0], /converted 1 orphaned result/);
-        assert.match(warnings[0], /dropped 3 duplicate result/);
+        assert.match(warnings[0], /"orphanedResults":1/);
+        assert.match(warnings[0], /"duplicateResults":3/);
       } finally {
         logger.warn = originalWarn;
       }
@@ -676,10 +678,7 @@ suite("OpenAI Responses Conversion Utils Test Suite", () => {
             .every((part) => part instanceof vscode.LanguageModelTextPart),
         );
         assert.strictEqual(warnings.length, 1);
-        assert.match(
-          warnings[0],
-          /converted 2 call\(s\) and 2 result\(s\) with invalid IDs/,
-        );
+        assert.match(warnings[0], /"conflictGroups":2/);
       } finally {
         logger.warn = originalWarn;
       }
@@ -881,13 +880,21 @@ suite("OpenAI Responses Conversion Utils Test Suite", () => {
       const result = convertResponsesInputToVSCode(input, instruction);
 
       assert.strictEqual(result.length, 2);
-      assert.deepStrictEqual(
-        toolCallParts(result[0]).map((part) => part.callId),
-        ["call_instruction"],
+      assert.ok(
+        result.every((message) =>
+          message.content.every(
+            (part) => part instanceof vscode.LanguageModelTextPart,
+          ),
+        ),
       );
-      assert.deepStrictEqual(
-        toolCallParts(result[1]).map((part) => part.callId),
-        ["call_input"],
+      assert.ok(
+        result.every((message) =>
+          message.content.some(
+            (part) =>
+              part instanceof vscode.LanguageModelTextPart &&
+              part.value.includes("Execution status is unknown"),
+          ),
+        ),
       );
     });
   });

--- a/src/test/server/toolHistory.test.ts
+++ b/src/test/server/toolHistory.test.ts
@@ -1,0 +1,708 @@
+import * as assert from "assert";
+import * as vscode from "vscode";
+
+import { convertAnthropicMessagesToVSCode } from "../../server/utils/anthropic";
+import { convertGeminiContentsToVSCode } from "../../server/utils/gemini";
+import { convertOpenAIMessagesToVSCode } from "../../server/utils/openaiChat";
+import { convertResponsesInputToVSCode } from "../../server/utils/openaiResponses";
+import {
+  type ToolHistoryMessage,
+  type ToolHistoryPart,
+  normalizeToolHistory,
+  toolHistoryToVSCode,
+} from "../../server/utils/toolResultPairing";
+import { logger } from "../../utils/logger";
+
+type Call = { kind: "call"; id?: string; name?: string; args?: object };
+type Result = { kind: "result"; id?: string; name?: string; value?: unknown };
+type Text = { kind: "text"; text: string };
+type Message = {
+  role: "user" | "assistant";
+  parts: Array<Call | Result | Text>;
+};
+const C = (id?: string, name = "lookup", args: object = {}): Call => ({
+  kind: "call",
+  id,
+  name,
+  args,
+});
+const R = (id?: string, value: unknown = "ok", name = "lookup"): Result => ({
+  kind: "result",
+  id,
+  name,
+  value,
+});
+const M = (...parts: Array<Call | Text>): Message => ({
+  role: "assistant",
+  parts,
+});
+const U = (...parts: Array<Result | Text>): Message => ({
+  role: "user",
+  parts,
+});
+const T = (text: string): Text => ({ kind: "text", text });
+const encode = (value: unknown): string => JSON.stringify(value);
+const adapters = {
+  Anthropic: (messages: Message[]) =>
+    convertAnthropicMessagesToVSCode(
+      messages.map((m) => ({
+        role: m.role,
+        content: m.parts.map((p) => {
+          if (p.kind === "text") {
+            return { type: "text", text: p.text };
+          }
+          if (p.kind === "call") {
+            return { type: "tool_use", id: p.id, name: p.name, input: p.args };
+          }
+          return {
+            type: "tool_result",
+            tool_use_id: p.id,
+            content: encode(p.value),
+          };
+        }),
+      })) as any,
+    ),
+  Chat: (messages: Message[]) =>
+    convertOpenAIMessagesToVSCode(
+      messages.flatMap((m) =>
+        m.role === "assistant"
+          ? [
+              {
+                role: "assistant",
+                content: m.parts
+                  .filter((p): p is Text => p.kind === "text")
+                  .map((p) => p.text)
+                  .join(""),
+                tool_calls: m.parts
+                  .filter((p): p is Call => p.kind === "call")
+                  .map((p) => ({
+                    id: p.id,
+                    type: "function",
+                    function: { name: p.name, arguments: encode(p.args) },
+                  })),
+              },
+            ]
+          : m.parts.map((p) =>
+              p.kind === "result"
+                ? { role: "tool", tool_call_id: p.id, content: encode(p.value) }
+                : { role: "user", content: (p as Text).text },
+            ),
+      ) as any,
+    ),
+  Responses: (messages: Message[]) =>
+    convertResponsesInputToVSCode(
+      messages.flatMap((m) =>
+        m.parts.map((p) => {
+          if (p.kind === "text") {
+            return { role: m.role, content: p.text };
+          }
+          if (p.kind === "call") {
+            return {
+              type: "function_call",
+              call_id: p.id,
+              name: p.name,
+              arguments: encode(p.args),
+            };
+          }
+          return {
+            type: "function_call_output",
+            call_id: p.id,
+            output: encode(p.value),
+          };
+        }),
+      ) as any,
+    ),
+  Gemini: (messages: Message[]) =>
+    convertGeminiContentsToVSCode(
+      messages.map((m) => ({
+        role: m.role === "assistant" ? "model" : "user",
+        parts: m.parts.map((p) => {
+          if (p.kind === "text") {
+            return { text: p.text };
+          }
+          if (p.kind === "call") {
+            return { functionCall: { id: p.id, name: p.name, args: p.args } };
+          }
+          return {
+            functionResponse: {
+              id: p.id,
+              name: p.name,
+              response: { output: p.value },
+            },
+          };
+        }),
+      })) as any,
+    ),
+};
+const calls = (messages: vscode.LanguageModelChatMessage[]) =>
+  messages
+    .flatMap((m) => m.content)
+    .filter(
+      (p): p is vscode.LanguageModelToolCallPart =>
+        p instanceof vscode.LanguageModelToolCallPart,
+    );
+const results = (messages: vscode.LanguageModelChatMessage[]) =>
+  messages
+    .flatMap((m) => m.content)
+    .filter(
+      (p): p is vscode.LanguageModelToolResultPart =>
+        p instanceof vscode.LanguageModelToolResultPart,
+    );
+const text = (messages: vscode.LanguageModelChatMessage[]) =>
+  messages
+    .flatMap((m) => m.content)
+    .filter(
+      (p): p is vscode.LanguageModelTextPart =>
+        p instanceof vscode.LanguageModelTextPart,
+    )
+    .map((p) => p.value)
+    .join("\n");
+function paired(messages: vscode.LanguageModelChatMessage[], count: number) {
+  assert.strictEqual(calls(messages).length, count);
+  assert.strictEqual(results(messages).length, count);
+  assert.strictEqual(new Set(calls(messages).map((c) => c.callId)).size, count);
+  assert.deepStrictEqual(
+    results(messages)
+      .map((r) => r.callId)
+      .sort(),
+    calls(messages)
+      .map((c) => c.callId)
+      .sort(),
+  );
+  const pending = new Set<string>();
+  for (const message of messages) {
+    for (const p of message.content) {
+      if (p instanceof vscode.LanguageModelToolCallPart) {
+        pending.add(p.callId);
+      }
+      if (p instanceof vscode.LanguageModelToolResultPart) {
+        assert.ok(pending.delete(p.callId));
+      }
+    }
+  }
+  assert.strictEqual(pending.size, 0);
+}
+
+suite("Unified tool history", () => {
+  for (const [name, convert] of Object.entries(adapters)) {
+    suite(name, () => {
+      test("preserves a valid pair and source input", () => {
+        const input = [M(C("x")), U(R("x"))];
+        const original = structuredClone(input);
+        const actual = convert(input);
+        paired(actual, 1);
+        assert.strictEqual(calls(actual)[0].callId, "x");
+        assert.deepStrictEqual(input, original);
+        assert.deepStrictEqual(convert(input), actual);
+      });
+      test("keeps missing execution status without call arguments", () => {
+        const actual = convert([
+          M(C("x", "submit", { secret: "not-in-note" }), C("y", "read", {})),
+          U(T("continue")),
+        ]);
+        paired(actual, 0);
+        assert.match(text(actual), /Execution status is unknown/);
+        assert.ok(!text(actual).includes("not-in-note"));
+        assert.ok(text(actual).includes("continue"));
+      });
+      test("preserves orphaned result content without poisoning a later pair", () => {
+        const actual = convert([
+          U(R("x", "earlier")),
+          M(C("x")),
+          U(R("x", "later")),
+        ]);
+        paired(actual, 1);
+        assert.match(text(actual), /without a matching tool call/);
+        assert.ok(text(actual).includes("earlier"));
+        assert.ok(
+          (
+            results(actual)[0].content[0] as vscode.LanguageModelTextPart
+          ).value.includes("later"),
+        );
+      });
+      test("merges identical calls and results within one turn", () => {
+        const actual = convert([M(C("x"), C("x")), U(R("x"), R("x"))]);
+        paired(actual, 1);
+      });
+      test("keeps orphan context and parallel results in one emitted result turn", () => {
+        const actual = convert([
+          M(C("a"), C("b")),
+          U(R("a")),
+          U(R("unknown", "saved")),
+          U(R("b")),
+        ]);
+        paired(actual, 2);
+        const resultMessages = actual.filter((m) =>
+          m.content.some(
+            (p) => p instanceof vscode.LanguageModelToolResultPart,
+          ),
+        );
+        assert.strictEqual(resultMessages.length, 1);
+        assert.ok(
+          resultMessages[0].content[0] instanceof
+            vscode.LanguageModelToolResultPart,
+        );
+        assert.ok(
+          resultMessages[0].content[1] instanceof
+            vscode.LanguageModelToolResultPart,
+        );
+        assert.ok(
+          resultMessages[0].content.some(
+            (p) =>
+              p instanceof vscode.LanguageModelTextPart &&
+              p.value.includes("saved"),
+          ),
+        );
+      });
+      test("preserves two complete replayed pairs across turns", () => {
+        const actual = convert([
+          M(C("x")),
+          U(R("x")),
+          M(C("x")),
+          U(R("x", "new")),
+        ]);
+        paired(actual, 2);
+        assert.notStrictEqual(calls(actual)[0].callId, calls(actual)[1].callId);
+      });
+      test("preserves conflicting results without choosing a winner", () => {
+        const actual = convert([
+          M(C("x")),
+          U(R("x", "first"), R("x", "second")),
+        ]);
+        paired(actual, 0);
+        assert.match(text(actual), /Conflicting tool history/);
+        assert.ok(
+          text(actual).includes("first") && text(actual).includes("second"),
+        );
+      });
+      test("does not emit ambiguous same-ID calls", () => {
+        const actual = convert([
+          M(C("x", "first", { a: 1 }), C("x", "second", { a: 2 })),
+          U(R("x")),
+        ]);
+        paired(actual, 0);
+        assert.match(text(actual), /Conflicting tool history/);
+      });
+      test("pairs parallel out-of-order results and handles a missing sibling", () => {
+        const actual = convert([
+          M(C("a"), C("b"), C("missing")),
+          U(R("b")),
+          U(R("a")),
+        ]);
+        paired(actual, 2);
+        assert.deepStrictEqual(
+          results(actual).map((r) => r.callId),
+          ["b", "a"],
+        );
+        assert.match(text(actual), /Execution status is unknown/);
+      });
+      test("does not match through independent user input or assistant text", () => {
+        for (const boundary of [U(T("new instruction")), M(T("explanation"))]) {
+          const actual = convert([M(C("x")), boundary, U(R("x"))]);
+          paired(actual, 0);
+          assert.match(text(actual), /Execution status is unknown/);
+          assert.match(text(actual), /without a matching tool call/);
+        }
+      });
+      test("retains empty, false, zero and large orphan results", () => {
+        for (const value of ["", false, 0, {}, "z".repeat(20_000)]) {
+          const actual = convert([U(R("x", value))]);
+          paired(actual, 0);
+          assert.ok(text(actual).includes(encode(value)));
+        }
+      });
+      test("keeps an explicitly empty result as a completed pair", () => {
+        paired(convert([M(C("x")), U(R("x", ""))]), 1);
+      });
+    });
+  }
+
+  test("Gemini reserves explicit matches before id-less FIFO", () => {
+    const actual = adapters.Gemini([
+      M(C("a"), C("b")),
+      U(R(undefined, "B"), R("a", "A")),
+    ]);
+    paired(actual, 2);
+    assert.deepStrictEqual(
+      results(actual).map((r) => r.callId),
+      ["b", "a"],
+    );
+  });
+  test("Gemini never consumes a future id-less call", () => {
+    const actual = adapters.Gemini([
+      M(C()),
+      U(R(undefined), R(undefined, "excess")),
+      M(C()),
+      U(R(undefined, "next")),
+    ]);
+    paired(actual, 2);
+    assert.ok(text(actual).includes("excess"));
+  });
+  test("Gemini partial id-less parallel turn keeps one pair", () => {
+    const actual = adapters.Gemini([M(C(), C()), U(R(undefined))]);
+    paired(actual, 1);
+    assert.match(text(actual), /Execution status is unknown/);
+  });
+  test("Gemini distinguishes structurally different values from key order", () => {
+    paired(
+      adapters.Gemini([
+        M(C("x")),
+        U(R("x", { a: 1, b: 2 }), R("x", { b: 2, a: 1 })),
+      ]),
+      1,
+    );
+  });
+  test("Responses keeps function and custom namespaces distinct", () => {
+    const actual = convertResponsesInputToVSCode([
+      { type: "function_call", call_id: "x", name: "f", arguments: "{}" },
+      { type: "custom_tool_call", call_id: "x", name: "f", input: "raw" },
+      { type: "custom_tool_call_output", call_id: "x", output: "custom" },
+      { type: "function_call_output", call_id: "x", output: "function" },
+    ] as any);
+    paired(actual, 2);
+  });
+  test("Chat retains free-form custom input instead of parsing it as JSON", () => {
+    const actual = convertOpenAIMessagesToVSCode([
+      {
+        role: "assistant",
+        tool_calls: [
+          {
+            type: "custom",
+            id: "x",
+            custom: { name: "shell", input: "echo hello" },
+          },
+        ],
+      },
+      { role: "tool", tool_call_id: "x", content: "hello" },
+    ]);
+    paired(actual, 1);
+    assert.deepStrictEqual(calls(actual)[0].input, { input: "echo hello" });
+  });
+  test("Chat pairs supported calls after skipping unknown tool types", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: "Working",
+        tool_calls: [
+          { type: "future_tool", id: "unknown-before" },
+          {
+            type: "function",
+            id: "lookup-id",
+            function: { name: "lookup", arguments: '{"key":"value"}' },
+          },
+          { type: "future_tool", id: "unknown-between" },
+          {
+            type: "custom",
+            id: "shell-id",
+            custom: { name: "shell", input: "echo hello" },
+          },
+        ],
+      },
+      { role: "tool", tool_call_id: "shell-id", content: "hello" },
+      { role: "tool", tool_call_id: "lookup-id", content: "found" },
+    ];
+    const original = structuredClone(input);
+    const actual = convertOpenAIMessagesToVSCode(input as any);
+    paired(actual, 2);
+    assert.deepStrictEqual(
+      calls(actual).map((call) => [call.callId, call.name, call.input]),
+      [
+        ["lookup-id", "lookup", { key: "value" }],
+        ["shell-id", "shell", { input: "echo hello" }],
+      ],
+    );
+    assert.deepStrictEqual(
+      results(actual).map((result) => [
+        result.callId,
+        (result.content[0] as vscode.LanguageModelTextPart).value,
+      ]),
+      [
+        ["shell-id", "hello"],
+        ["lookup-id", "found"],
+      ],
+    );
+    assert.ok(text(actual).includes("Working"));
+    assert.deepStrictEqual(input, original);
+  });
+  test("Anthropic wrong-role calls retain context without consuming later results", () => {
+    const actual = convertAnthropicMessagesToVSCode([
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_use",
+            id: "x",
+            name: "submit",
+            input: { secret: "omitted-arguments" },
+          },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [{ type: "tool_use", id: "x", name: "read", input: {} }],
+      },
+      {
+        role: "user",
+        content: [{ type: "tool_result", tool_use_id: "x", content: "ok" }],
+      },
+    ]);
+    paired(actual, 1);
+    assert.strictEqual(
+      actual[0].role,
+      vscode.LanguageModelChatMessageRole.User,
+    );
+    assert.match(text([actual[0]]), /tool call.*user message/i);
+    assert.match(text([actual[0]]), /submit/);
+    assert.match(text([actual[0]]), /x/);
+    assert.match(text([actual[0]]), /Execution status is unknown/);
+    assert.ok(!text(actual).includes("omitted-arguments"));
+    assert.strictEqual(calls(actual)[0].name, "read");
+  });
+  test("Anthropic wrong-role results preserve text, errors, media and source order", () => {
+    const bytes = Buffer.from([1, 2, 3]);
+    const input = [
+      {
+        role: "assistant" as const,
+        content: [
+          { type: "text" as const, text: "before" },
+          {
+            type: "tool_result" as const,
+            tool_use_id: "saved-result",
+            is_error: true,
+            content: [
+              { type: "text" as const, text: "saved body" },
+              {
+                type: "image" as const,
+                source: {
+                  type: "base64" as const,
+                  media_type: "image/png" as const,
+                  data: bytes.toString("base64"),
+                },
+              },
+            ],
+          },
+          { type: "text" as const, text: "after" },
+        ],
+      },
+    ];
+    const original = structuredClone(input);
+    const actual = convertAnthropicMessagesToVSCode(input);
+    paired(actual, 0);
+    assert.strictEqual(actual.length, 1);
+    assert.strictEqual(
+      actual[0].role,
+      vscode.LanguageModelChatMessageRole.Assistant,
+    );
+    const parts = actual[0].content;
+    assert.strictEqual(
+      (parts[0] as vscode.LanguageModelTextPart).value,
+      "before",
+    );
+    assert.match(
+      (parts[1] as vscode.LanguageModelTextPart).value,
+      /tool result.*assistant message.*saved-result/i,
+    );
+    assert.match(
+      (parts[2] as vscode.LanguageModelTextPart).value,
+      /Tool reported an error/,
+    );
+    assert.strictEqual(
+      (parts[3] as vscode.LanguageModelTextPart).value,
+      "saved body",
+    );
+    assert.ok(parts[4] instanceof vscode.LanguageModelDataPart);
+    assert.strictEqual(parts[4].mimeType, "image/png");
+    assert.deepStrictEqual(Buffer.from(parts[4].data), bytes);
+    assert.strictEqual(
+      (parts[5] as vscode.LanguageModelTextPart).value,
+      "after",
+    );
+    assert.deepStrictEqual(input, original);
+  });
+  test("Anthropic wrong-role empty results retain provenance without pairing", () => {
+    const actual = convertAnthropicMessagesToVSCode([
+      {
+        role: "assistant",
+        content: [
+          { type: "tool_use", id: "x", name: "read", input: {} },
+          { type: "tool_result", tool_use_id: "x", content: "" },
+        ],
+      },
+      {
+        role: "user",
+        content: [{ type: "tool_result", tool_use_id: "x", content: "actual" }],
+      },
+    ]);
+    paired(actual, 1);
+    assert.match(text(actual), /tool result.*assistant message/i);
+    assert.strictEqual(
+      (results(actual)[0].content[0] as vscode.LanguageModelTextPart).value,
+      "actual",
+    );
+  });
+  test("Anthropic error status survives when a result becomes context", () => {
+    const actual = convertAnthropicMessagesToVSCode([
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "missing",
+            content: "",
+            is_error: true,
+          },
+        ],
+      },
+    ]);
+    paired(actual, 0);
+    assert.match(text(actual), /Tool reported an error/);
+  });
+  test("resume-shaped history keeps differing masked/full bodies as conflict context", () => {
+    const input: Message[] = [];
+    for (let index = 0; index < 30; index++) {
+      input.push(M(C("call_" + index)));
+      input.push(
+        U(
+          R("call_" + index, "full " + index),
+          R("call_" + index, index % 2 ? "full " + index : "masked " + index),
+        ),
+      );
+    }
+    const actual = adapters.Gemini(input);
+    paired(actual, 15);
+    for (let index = 0; index < 30; index += 2) {
+      assert.ok(text(actual).includes("full " + index));
+      assert.ok(text(actual).includes("masked " + index));
+    }
+  });
+  test("request instructions cannot provide a result to input", () => {
+    const actual = convertResponsesInputToVSCode(
+      [{ type: "function_call_output", call_id: "x", output: "late" }],
+      [{ type: "function_call", call_id: "x", name: "f", arguments: "{}" }],
+    );
+    paired(actual, 0);
+  });
+});
+
+suite("Tool history normalizer", () => {
+  const call = (id?: string): ToolHistoryPart => ({
+    kind: "call",
+    id,
+    name: "f",
+    input: {},
+    value: {},
+    toolType: "function",
+    allowMissingId: true,
+  });
+  const result = (
+    id?: string,
+    value: unknown = { ok: true },
+  ): ToolHistoryPart => ({
+    kind: "result",
+    id,
+    name: "f",
+    value,
+    parts: [new vscode.LanguageModelTextPart(encode(value))],
+    toolType: "function",
+    allowMissingId: true,
+  });
+  const model = (...parts: ToolHistoryPart[]): ToolHistoryMessage => ({
+    role: "assistant",
+    parts,
+  });
+  const user = (...parts: ToolHistoryPart[]): ToolHistoryMessage => ({
+    role: "user",
+    parts,
+  });
+  test("reserves all explicit IDs before generating request-local IDs", () => {
+    const actual = toolHistoryToVSCode(
+      [
+        model(call()),
+        user(result()),
+        model(call("am_history_0_0")),
+        user(result("am_history_0_0")),
+      ],
+      "Test",
+    );
+    paired(actual, 2);
+    assert.strictEqual(calls(actual)[1].callId, "am_history_0_0");
+  });
+  test("retains media when orphaned or conflicting", () => {
+    const image = new vscode.LanguageModelDataPart(
+      new Uint8Array([1, 2, 3]),
+      "image/png",
+    );
+    const r = { ...result("x"), parts: [image] } as ToolHistoryPart;
+    for (const input of [
+      [user(r)],
+      [model(call("x")), user(r, result("x", "other"))],
+    ]) {
+      const actual = toolHistoryToVSCode(input, "Test");
+      paired(actual, 0);
+      assert.ok(actual.flatMap((m) => m.content).includes(image));
+    }
+  });
+  test("logs only counts, with no result bodies or IDs", () => {
+    const warnings: string[] = [];
+    const warn = logger.warn;
+    logger.warn = (message: string) => warnings.push(message);
+    try {
+      const history = [
+        model(call("sensitive-id")),
+        user(
+          result("sensitive-id", "secret"),
+          result("sensitive-id", "conflict"),
+        ),
+      ];
+      const { diagnostics } = normalizeToolHistory(history);
+      assert.strictEqual(diagnostics.conflictGroups, 1);
+      toolHistoryToVSCode(history, "Test");
+      assert.strictEqual(warnings.length, 1);
+      assert.ok(
+        !warnings[0].includes("sensitive-id") &&
+          !warnings[0].includes("secret"),
+      );
+    } finally {
+      logger.warn = warn;
+    }
+  });
+  test("idempotently retains normalized parts and unique IDs", () => {
+    const initial = [
+      model(call("x")),
+      user(result("x")),
+      model(call("x")),
+      user(result("x")),
+      model(call("missing")),
+    ];
+    const once = toolHistoryToVSCode(initial, "Test");
+    const roundtrip: ToolHistoryMessage[] = once.map((m) => ({
+      role:
+        m.role === vscode.LanguageModelChatMessageRole.Assistant
+          ? "assistant"
+          : "user",
+      parts: m.content.map((p): ToolHistoryPart => {
+        if (p instanceof vscode.LanguageModelToolCallPart) {
+          return {
+            kind: "call",
+            id: p.callId,
+            name: p.name,
+            input: p.input,
+            value: p.input,
+            toolType: "function",
+          };
+        }
+        if (p instanceof vscode.LanguageModelToolResultPart) {
+          return {
+            kind: "result",
+            id: p.callId,
+            parts: p.content as any,
+            value: p.content,
+            toolType: "function",
+          };
+        }
+        return { kind: "content", parts: [p] };
+      }),
+    }));
+    assert.deepStrictEqual(toolHistoryToVSCode(roundtrip, "Test"), once);
+  });
+});

--- a/src/test/server/toolHistoryRoutes.test.ts
+++ b/src/test/server/toolHistoryRoutes.test.ts
@@ -1,0 +1,286 @@
+import Anthropic from "@anthropic-ai/sdk";
+import { GoogleGenAI } from "@google/genai";
+import { getRequestListener } from "@hono/node-server";
+import { OpenAPIHono } from "@hono/zod-openapi";
+import * as assert from "assert";
+import { once } from "node:events";
+import { createServer } from "node:http";
+import OpenAI from "openai";
+import * as vscode from "vscode";
+
+import { registerAnthropicRoutes } from "../../server/routes/anthropicRoutes";
+import { registerGeminiRoutes } from "../../server/routes/geminiRoutes";
+import { registerOpenaiChatRoutes } from "../../server/routes/openai/openaiChatRoutes";
+import { registerOpenaiResponsesRoutes } from "../../server/routes/openai/openaiResponsesRoutes";
+
+suite("Normalized history through official SDKs", () => {
+  test("all four routes preserve newly generated IDs while normalizing input", async () => {
+    const captured: vscode.LanguageModelChatMessage[][] = [];
+    const model = {
+      id: "claude-test",
+      name: "Test",
+      family: "claude",
+      vendor: "copilot",
+      version: "test",
+      maxInputTokens: 200000,
+      capabilities: { supportsToolCalling: true, supportsImageToText: false },
+      countTokens: async () => 1,
+      sendRequest: async (messages: vscode.LanguageModelChatMessage[]) => {
+        captured.push(messages);
+        return {
+          stream: (async function* () {
+            yield new vscode.LanguageModelToolCallPart(
+              "new-client-call",
+              "lookup",
+              { key: "new" },
+            );
+          })(),
+          text: (async function* () {})(),
+        };
+      },
+    } as unknown as vscode.LanguageModelChat;
+    const app = new OpenAPIHono();
+    const options = {
+      requestTimeoutMs: 2000,
+      resolveChatModelClient: async () => ({ client: model }),
+    };
+    const anthropicRoutes = new OpenAPIHono();
+    registerAnthropicRoutes(anthropicRoutes, options);
+    app.route("/anthropic", anthropicRoutes);
+    const chatRoutes = new OpenAPIHono();
+    registerOpenaiChatRoutes(chatRoutes, options);
+    app.route("/openai", chatRoutes);
+    const responsesRoutes = new OpenAPIHono();
+    registerOpenaiResponsesRoutes(responsesRoutes, options);
+    app.route("/openai", responsesRoutes);
+    const geminiRoutes = new OpenAPIHono();
+    registerGeminiRoutes(geminiRoutes, options);
+    app.route("/gemini", geminiRoutes);
+    const server = createServer(getRequestListener(app.fetch));
+    server.listen(0, "127.0.0.1");
+    try {
+      await once(server, "listening");
+      const address = server.address();
+      assert.ok(address && typeof address !== "string");
+      const base = "http://127.0.0.1:" + address.port;
+      const anthropic = new Anthropic({
+        apiKey: "test",
+        baseURL: base + "/anthropic",
+        maxRetries: 0,
+      });
+      const aStream = await anthropic.messages.create({
+        model: model.id,
+        max_tokens: 100,
+        stream: true,
+        messages: [
+          {
+            role: "user",
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: "orphan",
+                content: "saved context",
+              },
+            ],
+          },
+          {
+            role: "assistant",
+            content: [{ type: "tool_use", id: "x", name: "lookup", input: {} }],
+          },
+          {
+            role: "user",
+            content: [{ type: "tool_result", tool_use_id: "x", content: "ok" }],
+          },
+          {
+            role: "assistant",
+            content: [{ type: "tool_use", id: "x", name: "lookup", input: {} }],
+          },
+          {
+            role: "user",
+            content: [{ type: "tool_result", tool_use_id: "x", content: "ok" }],
+          },
+        ],
+      });
+      const aIds: string[] = [];
+      for await (const event of aStream) {
+        if (
+          event.type === "content_block_start" &&
+          event.content_block.type === "tool_use"
+        ) {
+          aIds.push(event.content_block.id);
+        }
+      }
+      assert.deepStrictEqual(aIds, ["new-client-call"]);
+
+      const openai = new OpenAI({
+        apiKey: "test",
+        baseURL: base + "/openai/v1",
+        maxRetries: 0,
+      });
+      const cStream = await openai.chat.completions.create({
+        model: model.id,
+        stream: true,
+        messages: [
+          { role: "tool", tool_call_id: "orphan", content: "saved context" },
+          {
+            role: "assistant",
+            tool_calls: [
+              {
+                type: "function",
+                id: "x",
+                function: { name: "lookup", arguments: "{}" },
+              },
+            ],
+          },
+          { role: "tool", tool_call_id: "x", content: "ok" },
+          {
+            role: "assistant",
+            tool_calls: [
+              {
+                type: "function",
+                id: "x",
+                function: { name: "lookup", arguments: "{}" },
+              },
+            ],
+          },
+          { role: "tool", tool_call_id: "x", content: "ok" },
+        ],
+      });
+      const cIds: string[] = [];
+      for await (const chunk of cStream) {
+        for (const choice of chunk.choices) {
+          for (const call of choice.delta.tool_calls ?? []) {
+            if (call.id) {
+              cIds.push(call.id);
+            }
+          }
+        }
+      }
+      assert.deepStrictEqual(cIds, ["new-client-call"]);
+      const rStream = openai.responses.stream({
+        model: model.id,
+        input: [
+          {
+            type: "function_call_output",
+            call_id: "orphan",
+            output: "saved context",
+          },
+          {
+            type: "function_call",
+            call_id: "x",
+            name: "lookup",
+            arguments: "{}",
+          },
+          { type: "function_call_output", call_id: "x", output: "ok" },
+          {
+            type: "function_call",
+            call_id: "x",
+            name: "lookup",
+            arguments: "{}",
+          },
+          { type: "function_call_output", call_id: "x", output: "ok" },
+        ],
+      });
+      const response = await rStream.finalResponse();
+      assert.deepStrictEqual(
+        response.output
+          .filter((o) => o.type === "function_call")
+          .map((o) => o.call_id),
+        ["new-client-call"],
+      );
+
+      const gemini = new GoogleGenAI({
+        apiKey: "test",
+        vertexai: false,
+        httpOptions: { baseUrl: base + "/gemini", apiVersion: "v1beta" },
+      });
+      const gStream = await gemini.models.generateContentStream({
+        model: model.id,
+        contents: [
+          {
+            role: "user",
+            parts: [
+              {
+                functionResponse: {
+                  id: "orphan",
+                  name: "lookup",
+                  response: { output: "saved context" },
+                },
+              },
+            ],
+          },
+          {
+            role: "model",
+            parts: [{ functionCall: { id: "x", name: "lookup", args: {} } }],
+          },
+          {
+            role: "user",
+            parts: [
+              {
+                functionResponse: {
+                  id: "x",
+                  name: "lookup",
+                  response: { output: "ok" },
+                },
+              },
+            ],
+          },
+          {
+            role: "model",
+            parts: [{ functionCall: { id: "x", name: "lookup", args: {} } }],
+          },
+          {
+            role: "user",
+            parts: [
+              {
+                functionResponse: {
+                  id: "x",
+                  name: "lookup",
+                  response: { output: "ok" },
+                },
+              },
+            ],
+          },
+        ],
+      });
+      const gIds: Array<string | undefined> = [];
+      for await (const chunk of gStream) {
+        for (const call of chunk.functionCalls ?? []) {
+          gIds.push(call.id);
+        }
+      }
+      assert.deepStrictEqual(gIds, ["new-client-call"]);
+      assert.strictEqual(captured.length, 4);
+      for (const messages of captured) {
+        const parts = messages.flatMap((m) => m.content);
+        const calls = parts.filter(
+          (p): p is vscode.LanguageModelToolCallPart =>
+            p instanceof vscode.LanguageModelToolCallPart,
+        );
+        const results = parts.filter(
+          (p): p is vscode.LanguageModelToolResultPart =>
+            p instanceof vscode.LanguageModelToolResultPart,
+        );
+        assert.strictEqual(calls.length, 2);
+        assert.strictEqual(results.length, 2);
+        assert.strictEqual(new Set(calls.map((c) => c.callId)).size, 2);
+        assert.deepStrictEqual(
+          results.map((r) => r.callId),
+          calls.map((c) => c.callId),
+        );
+        assert.ok(
+          parts.some(
+            (p) =>
+              p instanceof vscode.LanguageModelTextPart &&
+              p.value.includes("saved context"),
+          ),
+        );
+      }
+    } finally {
+      server.closeAllConnections();
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Incomplete or replayed client histories can leave unmatched tool calls/results in requests sent to VS Code LM. Normalize complete inbound snapshots consistently across Anthropic Messages, OpenAI Chat Completions/Responses, and Gemini.

- Replace separate pairing logic with turn-scoped normalization: retain complete pairs, preserve missing-result status and orphan/conflict context, merge identical same-turn duplicates, and remap reused IDs only in the upstream request copy.
- Preserve Gemini ID-less pairing and group parallel formal parts for Copilot compatibility. Keep Chat source calls aligned when unsupported tool types are skipped, and retain wrong-role Anthropic tool blocks as context.
- Include the design, documentation, regression tests, and patch changeset `.changeset/real-plums-tan.md`. Client session files and newly generated response IDs remain unchanged.

## Test plan

- [x] Source/test type checks, ESLint, development build, Prettier, and `git diff --check`.
- [x] Full extension-host suite: **597 tests passed** using the installed VS Code Insiders host.
- [x] Four new adapter regression tests failed before the fixes and passed afterward.
- [x] Official SDK streaming tests across all four routes verify historical ID remapping preserves newly generated response IDs.
- [x] Live matrix: 12 requests across four endpoints, covering parallel calls with context, conflicting results, and complete-pair replay; all returned HTTP 200 and the expected marker.
- [x] Local Gemini CLI resume checks with `gemini-3.8-flash`, plus replay of the original #251 failure fixture, completed successfully.
