### PR TITLE
fix(search): support anonymous standalone search filters

### DIFF
--- a/.changeset/calm-responses-search.md
+++ b/.changeset/calm-responses-search.md
@@ -1,7 +1,0 @@
----
-"agent-maestro": minor
----
-
-Add OpenAI Responses web search through Exa with Codex support, streaming events, citations, isolation, and shared output budgeting.
-
-Unsupported or preview web-search declarations now return HTTP 400 instead of being silently ignored; only `web_search` and `web_search_2025_08_26` are supported.

--- a/.changeset/dry-sheep-stick.md
+++ b/.changeset/dry-sheep-stick.md
@@ -1,5 +1,0 @@
----
-"agent-maestro": patch
----
-
-fix(gemini): prevent CLI stream parsing failures during long-running requests by sending SDK-compatible heartbeats

--- a/.changeset/fine-boxes-cross.md
+++ b/.changeset/fine-boxes-cross.md
@@ -1,5 +1,0 @@
----
-"agent-maestro": patch
----
-
-Correct setup paths, API compatibility and remote-access guidance; consolidate documentation and update website feature and diagnostic descriptions.

--- a/.changeset/fuzzy-codex-search.md
+++ b/.changeset/fuzzy-codex-search.md
@@ -1,5 +1,0 @@
----
-"agent-maestro": minor
----
-
-Add experimental Codex standalone web search compatibility backed by Exa, including search filters, page open and find operations, bounded reference state, and automatic Codex capability configuration.

--- a/.changeset/icy-donkeys-live.md
+++ b/.changeset/icy-donkeys-live.md
@@ -1,5 +1,0 @@
----
-"agent-maestro": patch
----
-
-fix(gemini): ignore repeated explicitly identified tool results within the same call turn when restoring CLI sessions

--- a/.changeset/quick-tools-replay.md
+++ b/.changeset/quick-tools-replay.md
@@ -1,5 +1,0 @@
----
-"agent-maestro": patch
----
-
-fix(openai): preserve parallel tool-call turns when replaying Responses history

--- a/.changeset/real-plums-tan.md
+++ b/.changeset/real-plums-tan.md
@@ -1,5 +1,0 @@
----
-"agent-maestro": patch
----
-
-fix(proxy): normalize incomplete and replayed tool histories across API adapters

--- a/.changeset/six-facts-rush.md
+++ b/.changeset/six-facts-rush.md
@@ -1,5 +1,0 @@
----
-"agent-maestro": patch
----
-
-Fix Codex standalone domain, recency, country, and cache-only searches without an Exa API key by using anonymous MCP with bounded highlights.

--- a/.changeset/six-facts-rush.md
+++ b/.changeset/six-facts-rush.md
@@ -1,0 +1,5 @@
+---
+"agent-maestro": patch
+---
+
+Fix Codex standalone domain, recency, country, and cache-only searches without an Exa API key by using anonymous MCP with bounded highlights.

--- a/.changeset/twenty-zoos-go.md
+++ b/.changeset/twenty-zoos-go.md
@@ -1,5 +1,0 @@
----
-"agent-maestro": patch
----
-
-Fix Codex Responses SSE idle timeouts by sending JSON keepalive events during model startup, generation, web search, and token counting without replacing the OpenAI SDK's accumulated response.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v2.14.0 - 2026.09.06
+
+- Add experimental Codex standalone search at `/api/openai/v1/alpha/search`, with search queries, page `open`/`find`, and domain, date, country, and cache-only controls. Rerun **Agent Maestro: Configure Codex Settings** to add the required configuration; existing `web_search = "disabled"` settings are preserved.
+- Add hosted search directly to `/api/openai/v1/responses`: declare `web_search` to let AM search and generate an answer with source citations within the same request, with streaming support. Both search paths work without an Exa API key, subject to anonymous rate limits.
+- Fix Gemini CLI JSON parsing errors and Codex idle timeouts during slow or long-running responses.
+- Fix request failures caused by missing or repeated tool results when resuming conversations, and preserve results from parallel Codex tool calls. These improvements apply across Anthropic-, OpenAI-, and Gemini-compatible APIs.
+- Update client setup and troubleshooting instructions, and clarify supported search features and remote-access requirements.
+- **API compatibility:** Unsupported and preview web-search tool declarations in OpenAI Responses requests now return HTTP 400 instead of being silently ignored. Use `web_search` or `web_search_2025_08_26`.
+
 ## v2.13.0 - 2026.08.28
 
 - Add transparent Exa-powered web search to Anthropic-compatible requests, with streamed source links and support for anonymous or securely authenticated access.

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Search is available when a supported client requests it. AM does not add search 
 
 After configuring a supported Codex release, try asking it to find a recent release announcement and cite its sources. An existing `web_search = "disabled"` setting is preserved; change it to `"live"` if you want to enable search.
 
-Basic searches can use Exa's anonymous allowance. Run **Agent Maestro: Set Exa API Key** to use your Exa account; domain, recency, country, or cache-only constraints on standalone search require a key. Queries and retrieved page URLs are sent to Exa, whose usage limits and billing are separate from Copilot.
+Searches can use Exa's anonymous allowance, including domain, recency, country, and cache-only constraints on standalone search. No Exa API key is required; anonymous access remains subject to Exa's rate limits. Run **Agent Maestro: Set Exa API Key** to use your Exa account. Queries and retrieved page URLs are sent to Exa, whose usage limits and billing are separate from Copilot.
 
 These paths have different contracts: Gemini has no hosted-search integration here, and not every native search option or Codex web command is supported. See [search compatibility and supported Codex versions](docs/llm-compatibility.md#web-search).
 

--- a/docs/2026-08-31-codex-standalone-web-search-design.md
+++ b/docs/2026-08-31-codex-standalone-web-search-design.md
@@ -17,11 +17,12 @@ POST /api/openai/v1/alpha/search
 ```
 
 The endpoint translates supported Codex `web.run` commands into calls to
-the hosted Exa MCP server. Advanced search settings use Exa's authenticated
-Search API because the pinned MCP advanced-search tool cannot disable full-page
-text retrieval. It returns the plain-text search output expected by Codex
-and optional structured result DTOs for Codex clients that display search
-activity.
+the hosted Exa MCP server. Advanced search settings use anonymous advanced MCP
+when no key is configured, or Exa's authenticated Search API when a key is
+available. Both paths return bounded highlights; anonymous MCP limits unused
+extracted text to one character per result. It returns the plain-text search
+output expected by Codex and optional structured result DTOs for Codex clients
+that display search activity.
 
 The original rollout gated automatic configuration on reference-based `open`
 and `find`. That gate is complete: `Configure Codex Settings` writes the
@@ -245,12 +246,14 @@ During design validation, the anonymous hosted endpoint:
 - listed all three explicitly requested tools; and
 - completed an anonymous `web_search_exa` call.
 
-The pinned `web_search_advanced_exa` implementation always requests
-`contents.text`, even when highlights are enabled. Agent Maestro therefore does
-not call that tool for standalone search. Requests needing domain, recency,
-country, or cache-only policy use the Exa Search API with a highlights-only
-`contents` object when an API key is configured. Without a key, they return a
-recoverable `advanced_search_requires_api_key` result.
+The `web_search_advanced_exa` implementation always requests `contents.text`,
+even when highlights are enabled. The original implementation therefore
+required an API key for advanced standalone searches. Validation on 2026-09-05
+confirmed that the anonymous hosted tool accepts `textMaxCharacters: 1` along
+with domain, date, country, and `maxAgeHours: -1` filters, returning useful
+highlights and one character of text per result. Agent Maestro uses this
+bounded request without a key and discards the text when normalizing results.
+With a key, the existing highlights-only Search API request remains in use.
 
 ### Authentication and Rate Limiting
 
@@ -376,12 +379,16 @@ true:
 - there is no location constraint; and
 - no explicit cache-only policy must be enforced.
 
-Otherwise use the authenticated Exa Search API. If no API key is configured,
-return a recoverable unavailable result without dispatching the unsafe advanced
-MCP tool.
+Otherwise use the authenticated Exa Search API when a key is configured, or
+`web_search_advanced_exa` without a key. Both requests preserve the same domain,
+date, country, and cache policy. Missing MCP capability or provider failure
+returns a recoverable error; it does not trigger an unconstrained search.
 
-The advanced request includes only highlights with a bounded character limit.
-It omits `text`, so raw full-page text is not requested during the search phase.
+The authenticated request omits `text` and requests only bounded highlights.
+The anonymous MCP request sets `textMaxCharacters: 1`, `enableHighlights: true`,
+and `highlightsMaxCharacters: 1200`; it requests no summaries, context string,
+or subpages. Its text is discarded before results enter Codex's output or page
+cache. The existing result count and total output budgets apply to both paths.
 
 ### Domain Filters
 
@@ -626,8 +633,8 @@ Responsibilities:
 - MCP initialize and protocol negotiation;
 - lazy MCP initialization so authenticated Search API calls do not depend on
   MCP availability;
-- MCP tool discovery only when a simple search or uncached page fetch will
-  actually call an MCP tool;
+- MCP tool discovery only when a simple search, anonymous advanced search, or
+  uncached page fetch will actually call an MCP tool;
 - session ID propagation;
 - JSON and SSE JSON-RPC response parsing;
 - tool discovery;

--- a/docs/llm-compatibility.md
+++ b/docs/llm-compatibility.md
@@ -107,7 +107,7 @@ Configure an optional Exa key with **Agent Maestro: Set Exa API Key**. Queries a
 
 Hosted search accepts domain filters and country-level location, but rejects unsupported options. Anthropic allow/block lists are mutually exclusive; Responses permits both. Hosted searches use at most five results and 8,000 characters of evidence; the response output budget is shared across model rounds. Mixed client/server tool calls prioritize client tools, and immediate client-tool-result continuations cannot initiate hosted search. Search synthesis exposes no further tools.
 
-Responses `external_web_access: false` is rejected. Standalone cache-only search is a different contract: it uses authenticated Exa Search API retrieval, and `open`/`find` can use only pages already cached in the current extension process. Domain, recency, country, or cache-only standalone searches require an Exa key; unconstrained searches can use anonymous MCP access.
+Responses `external_web_access: false` is rejected. Standalone cache-only search is a different contract: it sends `maxAgeHours: -1` through anonymous Exa MCP or the authenticated Exa Search API, and `open`/`find` can use only pages already cached in the current extension process. Domain, recency, country, and cache-only standalone searches work without an Exa key, subject to anonymous rate limits. Advanced searches return bounded highlights to the client; anonymous MCP requests limit the unused extracted text to one character per result.
 
 ### Codex Standalone Configuration
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "agent-maestro",
   "displayName": "Agent Maestro",
   "description": "Turn VS Code into your compliant AI playground! With Agent Maestro, spin up Cline or Roo on demand and plug Claude Code or Codex straight in through an OpenAI/Anthropic-compatible API.",
-  "version": "2.13.0",
+  "version": "2.14.0",
   "icon": "assets/icons/icon.png",
   "publisher": "Joouis",
   "repository": "https://github.com/Joouis/agent-maestro",

--- a/src/server/webSearch/codexStandaloneWebSearch.ts
+++ b/src/server/webSearch/codexStandaloneWebSearch.ts
@@ -1295,6 +1295,12 @@ export class CodexStandaloneWebSearch {
       if (searchPlans.some(({ advanced }) => !advanced)) {
         requiredTools.add("web_search_exa");
       }
+      if (
+        !session.authenticated &&
+        searchPlans.some(({ advanced }) => advanced)
+      ) {
+        requiredTools.add("web_search_advanced_exa");
+      }
       if (needsPageFetch) {
         requiredTools.add("web_fetch_exa");
       }
@@ -1328,33 +1334,37 @@ export class CodexStandaloneWebSearch {
         searchPlans,
         concurrency,
         async ({ advanced, allowed, query }) => {
-          if (advanced && !session.authenticated) {
-            return [];
-          }
           stats.providerCalls++;
           if (advanced) {
-            const result = await session.searchAdvanced(
-              {
-                query: query.q,
-                numResults: budget.results,
-                highlightsMaxCharacters: 1_200,
-                ...(allowed?.length && { includeDomains: allowed }),
-                ...(blockedDomains?.length && {
-                  excludeDomains: blockedDomains,
-                }),
-                ...(query.recency !== undefined && {
-                  startPublishedDate: subtractUtcDays(
-                    this.now(),
-                    query.recency,
-                  ),
-                }),
-                ...(country && {
-                  userLocation: normalizeWebSearchCountryCode(country),
-                }),
-                ...(cacheOnly && { maxAgeHours: -1 }),
-              },
-              signal,
-            );
+            const args = {
+              query: query.q,
+              numResults: budget.results,
+              highlightsMaxCharacters: 1_200,
+              ...(allowed?.length && { includeDomains: allowed }),
+              ...(blockedDomains?.length && {
+                excludeDomains: blockedDomains,
+              }),
+              ...(query.recency !== undefined && {
+                startPublishedDate: subtractUtcDays(this.now(), query.recency),
+              }),
+              ...(country && {
+                userLocation: normalizeWebSearchCountryCode(country),
+              }),
+              ...(cacheOnly && { maxAgeHours: -1 }),
+            };
+            const result = session.authenticated
+              ? await session.searchAdvanced(args, signal)
+              : await session.callTool(
+                  "web_search_advanced_exa",
+                  {
+                    ...args,
+                    // MCP cannot disable text extraction; request its minimum
+                    // and retain only highlights in the normalized results.
+                    textMaxCharacters: 1,
+                    enableHighlights: true,
+                  },
+                  signal,
+                );
             return recordResults(
               await this.filterResolvedPublicResults(
                 normalizeHighlightOnlyResults(
@@ -1385,10 +1395,7 @@ export class CodexStandaloneWebSearch {
         (error) => controller.abort(error),
       );
       const merged = roundRobinResults(perQuery, budget.results);
-      const unavailableAdvancedSearch = searchPlans.some(
-        ({ advanced }) => advanced && !session.authenticated,
-      );
-      if (!unavailableAdvancedSearch && merged.length === 0) {
+      if (merged.length === 0) {
         addOutput("No usable web search results were returned.");
       }
       let searchOutput = UNTRUSTED_SEARCH_HEADER;
@@ -1457,11 +1464,6 @@ export class CodexStandaloneWebSearch {
           visibleSearchReferences,
           resultDtos,
           OUTPUT_PRIORITY_EVIDENCE,
-        );
-      }
-      if (unavailableAdvancedSearch) {
-        addOutput(
-          "Web search unavailable: advanced_search_requires_api_key. Configure an Exa API key to apply filters or cache-only search without requesting full-page text.",
         );
       }
     }

--- a/src/test/server/codexStandaloneWebSearch.test.ts
+++ b/src/test/server/codexStandaloneWebSearch.test.ts
@@ -478,25 +478,205 @@ suite("Codex standalone web search", () => {
     assert.match(response.output, /unknown_reference/);
   });
 
-  test("requires an API key for advanced search instead of requesting full-page text", async () => {
-    const session = new FakeExaSession(false, () => {
-      throw new Error("Unexpected provider call");
-    });
+  test("maps anonymous advanced filters and returns highlights without extracted text", async () => {
+    const session = new FakeExaSession(false, () => ({
+      results: [
+        {
+          title: "Example",
+          url: "https://example.com/result",
+          publishedDate: "2026-08-29",
+          highlights: ["Relevant evidence"],
+          text: "UNUSED_TEXT_SENTINEL".repeat(1_000),
+          summary: "UNUSED_SUMMARY_SENTINEL",
+        },
+      ],
+    }));
     const adapter = createStandaloneSearch({
       client: createClient(session),
+      now: () => new Date("2026-08-31T12:00:00.000Z"),
     });
 
     const response = await adapter.execute(
       request(
         "anonymous-advanced",
-        { search_query: [{ q: "facts", domains: ["example.com"] }] },
-        { external_web_access: "cached" },
+        {
+          search_query: [{ q: "facts", domains: ["example.com"], recency: 7 }],
+        },
+        {
+          filters: {
+            allowed_domains: ["example.com", "other.example"],
+            blocked_domains: ["blocked.example"],
+          },
+          user_location: { type: "approximate", country: "us" },
+        },
       ),
       new AbortController().signal,
     );
 
+    assert.deepStrictEqual(session.calls, [
+      {
+        name: "web_search_advanced_exa",
+        args: {
+          query: "facts",
+          numResults: 5,
+          highlightsMaxCharacters: 1_200,
+          includeDomains: ["example.com"],
+          excludeDomains: ["blocked.example"],
+          startPublishedDate: "2026-08-24",
+          userLocation: "US",
+          textMaxCharacters: 1,
+          enableHighlights: true,
+        },
+      },
+    ]);
+    assert.deepStrictEqual(response.results, [
+      {
+        type: "text_result",
+        ref_id: "turn0search0",
+        url: "https://example.com/result",
+        title: "Example",
+        snippet: "Relevant evidence",
+      },
+    ]);
+    assert.match(response.output, /Published: 2026-08-29/);
+    assert.doesNotMatch(JSON.stringify(response), /UNUSED_/);
+    assert.doesNotMatch(JSON.stringify(session.calls), /private conversation/);
+  });
+
+  test("preserves anonymous cache-only modes without filling the page cache or fetching pages", async () => {
+    for (const mode of [false, "cached", "indexed"]) {
+      const session = new FakeExaSession(false, () => ({
+        results: [
+          {
+            title: "Cached result",
+            url: "https://example.com/result",
+            highlights: ["Cached evidence"],
+            text: "Text that must not populate the page cache",
+          },
+        ],
+      }));
+      const adapter = createStandaloneSearch({ client: createClient(session) });
+      const search = await adapter.execute(
+        request(
+          "anonymous-cache",
+          { search_query: [{ q: "facts" }] },
+          { external_web_access: mode },
+        ),
+        new AbortController().signal,
+      );
+      assert.strictEqual(search.results.length, 1);
+      assert.strictEqual(session.calls[0].name, "web_search_advanced_exa");
+      assert.strictEqual(session.calls[0].args.maxAgeHours, -1);
+      const page = await adapter.execute(
+        request(
+          "anonymous-cache",
+          {
+            open: [{ ref_id: "turn0search0" }],
+            find: [{ ref_id: "turn0search0", pattern: "Cached" }],
+          },
+          { external_web_access: mode },
+        ),
+        new AbortController().signal,
+      );
+      assert.match(page.output, /cache_only_page_not_cached/);
+      assert.strictEqual(session.calls.length, 1);
+    }
+  });
+
+  test("does not retry an anonymous cache miss with live access", async () => {
+    const session = new FakeExaSession(false, () => ({ results: [] }));
+    const adapter = createStandaloneSearch({ client: createClient(session) });
+    const response = await adapter.execute(
+      request(
+        "cache-miss",
+        { search_query: [{ q: "facts" }] },
+        { external_web_access: false },
+      ),
+      new AbortController().signal,
+    );
+    assert.strictEqual(session.calls.length, 1);
+    assert.strictEqual(session.calls[0].args.maxAgeHours, -1);
+    assert.deepStrictEqual(response.results, []);
+    assert.match(response.output, /No usable web search results/);
+  });
+
+  test("keeps mixed anonymous simple and advanced searches sequential", async () => {
+    let active = 0;
+    let maxActive = 0;
+    const session = new FakeExaSession(false, async (_name, args) => {
+      maxActive = Math.max(maxActive, ++active);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      active--;
+      return searchResult(String(args.query), `https://${args.query}.example`);
+    });
+    const adapter = createStandaloneSearch({ client: createClient(session) });
+    const response = await adapter.execute(
+      request("mixed-anonymous", {
+        search_query: [
+          { q: "simple" },
+          { q: "filtered", domains: ["filtered.example"] },
+        ],
+      }),
+      new AbortController().signal,
+    );
+    assert.strictEqual(maxActive, 1);
+    assert.deepStrictEqual(
+      session.calls.map(({ name }) => name),
+      ["web_search_exa", "web_search_advanced_exa"],
+    );
+    assert.deepStrictEqual(
+      response.results.map(({ title }) => title),
+      ["simple", "filtered"],
+    );
+  });
+
+  test("does not broaden anonymous advanced search when its MCP tool is unavailable", async () => {
+    const session = new FakeExaSession(false, () => {
+      throw new Error("Unexpected provider call");
+    });
+    session.listTools = async () => ["web_search_exa", "web_fetch_exa"];
+    const adapter = createStandaloneSearch({ client: createClient(session) });
+    const response = await adapter.execute(
+      request("missing-advanced", {
+        search_query: [{ q: "facts", domains: ["example.com"] }],
+      }),
+      new AbortController().signal,
+    );
+    assert.match(response.output, /protocol_error/);
+    assert.deepStrictEqual(response.results, []);
     assert.strictEqual(session.calls.length, 0);
-    assert.match(response.output, /advanced_search_requires_api_key/);
+  });
+
+  test("bounds anonymous advanced highlights and never substitutes raw text", async () => {
+    const session = new FakeExaSession(false, () => ({
+      results: [
+        {
+          title: "No highlights",
+          url: "https://example.com/one",
+          text: "RAW_TEXT_SENTINEL",
+        },
+        {
+          title: "Long highlights",
+          url: "https://example.com/two",
+          highlights: ["字".repeat(20_000)],
+          text: "RAW_TEXT_SENTINEL",
+        },
+      ],
+    }));
+    const adapter = createStandaloneSearch({ client: createClient(session) });
+    const response = await adapter.execute(
+      {
+        ...request("bounded-advanced", {
+          search_query: [{ q: "facts", domains: ["example.com"] }],
+        }),
+        max_output_tokens: 500,
+      },
+      new AbortController().signal,
+    );
+    assert.ok(Buffer.byteLength(response.output) <= codexOutputByteBudget(500));
+    assert.strictEqual(response.results.length, 2);
+    assert.strictEqual(response.results[0].snippet, undefined);
+    assert.doesNotMatch(JSON.stringify(response), /RAW_TEXT_SENTINEL/);
   });
 
   test("supports reference open and cached literal find", async () => {
@@ -845,17 +1025,15 @@ suite("Codex standalone web search", () => {
     const response = await adapter.execute(
       {
         ...request("priority-status", {
-          search_query: [
-            { q: "simple" },
-            { q: "filtered", domains: ["example.com"] },
-          ],
+          search_query: [{ q: "simple" }],
+          sports: [{ fn: "schedule", league: "nba" }],
         }),
         max_output_tokens: 220,
       },
       new AbortController().signal,
     );
 
-    assert.match(response.output, /advanced_search_requires_api_key/);
+    assert.match(response.output, /unsupported_command: sports/);
     assert.doesNotMatch(response.output, /Optional evidence/);
     assert.deepStrictEqual(response.results, []);
   });
@@ -871,10 +1049,8 @@ suite("Codex standalone web search", () => {
     const response = await adapter.execute(
       {
         ...request("priority-tight-status", {
-          search_query: [
-            { q: "simple" },
-            { q: "filtered", domains: ["example.com"] },
-          ],
+          search_query: [{ q: "simple" }],
+          sports: [{ fn: "schedule", league: "nba" }],
         }),
         max_output_tokens: 130,
       },
@@ -1781,26 +1957,75 @@ suite("Codex standalone web search", () => {
       assert.strictEqual(JSON.stringify(body).includes('"text"'), false);
     });
 
-    test("does not contact MCP for anonymous advanced-only requests", async () => {
-      let fetches = 0;
+    test("dispatches anonymous advanced MCP and preserves policy across a rate-limit retry", async () => {
+      const toolCalls: ToolCall[] = [];
+      let discoveries = 0;
       const client = new ExaMcpClient({
+        endpoint: "https://mcp.test",
         getApiKey: async () => undefined,
-        fetch: async () => {
-          fetches++;
-          throw new Error("Unexpected fetch");
+        fetch: async (input, init) => {
+          assert.strictEqual(String(input), "https://mcp.test");
+          const headers = new Headers(init?.headers);
+          assert.strictEqual(headers.has("x-api-key"), false);
+          assert.strictEqual(headers.has("authorization"), false);
+          assert.doesNotMatch(String(init?.body), /private conversation/);
+          const body = JSON.parse(String(init?.body));
+          if (body.method === "notifications/initialized") {
+            return new Response(null, { status: 202 });
+          }
+          let result: unknown;
+          if (body.method === "initialize") {
+            result = { protocolVersion: "2025-03-26" };
+          } else if (body.method === "tools/list") {
+            discoveries++;
+            result = { tools: [{ name: "web_search_advanced_exa" }] };
+          } else {
+            assert.strictEqual(body.method, "tools/call");
+            toolCalls.push({
+              name: body.params.name,
+              args: body.params.arguments,
+            });
+            if (toolCalls.length === 1) {
+              return new Response(null, {
+                status: 429,
+                headers: { "retry-after": "0" },
+              });
+            }
+            result = searchResult("Example", "https://example.com/result");
+          }
+          return new Response(
+            JSON.stringify({ jsonrpc: "2.0", id: body.id, result }),
+            { headers: { "content-type": "application/json" } },
+          );
         },
       });
       const adapter = createStandaloneSearch({ client });
 
       const response = await adapter.execute(
-        request("lazy-anonymous", {
-          search_query: [{ q: "facts", domains: ["example.com"] }],
-        }),
+        request(
+          "anonymous-mcp",
+          { search_query: [{ q: "facts", domains: ["example.com"] }] },
+          { external_web_access: false },
+        ),
         new AbortController().signal,
       );
 
-      assert.strictEqual(fetches, 0);
-      assert.match(response.output, /advanced_search_requires_api_key/);
+      assert.strictEqual(discoveries, 1);
+      assert.strictEqual(toolCalls.length, 2);
+      assert.deepStrictEqual(toolCalls[0], {
+        name: "web_search_advanced_exa",
+        args: {
+          query: "facts",
+          numResults: 5,
+          includeDomains: ["example.com"],
+          highlightsMaxCharacters: 1_200,
+          maxAgeHours: -1,
+          textMaxCharacters: 1,
+          enableHighlights: true,
+        },
+      });
+      assert.deepStrictEqual(toolCalls[1], toolCalls[0]);
+      assert.strictEqual(response.results[0].snippet, "Example evidence");
     });
 
     test("honors cancellation while retrieving an API key", async () => {


### PR DESCRIPTION
## Summary

Codex standalone searches with domain, recency, country, or cache-only constraints returned `advanced_search_requires_api_key` without an Exa key. Route these requests through anonymous advanced MCP, preserving the constraints and returning bounded highlights; limit unused extracted text to one character per result. Keep the authenticated Search API path unchanged.

Update search documentation and add patch changeset `.changeset/six-facts-rush.md`. Anonymous Exa rate limits still apply.

## Test plan

- [x] Source/test TypeScript, ESLint, Prettier, and `git diff --check`.
- [x] Full extension-host suite: 602 passing on VS Code Insiders; focused standalone suite: 56 passing.
- [x] Regression coverage for filter mapping, cache-only behavior, bounded output, sequential anonymous dispatch, missing MCP capability, and preserved constraints across rate-limit retries.
- [x] Five no-key API probes on port 33333: domain, recency, country, cached, and combined constraints all returned useful results.
- [x] Real Codex 0.152.1 / gpt-5.6-sol repeated the previously failing domain-filtered search, referenced open, and find task in 27 seconds, with correct date/citation and no AM Output errors. The literal find had no match and the client disclosed that, using publication metadata.

Authenticated Exa behavior is covered by regression tests; live authenticated testing was not run because no key was available.
