### PR TITLE
fix(anthropic): preserve tool-use stop reason after text

### DIFF
--- a/.changeset/bright-tools-stop.md
+++ b/.changeset/bright-tools-stop.md
@@ -1,0 +1,5 @@
+---
+"agent-maestro": patch
+---
+
+Keep Claude Code's tool loop running when a proxied model emits text after a tool call.

--- a/src/server/routes/anthropicRoutes.ts
+++ b/src/server/routes/anthropicRoutes.ts
@@ -538,7 +538,7 @@ export function registerAnthropicRoutes(
           stop_reason:
             stopReason === "max_tokens"
               ? "max_tokens"
-              : content.at(-1)?.type === "tool_use"
+              : content.some((block) => block.type === "tool_use")
                 ? "tool_use"
                 : "end_turn",
           stop_sequence: null,
@@ -738,7 +738,7 @@ export function registerAnthropicRoutes(
               stop_reason:
                 stopReason === "max_tokens"
                   ? "max_tokens"
-                  : contentBlocks.at(-1)?.type === "tool_use"
+                  : contentBlocks.some((block) => block.type === "tool_use")
                     ? "tool_use"
                     : "end_turn",
               stop_sequence: null,

--- a/src/test/server/anthropic.test.ts
+++ b/src/test/server/anthropic.test.ts
@@ -1,6 +1,8 @@
+import { OpenAPIHono } from "@hono/zod-openapi";
 import * as assert from "assert";
 import * as vscode from "vscode";
 
+import { registerAnthropicRoutes } from "../../server/routes/anthropicRoutes";
 import {
   convertAnthropicMessageToVSCode,
   convertAnthropicMessagesToVSCode,
@@ -1012,5 +1014,71 @@ suite("Anthropic Conversion Utils Test Suite", () => {
         output_tokens: 10,
       });
     });
+  });
+});
+
+suite("Anthropic response stop reason", () => {
+  const createGptToolThenTextApp = () => {
+    const app = new OpenAPIHono();
+    registerAnthropicRoutes(app, {
+      requestTimeoutMs: 1_000,
+      resolveChatModelClient: async () => ({
+        client: createMockModel({
+          id: "gpt-6-astra",
+          name: "GPT-6 Astra",
+          family: "gpt-6",
+          sendRequest: async () => ({
+            stream: (async function* () {
+              yield new vscode.LanguageModelToolCallPart(
+                "call-1",
+                "read_file",
+                { path: "/test" },
+              );
+              yield new vscode.LanguageModelTextPart("Reading the file now.");
+            })(),
+            text: (async function* () {})(),
+          }),
+        }),
+      }),
+    });
+    return app;
+  };
+
+  const requestBody = {
+    model: "gpt-6-astra",
+    max_tokens: 100,
+    messages: [{ role: "user", content: "Read a file" }],
+  };
+
+  test("preserves tool_use when text follows a tool call", async () => {
+    const response = await createGptToolThenTextApp().request("/v1/messages", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(requestBody),
+    });
+    const body = (await response.json()) as Record<string, any>;
+
+    assert.strictEqual(response.status, 200);
+    assert.deepStrictEqual(
+      body.content.map((block: Record<string, unknown>) => block.type),
+      ["tool_use", "text"],
+    );
+    assert.strictEqual(body.stop_reason, "tool_use");
+  });
+
+  test("preserves tool_use in a stream when text follows a tool call", async () => {
+    const response = await createGptToolThenTextApp().request("/v1/messages", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ...requestBody, stream: true }),
+    });
+    const events = (await response.text())
+      .split("\n")
+      .filter((line) => line.startsWith("data: "))
+      .map((line) => JSON.parse(line.slice(6)));
+    const messageDelta = events.find((event) => event.type === "message_delta");
+
+    assert.strictEqual(response.status, 200);
+    assert.strictEqual(messageDelta?.delta.stop_reason, "tool_use");
   });
 });


### PR DESCRIPTION
## Summary

- return `stop_reason: "tool_use"` whenever an Anthropic-compatible response contains a client tool call, even if proxied GPT/Copilot output emits trailing text
- preserve the higher-priority `max_tokens` stop reason
- cover Claude Code-style GPT responses in both non-streaming and streaming routes

## Why

The order `tool_use` then `text` is valid mixed content. The trailing text does not cancel the already-emitted tool request. Returning `end_turn` can make Anthropic clients such as Claude Code stop instead of executing the tool and continuing with a `tool_result`.

## Test plan

- [x] `pnpm check-types`
- [x] `pnpm lint`
- [x] `pnpm run build-tests`
- [x] focused VS Code test: `vscode-test --grep "Anthropic response stop reason" --timeout 10000` (2 passing)
- [x] full VS Code suite exercised the new tests (602 passing overall; two unrelated existing 2-second timeout failures occurred in model fallback and `.env` file tests while the extension host was temporarily unresponsive)