### PR TITLE
fix(openai): preserve instruction roles through VS Code conversion

### DIFF
--- a/.changeset/fix-openai-instruction-roles.md
+++ b/.changeset/fix-openai-instruction-roles.md
@@ -1,0 +1,5 @@
+---
+"agent-maestro": patch
+---
+
+Preserve OpenAI Responses instructions and Chat/Responses system and developer messages as VS Code System messages, including through tool-history normalization. This prevents instruction-role downgrading that can suppress Codex progress updates. Requires the VS Code languageModelSystem proposed API to be enabled; system and developer share its single instruction role.

--- a/.vscode-test.mjs
+++ b/.vscode-test.mjs
@@ -2,4 +2,5 @@ import { defineConfig } from "@vscode/test-cli";
 
 export default defineConfig({
   files: "out/test/**/*.test.js",
+  launchArgs: ["--enable-proposed-api=joouis.agent-maestro"],
 });

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,10 @@
       "name": "Run Extension",
       "type": "extensionHost",
       "request": "launch",
-      "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}",
+        "--enable-proposed-api=joouis.agent-maestro"
+      ],
       "outFiles": ["${workspaceFolder}/dist/**/*.cjs"],
       "preLaunchTask": "${defaultBuildTask}",
       "env": {

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ This README and the [documentation index](docs/README.md) describe this checkout
 
 For source development, use Node.js 22 or newer and the pnpm version specified in [package.json](package.json).
 
+This checkout preserves OpenAI instruction roles using VS Code's proposed `languageModelSystem` API. Development/test launches enable it explicitly. Installed development builds require `code --enable-proposed-api=joouis.agent-maestro`; ordinary Marketplace publication is blocked while this proposed API dependency remains. See [instruction-role compatibility](docs/llm-compatibility.md#instruction-roles).
+
 ### 1. Install and Start the Proxy
 
 Install [Agent Maestro from VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=Joouis.agent-maestro) or [Open VSX](https://open-vsx.org/extension/Joouis/agent-maestro).

--- a/docs/llm-compatibility.md
+++ b/docs/llm-compatibility.md
@@ -75,6 +75,14 @@ Complete inbound snapshots are normalized before dispatch. Calls without results
 
 Normalization does not execute tools, summarize result bodies, rewrite client sessions, or change newly generated response IDs. The [normalization design](2026-09-04-tool-history-normalization-design.md) specifies turn boundaries and conflict rules. Gemini Live/NON_BLOCKING incremental results are outside this finite-history contract.
 
+## Instruction Roles
+
+Agent Maestro is a protocol adapter: it should forward caller-supplied instructions without changing them into ordinary user content. This experimental mapping does not inject progress prompts, synthesize commentary, or modify provider safety/formatting templates. It mitigates missing GPT-6 progress updates in the tested setup; it does not guarantee that every model will emit progress text.
+
+OpenAI Responses string `instructions` and Chat/Responses `system` and `developer` messages are preserved as VS Code System messages, including through history normalization. VS Code exposes only one instruction role, so it cannot preserve a distinction between OpenAI system and developer priorities. User input and assistant/tool history retain their original roles. Array-shaped Responses `instructions` remain a legacy history input: item roles are respected rather than promoting arbitrary user or tool content.
+
+This uses the proposed `languageModelSystem` API, not a stable API in the minimum supported VS Code version. Enable it for a development build with `code --enable-proposed-api=joouis.agent-maestro`. The development launch and test configuration include this flag. Do not publish this build as an ordinary Marketplace extension until a supported distribution path or stable API is available. There is no silent fallback to user messages: that changes instruction priority and can suppress Codex progress updates. Copilot's own safety policies remain in effect.
+
 ## Usage, Context, and Reasoning
 
 | Topic              | AM behavior                                                                                                                                            |

--- a/docs/openai-responses-api-design.md
+++ b/docs/openai-responses-api-design.md
@@ -12,7 +12,7 @@ Send the complete conversation history on each request. The Responses endpoint d
 
 | Input                                                                             | AM behavior                                                                                                                              |
 | --------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| Text messages and `instructions`                                                  | Converted to VS Code messages; system/developer instructions use the VS Code user-role representation.                                   |
+| Text messages and `instructions`                                                  | Converted to VS Code messages; string instructions and system/developer messages use the proposed VS Code System role.                   |
 | Function tools/calls/results                                                      | Supported with complete-history normalization.                                                                                           |
 | Custom tools/calls/results                                                        | Raw string input is preserved and returned as `custom_tool_call`.                                                                        |
 | Namespace tools                                                                   | Nested function/custom tools are registered under encoded names and decoded to namespace + bare name on output.                          |

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "version": "2.14.0",
   "icon": "assets/icons/icon.png",
   "publisher": "Joouis",
+  "enabledApiProposals": [
+    "languageModelSystem"
+  ],
   "repository": "https://github.com/Joouis/agent-maestro",
   "engines": {
     "vscode": "^1.120.0",

--- a/src/server/utils/openaiChat.ts
+++ b/src/server/utils/openaiChat.ts
@@ -70,12 +70,12 @@ export const convertOpenAIMessagesToVSCode = (
         // LanguageModelTextPart, mirroring the user-role branch below.
         if (typeof msg.content === "string") {
           return new vscode.LanguageModelChatMessage(
-            vscode.LanguageModelChatMessageRole.User,
+            vscode.LanguageModelChatMessageRole.System,
             msg.content,
           );
         }
         return new vscode.LanguageModelChatMessage(
-          vscode.LanguageModelChatMessageRole.User,
+          vscode.LanguageModelChatMessageRole.System,
           msg.content.map((m) => new vscode.LanguageModelTextPart(m.text)),
         );
 
@@ -157,7 +157,9 @@ export const convertOpenAIMessagesToVSCode = (
       role:
         message.role === vscode.LanguageModelChatMessageRole.Assistant
           ? "assistant"
-          : "user",
+          : message.role === vscode.LanguageModelChatMessageRole.System
+            ? "system"
+            : "user",
       boundary: raw.role === "system" || raw.role === "developer",
       parts: message.content.map((part): ToolHistoryPart => {
         if (

--- a/src/server/utils/openaiResponses.ts
+++ b/src/server/utils/openaiResponses.ts
@@ -621,7 +621,10 @@ const convertEasyInputMessage = (
         return vscode.LanguageModelChatMessage.Assistant(msg.content);
       case "system":
       case "developer":
-        return vscode.LanguageModelChatMessage.User(msg.content);
+        return new vscode.LanguageModelChatMessage(
+          vscode.LanguageModelChatMessageRole.System,
+          msg.content,
+        );
       default:
         return vscode.LanguageModelChatMessage.User(msg.content);
     }
@@ -635,7 +638,10 @@ const convertEasyInputMessage = (
       return vscode.LanguageModelChatMessage.Assistant(parts);
     case "system":
     case "developer":
-      return vscode.LanguageModelChatMessage.User(parts);
+      return new vscode.LanguageModelChatMessage(
+        vscode.LanguageModelChatMessageRole.System,
+        parts,
+      );
     default:
       return vscode.LanguageModelChatMessage.User(parts);
   }
@@ -653,7 +659,10 @@ const convertInputMessage = (
       return vscode.LanguageModelChatMessage.User(parts);
     case "system":
     case "developer":
-      return vscode.LanguageModelChatMessage.User(parts);
+      return new vscode.LanguageModelChatMessage(
+        vscode.LanguageModelChatMessageRole.System,
+        parts,
+      );
     default:
       return vscode.LanguageModelChatMessage.User(parts);
   }
@@ -796,7 +805,9 @@ const responseItemToHistory = (
     role:
       converted.role === vscode.LanguageModelChatMessageRole.Assistant
         ? "assistant"
-        : "user",
+        : converted.role === vscode.LanguageModelChatMessageRole.System
+          ? "system"
+          : "user",
     boundary: raw.role === "system" || raw.role === "developer",
     parts: converted.content.map((part): ToolHistoryPart => {
       if (part instanceof vscode.LanguageModelToolCallPart) {
@@ -841,10 +852,13 @@ export const convertResponsesInputToVSCode = (
   instruction?: string | ResponseInput | null,
 ): vscode.LanguageModelChatMessage[] => {
   const history: ToolHistoryMessage[] = [];
-  const appendInput = (value: string | ResponseInput | undefined | null) => {
+  const appendInput = (
+    value: string | ResponseInput | undefined | null,
+    textRole: "user" | "system" = "user",
+  ) => {
     if (typeof value === "string") {
       history.push({
-        role: "user",
+        role: textRole,
         parts: [
           { kind: "content", parts: [new vscode.LanguageModelTextPart(value)] },
         ],
@@ -859,7 +873,7 @@ export const convertResponsesInputToVSCode = (
     }
   };
   if (instruction) {
-    appendInput(instruction);
+    appendInput(instruction, "system");
     history.push({ role: "user", parts: [], boundary: true });
   }
   appendInput(input);

--- a/src/server/utils/toolResultPairing.ts
+++ b/src/server/utils/toolResultPairing.ts
@@ -29,7 +29,7 @@ export type ToolHistoryPart =
     };
 
 export interface ToolHistoryMessage {
-  role: "assistant" | "user";
+  role: "assistant" | "user" | "system";
   parts: ToolHistoryPart[];
   /** Instructions and independent request sections cannot share a call turn. */
   boundary?: boolean;
@@ -454,11 +454,16 @@ export function toolHistoryToVSCode(
                   ToolHistoryContent | vscode.LanguageModelToolCallPart
                 >,
               )
-            : vscode.LanguageModelChatMessage.User(
-                parts as Array<
-                  ToolHistoryContent | vscode.LanguageModelToolResultPart
-                >,
-              ),
+            : message.role === "system"
+              ? new vscode.LanguageModelChatMessage(
+                  vscode.LanguageModelChatMessageRole.System,
+                  parts as ToolHistoryContent[],
+                )
+              : vscode.LanguageModelChatMessage.User(
+                  parts as Array<
+                    ToolHistoryContent | vscode.LanguageModelToolResultPart
+                  >,
+                ),
         );
       }
     }

--- a/src/test/server/instructionRoles.test.ts
+++ b/src/test/server/instructionRoles.test.ts
@@ -1,0 +1,103 @@
+import * as assert from "assert";
+import * as vscode from "vscode";
+
+import { convertOpenAIMessagesToVSCode } from "../../server/utils/openaiChat";
+import { convertResponsesInputToVSCode } from "../../server/utils/openaiResponses";
+
+suite("OpenAI instruction role preservation", () => {
+  const roles = vscode.LanguageModelChatMessageRole;
+
+  for (const role of ["system", "developer"] as const) {
+    test(`preserves Responses ${role} arrays through normalization`, () => {
+      const messages = convertResponsesInputToVSCode([
+        {
+          type: "message",
+          role,
+          content: [{ type: "input_text", text: "Explain progress" }],
+        },
+        { role: "user", content: "Check build" },
+      ]);
+      assert.deepStrictEqual(
+        messages.map((message) => message.role),
+        [roles.System, roles.User],
+      );
+      assert.strictEqual(
+        (messages[0].content[0] as vscode.LanguageModelTextPart).value,
+        "Explain progress",
+      );
+    });
+
+    test(`preserves Chat ${role} arrays through normalization`, () => {
+      const messages = convertOpenAIMessagesToVSCode([
+        { role, content: [{ type: "text", text: "Explain progress" }] },
+        { role: "user", content: "Check build" },
+      ]);
+      assert.deepStrictEqual(
+        messages.map((message) => message.role),
+        [roles.System, roles.User],
+      );
+    });
+  }
+
+  test("preserves string instructions without promoting input or breaking tool pairs", () => {
+    const messages = convertResponsesInputToVSCode(
+      [
+        { role: "user", content: "Check build" },
+        { role: "assistant", content: "Checking" },
+        {
+          type: "function_call",
+          call_id: "build",
+          name: "get_status",
+          arguments: "{}",
+        },
+        { type: "function_call_output", call_id: "build", output: "passed" },
+      ],
+      "Explain progress",
+    );
+    assert.deepStrictEqual(
+      messages.map((message) => message.role),
+      [roles.System, roles.User, roles.Assistant, roles.Assistant, roles.User],
+    );
+    assert.ok(
+      messages[3].content[0] instanceof vscode.LanguageModelToolCallPart,
+    );
+    assert.ok(
+      messages[4].content[0] instanceof vscode.LanguageModelToolResultPart,
+    );
+  });
+
+  test("keeps instruction boundaries from pairing unrelated tool history", () => {
+    const messages = convertResponsesInputToVSCode([
+      {
+        type: "function_call",
+        call_id: "build",
+        name: "get_status",
+        arguments: "{}",
+      },
+      { role: "developer", content: "New instructions" },
+      { type: "function_call_output", call_id: "build", output: "passed" },
+    ]);
+    assert.deepStrictEqual(
+      messages.map((message) => message.role),
+      [roles.Assistant, roles.System, roles.User],
+    );
+    assert.ok(
+      messages.every((message) =>
+        message.content.every(
+          (part) => part instanceof vscode.LanguageModelTextPart,
+        ),
+      ),
+    );
+  });
+
+  test("respects individual roles in legacy instruction arrays", () => {
+    const messages = convertResponsesInputToVSCode("request", [
+      { role: "developer", content: "instructions" },
+      { role: "user", content: "context" },
+    ]);
+    assert.deepStrictEqual(
+      messages.map((message) => message.role),
+      [roles.System, roles.User, roles.User],
+    );
+  });
+});

--- a/src/test/server/openaiChat.test.ts
+++ b/src/test/server/openaiChat.test.ts
@@ -12,7 +12,7 @@ const encode = (value: unknown): Uint8Array =>
 
 suite("OpenAI Conversion Utils Test Suite", () => {
   suite("convertOpenAIMessagesToVSCode", () => {
-    test("should convert system message to User role", () => {
+    test("should convert system message to System role", () => {
       const messages = [
         { role: "system" as const, content: "You are a helpful assistant" },
       ];
@@ -22,11 +22,11 @@ suite("OpenAI Conversion Utils Test Suite", () => {
       assert.strictEqual(result.length, 1);
       assert.strictEqual(
         result[0].role,
-        vscode.LanguageModelChatMessageRole.User,
+        vscode.LanguageModelChatMessageRole.System,
       );
     });
 
-    test("should convert developer message to User role", () => {
+    test("should convert developer message to System role", () => {
       const messages = [
         { role: "developer" as const, content: "System instructions here" },
       ];
@@ -36,7 +36,7 @@ suite("OpenAI Conversion Utils Test Suite", () => {
       assert.strictEqual(result.length, 1);
       assert.strictEqual(
         result[0].role,
-        vscode.LanguageModelChatMessageRole.User,
+        vscode.LanguageModelChatMessageRole.System,
       );
     });
 
@@ -60,7 +60,7 @@ suite("OpenAI Conversion Utils Test Suite", () => {
       assert.strictEqual(result.length, 1);
       assert.strictEqual(
         result[0].role,
-        vscode.LanguageModelChatMessageRole.User,
+        vscode.LanguageModelChatMessageRole.System,
       );
       const parts = result[0].content as vscode.LanguageModelTextPart[];
       assert.strictEqual(parts.length, 3);

--- a/src/test/server/openaiResponses.test.ts
+++ b/src/test/server/openaiResponses.test.ts
@@ -135,7 +135,7 @@ suite("OpenAI Responses Conversion Utils Test Suite", () => {
       assert.ok(result);
       assert.strictEqual(
         result!.role,
-        vscode.LanguageModelChatMessageRole.User,
+        vscode.LanguageModelChatMessageRole.System,
       );
     });
 
@@ -145,7 +145,7 @@ suite("OpenAI Responses Conversion Utils Test Suite", () => {
       assert.ok(result);
       assert.strictEqual(
         result!.role,
-        vscode.LanguageModelChatMessageRole.User,
+        vscode.LanguageModelChatMessageRole.System,
       );
     });
 
@@ -486,7 +486,7 @@ suite("OpenAI Responses Conversion Utils Test Suite", () => {
       assert.strictEqual(result.length, 2);
       assert.strictEqual(
         result[0].role,
-        vscode.LanguageModelChatMessageRole.User,
+        vscode.LanguageModelChatMessageRole.System,
       );
     });
 

--- a/src/vscode.proposed.languageModelSystem.d.ts
+++ b/src/vscode.proposed.languageModelSystem.d.ts
@@ -1,0 +1,5 @@
+declare module "vscode" {
+  export enum LanguageModelChatMessageRole {
+    System = 3,
+  }
+}


### PR DESCRIPTION
## Summary

Related to #255. This is a **draft mitigation for discussion**, not a proposal to ship a proposed-API dependency in the normal release without maintainer agreement.

- Preserve OpenAI Responses string `instructions` and Chat/Responses `system` / `developer` messages as VS Code System messages, including through shared tool-history normalization.
- Keep ordinary user input, assistant history, and tool results at their existing roles; respect individual roles in legacy array-shaped Responses instructions.
- Add regression coverage, declare `languageModelSystem`, enable it in development/test launches, and document the compatibility/distribution limits.
- Changeset: `.changeset/fix-openai-instruction-roles.md`.

## Why / observed mitigation

The existing conversion downgrades caller instruction messages to User. In the controlled comparisons in #255, GPT-5.6 still emitted progress text, while GPT-6 typically emitted only tool calls until its final response. Changing only the instruction role to System restored GPT-6 progress text. This is not evidence that model reasoning was lost, nor proof of the models' internal reason for the difference.

After running this development build locally, the reporter also confirmed that it mitigates the issue in actual Codex usage. A live GPT-6 Responses exchange through the running patched proxy produced:

1. Progress text, then a build-status tool call.
2. Progress text, then a test-status tool call.
3. A final summary.

All three HTTP requests completed successfully. The status tool used synthetic results; this smoke test did not itself execute builds or tests. Controlled counts and environment details are in #255. These observations are a mitigation in the tested setup, not a guarantee of commentary on every request/model.

## Adapter responsibility / non-goals

Agent Maestro should translate protocols while preserving the nature of caller-supplied messages as far as the target API allows, rather than recasting instructions as ordinary user content. This patch does **not** add progress instructions, rewrite prompt text, fabricate intermediate messages, or special-case GPT-6. It does not modify Copilot safety/formatting templates or attempt to bypass provider policies. Output behavior remains the model/provider's responsibility.

The target API has only one System instruction role: both OpenAI system and developer map to it. Therefore this is **not fully lossless priority preservation** between those two OpenAI roles. Assistant phase and thinking-part forwarding are separate concerns and are not changed here.

## Dependency / why this remains draft

This approach depends on VS Code's **proposed `languageModelSystem` API**, declared in `enabledApiProposals`, and a compatible host/provider that accepts System messages. It is not part of the stable API at this project's minimum supported VS Code version. Development/test launches explicitly enable it with `--enable-proposed-api=joouis.agent-maestro`; installed experimental builds also need proposal enablement. This flag enables API access; it is not an extra user prompt or model-behavior setting.

Ordinary Marketplace publication is blocked while this proposed-API dependency remains. The draft does not provide a stable-release fallback or claim that all supported hosts/providers work. Silently falling back to User would reintroduce the semantic loss. The stable distribution path and unsupported-host behavior need maintainer agreement before this can become release-ready.

Would you prefer this as an explicitly experimental development path, a supported stable alternative if one exists, or an upstream VS Code/Copilot API discussion first? Keeping this draft linked to #255 so that the architectural boundary and distribution tradeoff can be reviewed together.

## Test plan

- [x] `pnpm check-types`
- [x] `pnpm lint`
- [x] `pnpm build-tests` + `pnpm exec vscode-test`: 609 passing on the final rerun. The first run had 608 passing and one existing model-resolution fallback test exceeding its 2-second timeout; the unchanged full-suite rerun passed all 609. Test hosts used separate ports from the running local proxies.
- [x] Live GPT-6 Responses smoke test through the running development proxy: progress text before both tool calls, then final response.
- [x] Reporter confirmation in actual local Codex usage.
- [ ] Maintainer agreement on proposed-API use, supported hosts/providers, and distribution strategy.
