### PR TITLE
feat(openai): add opt-in Responses history recovery

### DIFF
--- a/.changeset/deep-houses-fail.md
+++ b/.changeset/deep-houses-fail.md
@@ -1,0 +1,5 @@
+---
+"agent-maestro": minor
+---
+
+Add a disabled-by-default experimental setting for one-shot recovery of paired Responses tool histories rejected by Copilot before output. Recovery changes completed tool history into labelled context; document semantic, usage, and pruning limitations.

--- a/README.md
+++ b/README.md
@@ -116,6 +116,27 @@ Use VS Code settings for the following options. Port and default-Roo settings ca
 
 `AGENT_MAESTRO_PROXY_PORT` and `AGENT_MAESTRO_MCP_PORT` environment variables override the corresponding settings. Restart the extension host after changing ports or extension identifiers.
 
+### Experimental Responses history recovery
+
+The application-scoped setting **agent-maestro.experimental.responsesToolHistoryRecovery**
+is **false by default**. Enable it only if you accept a change in how completed
+tool history is presented to the model. It applies to ordinary OpenAI Responses
+requests through Copilot, not hosted web-search loops or other API routes.
+
+When Copilot rejects a completely paired history with the specific missing-tool-call
+error, AM may retry once, only before any model stream part has been received.
+The retry replaces completed structured tool calls/results with labelled text/data
+context, preserving their content and leaving new tool definitions unchanged.
+This changes semantics and may affect model behavior, latency, usage, and caching.
+It does not guarantee recovery or prevent downstream context pruning. Other errors,
+partial responses, and invalid converted histories are not retried this way.
+The Output channel reports each recovery attempt without logging history content.
+
+The setting is read for each new request; disabling it restores normal forwarding.
+No recovery state or rewritten history is persisted. Prefer client compaction or a
+fresh session when possible. This is an opt-in workaround for upstream pruning,
+not a repair to Copilot's renderer or a reason to increase the advertised window.
+
 ### Roo/Kilo and MCP Setup
 
 The MCP server normally uses port `23334` and requires the configured default Roo extension to provide a task manager. If only Kilo Code is installed, set `agent-maestro.defaultRooIdentifier` to `kilocode.kilo-code` and reload VS Code before starting MCP. HTTP task requests can also select an installed variant explicitly with `extensionId`.

--- a/package.json
+++ b/package.json
@@ -90,6 +90,12 @@
           "default": "",
           "description": "Model ID to use when a requested model is unavailable after exact and fuzzy matching. Leave empty to use VS Code's automatic model fallback.",
           "scope": "application"
+        },
+        "agent-maestro.experimental.responsesToolHistoryRecovery": {
+          "type": "boolean",
+          "default": false,
+          "description": "Experimental, opt-in recovery for ordinary Copilot-backed Responses requests. On a specific downstream tool-pairing rejection before output, retry once with completed tool history converted to labelled text/data context. Changes history semantics and may increase usage; does not guarantee recovery. Excludes hosted web-search loops.",
+          "scope": "application"
         }
       }
     },

--- a/src/server/routes/openai/openaiResponsesRoutes.ts
+++ b/src/server/routes/openai/openaiResponsesRoutes.ts
@@ -14,6 +14,7 @@ import {
   getCopilotModelConfiguration,
   withCopilotConfiguration,
 } from "../../../utils/chatModels";
+import { readConfiguration } from "../../../utils/config";
 import { logger } from "../../../utils/logger";
 import { CommonResponseError } from "../../schemas/openai";
 import { handleErrorWithLogging } from "../../utils/errorDiagnostics";
@@ -21,7 +22,6 @@ import {
   LanguageModelClientDisconnectedError,
   LanguageModelRequestLifecycle,
   LanguageModelRequestTimeoutError,
-  interruptibleLanguageModelStream,
 } from "../../utils/languageModelRequestLifecycle";
 import { extractOpenAIResponsesUsage } from "../../utils/openai";
 import {
@@ -51,6 +51,7 @@ import {
   OpenAIResponsesRequestValidationError,
   prepareOpenAIResponsesTools,
 } from "../../utils/openaiResponsesWebSearch";
+import { streamResponsesWithHistoryRecovery } from "../../utils/responsesHistoryRecovery";
 import {
   WEB_SEARCH_PROVIDER_TIMEOUT_MS,
   WebSearchProvider,
@@ -157,6 +158,7 @@ Limitations:
 });
 
 export interface OpenaiResponsesRoutesOptions {
+  isToolHistoryRecoveryEnabled?: () => boolean;
   heartbeatIntervalMs?: number;
   providerTimeoutMs?: number;
   requestTimeoutMs?: number;
@@ -370,22 +372,22 @@ export function registerOpenaiResponsesRoutes(
       }
 
       // 9. Handle non-streaming response
+      const recoveryEnabled = (
+        options.isToolHistoryRecoveryEnabled ??
+        (() => readConfiguration().responsesToolHistoryRecovery)
+      )();
       if (!stream) {
-        const response = await requestLifecycle.waitFor(
-          client.sendRequest(
-            vsCodeMessages,
-            configuredRequestOptions,
-            cancellationToken,
-          ),
-        );
         let accumulatedText = "";
         const toolCalls: { callId: string; name: string; input: unknown }[] =
           [];
         let responseUsage: ResponseUsage | undefined;
 
-        for await (const chunk of interruptibleLanguageModelStream(
-          response.stream,
+        for await (const chunk of streamResponsesWithHistoryRecovery(
+          client,
+          vsCodeMessages,
+          configuredRequestOptions,
           requestLifecycle,
+          recoveryEnabled,
         )) {
           if (chunk instanceof vscode.LanguageModelTextPart) {
             accumulatedText += chunk.value;
@@ -509,13 +511,6 @@ export function registerOpenaiResponsesRoutes(
             writeSSE,
             sequenceNumberRef,
             async (writeSSE) => {
-              const response = await requestLifecycle!.waitFor(
-                client.sendRequest(
-                  vsCodeMessages,
-                  configuredRequestOptions,
-                  cancellationToken,
-                ),
-              );
               // Process stream
               const output: OutputItem[] = [];
               let outputIndex = 0;
@@ -525,9 +520,12 @@ export function registerOpenaiResponsesRoutes(
               let totalOutputText = ""; // Track all output for token counting
               let responseUsage: ResponseUsage | undefined;
 
-              for await (const chunk of interruptibleLanguageModelStream(
-                response.stream,
+              for await (const chunk of streamResponsesWithHistoryRecovery(
+                client,
+                vsCodeMessages,
+                configuredRequestOptions,
                 requestLifecycle!,
+                recoveryEnabled,
               )) {
                 if (chunk instanceof vscode.LanguageModelTextPart) {
                   if (!currentMessageId) {

--- a/src/server/utils/responsesHistoryRecovery.ts
+++ b/src/server/utils/responsesHistoryRecovery.ts
@@ -1,0 +1,169 @@
+import * as vscode from "vscode";
+
+import { logger } from "../../utils/logger";
+import {
+  LanguageModelClientDisconnectedError,
+  LanguageModelRequestLifecycle,
+  interruptibleLanguageModelStream,
+} from "./languageModelRequestLifecycle";
+
+function isPairedFailure(
+  error: unknown,
+  messages: vscode.LanguageModelChatMessage[],
+): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  const match =
+    /No tool call found for function call output with call_id ([A-Za-z0-9_-]+)/.exec(
+      error.message,
+    );
+  if (!match) {
+    return false;
+  }
+  const calls = new Set<string>();
+  const results = new Set<string>();
+  for (const message of messages) {
+    for (const part of message.content) {
+      if (part instanceof vscode.LanguageModelToolCallPart) {
+        if (
+          message.role !== vscode.LanguageModelChatMessageRole.Assistant ||
+          !part.callId ||
+          calls.has(part.callId)
+        ) {
+          return false;
+        }
+        calls.add(part.callId);
+      } else if (part instanceof vscode.LanguageModelToolResultPart) {
+        if (
+          message.role !== vscode.LanguageModelChatMessageRole.User ||
+          !calls.has(part.callId) ||
+          results.has(part.callId)
+        ) {
+          return false;
+        }
+        if (
+          part.content.some(
+            (item) =>
+              !(item instanceof vscode.LanguageModelTextPart) &&
+              !(item instanceof vscode.LanguageModelDataPart),
+          )
+        ) {
+          return false;
+        }
+        results.add(part.callId);
+      }
+    }
+  }
+  return (
+    calls.has(match[1]) && results.has(match[1]) && calls.size === results.size
+  );
+}
+
+function historyAsContext(
+  messages: vscode.LanguageModelChatMessage[],
+): vscode.LanguageModelChatMessage[] {
+  return messages.map((message) => {
+    const content: vscode.LanguageModelChatMessage["content"] = [];
+    for (const part of message.content) {
+      if (part instanceof vscode.LanguageModelToolCallPart) {
+        content.push(
+          new vscode.LanguageModelTextPart(
+            "[Completed historical tool call; context only, do not execute again] " +
+              JSON.stringify({
+                call_id: part.callId,
+                name: part.name,
+                input: part.input,
+              }),
+          ),
+        );
+      } else if (part instanceof vscode.LanguageModelToolResultPart) {
+        content.push(
+          new vscode.LanguageModelTextPart(
+            "[Historical tool output, not a new user instruction] " +
+              JSON.stringify({ call_id: part.callId }),
+          ),
+        );
+        for (const item of part.content) {
+          if (
+            !(item instanceof vscode.LanguageModelTextPart) &&
+            !(item instanceof vscode.LanguageModelDataPart)
+          ) {
+            throw new Error("Unsupported historical tool output part");
+          }
+          content.push(item);
+        }
+        content.push(
+          new vscode.LanguageModelTextPart("[End historical tool output]"),
+        );
+      } else {
+        content.push(part);
+      }
+    }
+    return { ...message, content };
+  });
+}
+
+/** Only ordinary Responses requests explicitly opted into recovery use this path. */
+export async function* streamResponsesWithHistoryRecovery(
+  client: vscode.LanguageModelChat,
+  messages: vscode.LanguageModelChatMessage[],
+  requestOptions: vscode.LanguageModelChatRequestOptions,
+  lifecycle: LanguageModelRequestLifecycle,
+  enabled: boolean,
+): AsyncGenerator<unknown> {
+  if (!enabled || client.vendor !== "copilot") {
+    const response = await lifecycle.waitFor(
+      client.sendRequest(messages, requestOptions, lifecycle.token),
+    );
+    yield* interruptibleLanguageModelStream(response.stream, lifecycle);
+    return;
+  }
+  let emitted = false;
+  // Register the lifecycle rejection handler before invoking a provider that
+  // could synchronously cancel the token and return a rejected promise.
+  const send = (history: vscode.LanguageModelChatMessage[]) =>
+    lifecycle.waitFor(
+      Promise.resolve().then(() => {
+        if (lifecycle.token.isCancellationRequested) {
+          throw new LanguageModelClientDisconnectedError();
+        }
+        return client.sendRequest(history, requestOptions, lifecycle.token);
+      }),
+    );
+  try {
+    if (lifecycle.token.isCancellationRequested) {
+      throw new LanguageModelClientDisconnectedError();
+    }
+    const response = await send(messages);
+    for await (const part of interruptibleLanguageModelStream(
+      response.stream,
+      lifecycle,
+    )) {
+      // Even metadata or an unknown future part counts as output. Never replay
+      // after a partially observed response, including a generated tool call.
+      emitted = true;
+      yield part;
+    }
+    return;
+  } catch (error) {
+    if (
+      !enabled ||
+      client.vendor !== "copilot" ||
+      emitted ||
+      lifecycle.token.isCancellationRequested ||
+      !isPairedFailure(error, messages)
+    ) {
+      throw error;
+    }
+  }
+
+  logger.warn(
+    "Responses experimental history recovery: retrying once with completed tool history represented as labelled text/data context. Request semantics change; recovery is not guaranteed.",
+  );
+  if (lifecycle.token.isCancellationRequested) {
+    throw new LanguageModelClientDisconnectedError();
+  }
+  const response = await send(historyAsContext(messages));
+  yield* interruptibleLanguageModelStream(response.stream, lifecycle);
+}

--- a/src/test/server/responsesHistoryRecovery.test.ts
+++ b/src/test/server/responsesHistoryRecovery.test.ts
@@ -1,0 +1,379 @@
+import { OpenAPIHono } from "@hono/zod-openapi";
+import * as assert from "assert";
+import * as vscode from "vscode";
+
+import { registerOpenaiResponsesRoutes } from "../../server/routes/openai/openaiResponsesRoutes";
+import { LanguageModelRequestLifecycle } from "../../server/utils/languageModelRequestLifecycle";
+import { streamResponsesWithHistoryRecovery } from "../../server/utils/responsesHistoryRecovery";
+
+const paired = () => [
+  vscode.LanguageModelChatMessage.Assistant([
+    new vscode.LanguageModelToolCallPart("call_example", "lookup", {
+      key: "value",
+    }),
+  ]),
+  vscode.LanguageModelChatMessage.User([
+    new vscode.LanguageModelToolResultPart("call_example", [
+      new vscode.LanguageModelTextPart("saved output"),
+    ]),
+  ]),
+];
+const mismatch = () =>
+  new Error(
+    "Request Failed: 400 No tool call found for function call output with call_id call_example.",
+  );
+const success = () => ({
+  stream: (async function* () {
+    yield new vscode.LanguageModelTextPart("ok");
+  })(),
+  text: (async function* () {})(),
+});
+const model = (
+  sendRequest: vscode.LanguageModelChat["sendRequest"],
+  vendor = "copilot",
+) =>
+  Object.freeze({
+    id: "test",
+    vendor,
+    sendRequest,
+    countTokens: async () => 1,
+  }) as unknown as vscode.LanguageModelChat;
+async function collect(stream: AsyncIterable<unknown>) {
+  const parts: unknown[] = [];
+  for await (const part of stream) {
+    parts.push(part);
+  }
+  return parts;
+}
+
+suite("Opt-in Responses history recovery", () => {
+  test("hosted search bypasses recovery even when enabled", async () => {
+    let count = 0;
+    const app = new OpenAPIHono();
+    const client = model(async () => {
+      count++;
+      throw mismatch();
+    });
+    registerOpenaiResponsesRoutes(app, {
+      resolveChatModelClient: async () => ({ client }),
+      isToolHistoryRecoveryEnabled: () => true,
+      webSearchProvider: { search: async () => [] },
+    });
+    const response = await app.request("/v1/responses", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "test",
+        stream: true,
+        tools: [{ type: "web_search" }],
+        input: [
+          {
+            type: "function_call",
+            call_id: "call_example",
+            name: "lookup",
+            arguments: "{}",
+          },
+          {
+            type: "function_call_output",
+            call_id: "call_example",
+            output: "saved",
+          },
+          { role: "user", content: "Search now" },
+        ],
+      }),
+    });
+    assert.ok((await response.text()).includes("No tool call found"));
+    assert.strictEqual(count, 1);
+  });
+  let lifecycle: LanguageModelRequestLifecycle;
+  setup(() => {
+    lifecycle = new LanguageModelRequestLifecycle(
+      new AbortController().signal,
+      2000,
+    );
+  });
+  teardown(() => {
+    lifecycle.dispose();
+  });
+  const run = (
+    client: vscode.LanguageModelChat,
+    enabled = true,
+    messages = paired(),
+    options = {},
+  ) =>
+    collect(
+      streamResponsesWithHistoryRecovery(
+        client,
+        messages,
+        options,
+        lifecycle,
+        enabled,
+      ),
+    );
+
+  test("disabled and non-Copilot modes never retry", async () => {
+    for (const [enabled, vendor] of [
+      [false, "copilot"],
+      [true, "other"],
+    ] as const) {
+      let count = 0;
+      const client = model(async () => {
+        count++;
+        throw mismatch();
+      }, vendor);
+      await assert.rejects(run(client, enabled));
+      assert.strictEqual(count, 1);
+    }
+  });
+  test("normal request identity, options and output remain unchanged", async () => {
+    const messages = paired(),
+      options = { tools: [{ name: "lookup", inputSchema: {} }] };
+    const client = model(async (m, o) => {
+      assert.strictEqual(m, messages);
+      assert.strictEqual(o, options);
+      return success();
+    });
+    assert.strictEqual((await run(client, true, messages, options)).length, 1);
+  });
+  test("direct rejection retries once preserving context and new tool calls", async () => {
+    let count = 0;
+    const messages = paired();
+    const original = JSON.stringify(messages);
+    const options = { tools: [{ name: "lookup", inputSchema: {} }] };
+    const newCall = new vscode.LanguageModelToolCallPart(
+      "new_call",
+      "lookup",
+      {},
+    );
+    const client = model(async (m, o) => {
+      assert.strictEqual(o, options);
+      if (++count === 1) {
+        throw mismatch();
+      }
+      assert.ok(
+        m
+          .flatMap((x) => x.content)
+          .every(
+            (p) =>
+              !(p instanceof vscode.LanguageModelToolCallPart) &&
+              !(p instanceof vscode.LanguageModelToolResultPart),
+          ),
+      );
+      assert.ok(JSON.stringify(m).includes("saved output"));
+      assert.ok(JSON.stringify(m).includes("value"));
+      return {
+        stream: (async function* () {
+          yield newCall;
+        })(),
+        text: (async function* () {})(),
+      };
+    });
+    assert.deepStrictEqual(await run(client, true, messages, options), [
+      newCall,
+    ]);
+    assert.strictEqual(count, 2);
+    assert.strictEqual(JSON.stringify(messages), original);
+  });
+  test("pre-output stream rejection retries", async () => {
+    let count = 0;
+    const client = model(async () =>
+      ++count === 1
+        ? {
+            stream: (async function* () {
+              throw mismatch();
+            })(),
+            text: (async function* () {})(),
+          }
+        : success(),
+    );
+    assert.strictEqual((await run(client)).length, 1);
+    assert.strictEqual(count, 2);
+  });
+  test("no retry after text, tool call, metadata, or unknown output", async () => {
+    for (const part of [
+      new vscode.LanguageModelTextPart("partial"),
+      new vscode.LanguageModelToolCallPart("new", "lookup", {}),
+      new vscode.LanguageModelDataPart(new Uint8Array([1]), "application/json"),
+      {},
+    ]) {
+      let count = 0;
+      const client = model(async () => {
+        count++;
+        return {
+          stream: (async function* () {
+            yield part;
+            throw mismatch();
+          })(),
+          text: (async function* () {})(),
+        };
+      });
+      await assert.rejects(run(client));
+      assert.strictEqual(count, 1);
+    }
+  });
+  test("failed recovery is not retried again", async () => {
+    let count = 0;
+    const client = model(async () => {
+      count++;
+      throw mismatch();
+    });
+    await assert.rejects(run(client));
+    assert.strictEqual(count, 2);
+  });
+  test("unrelated errors or unknown call IDs do not retry", async () => {
+    for (const error of [
+      new Error("Unauthorized"),
+      new Error(
+        "No tool call found for function call output with call_id other.",
+      ),
+    ]) {
+      let count = 0;
+      const client = model(async () => {
+        count++;
+        throw error;
+      });
+      await assert.rejects(run(client));
+      assert.strictEqual(count, 1);
+    }
+  });
+  test("incomplete, reversed, duplicate and wrong-role pairs do not retry", async () => {
+    const h = paired();
+    for (const messages of [
+      h.slice(0, 1),
+      h.slice(1),
+      [...h].reverse(),
+      [...h, ...h],
+      [{ ...h[0], role: vscode.LanguageModelChatMessageRole.User }, h[1]],
+    ]) {
+      let count = 0;
+      const client = model(async () => {
+        count++;
+        throw mismatch();
+      });
+      await assert.rejects(run(client, true, messages));
+      assert.strictEqual(count, 1);
+    }
+  });
+  test("parallel calls, text and data survive recovery", async () => {
+    const data = new vscode.LanguageModelDataPart(
+      new Uint8Array([1, 2]),
+      "image/png",
+    );
+    const messages = paired();
+    messages[0].content.push(
+      new vscode.LanguageModelToolCallPart("parallel", "lookup", {}),
+    );
+    messages[1].content.unshift(
+      new vscode.LanguageModelTextPart("note"),
+      new vscode.LanguageModelToolResultPart("parallel", [data]),
+    );
+    let count = 0;
+    const client = model(async (m) => {
+      if (++count === 1) {
+        throw mismatch();
+      }
+      assert.ok(m[1].content.includes(data));
+      assert.ok(JSON.stringify(m).includes("note"));
+      return success();
+    });
+    await run(client, true, messages);
+    assert.strictEqual(count, 2);
+  });
+  test("cancellation before or during rejection prevents retries", async () => {
+    const controller = new AbortController();
+    lifecycle.dispose();
+    lifecycle = new LanguageModelRequestLifecycle(controller.signal, 2000);
+    let count = 0;
+    const client = model(async () => {
+      count++;
+      controller.abort();
+      throw mismatch();
+    });
+    await assert.rejects(run(client));
+    assert.strictEqual(count, 1);
+    await assert.rejects(run(client));
+    assert.strictEqual(count, 1);
+  });
+  test("recovery stream remains subject to original timeout", async () => {
+    lifecycle.dispose();
+    lifecycle = new LanguageModelRequestLifecycle(
+      new AbortController().signal,
+      30,
+    );
+    let count = 0;
+    const client = model(async () => {
+      if (++count === 1) {
+        throw mismatch();
+      }
+      return {
+        stream: {
+          [Symbol.asyncIterator]() {
+            return {
+              next: () => new Promise<IteratorResult<unknown>>(() => {}),
+            };
+          },
+        },
+        text: (async function* () {})(),
+      };
+    });
+    await assert.rejects(run(client), /timed out/);
+    assert.strictEqual(count, 2);
+  });
+
+  for (const stream of [false, true]) {
+    test("HTTP route opt-in and opt-out: stream=" + stream, async () => {
+      let enabled = false,
+        count = 0;
+      const app = new OpenAPIHono();
+      const client = model(async () => {
+        if (++count % 2 === 1) {
+          throw mismatch();
+        }
+        return success();
+      });
+      registerOpenaiResponsesRoutes(app, {
+        resolveChatModelClient: async () => ({ client }),
+        isToolHistoryRecoveryEnabled: () => enabled,
+        heartbeatIntervalMs: 5,
+      });
+      const request = () =>
+        app.request("/v1/responses", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            model: "test",
+            stream,
+            input: [
+              {
+                type: "custom_tool_call",
+                call_id: "call_example",
+                name: "lookup",
+                input: "saved input",
+              },
+              {
+                type: "custom_tool_call_output",
+                call_id: "call_example",
+                output: "saved output",
+              },
+            ],
+          }),
+        });
+      const off = await request();
+      const offBody = await off.text();
+      assert.ok(offBody.includes("No tool call found"));
+      assert.strictEqual(count, 1);
+      enabled = true;
+      count = 0;
+      const on = await request();
+      const onBody = await on.text();
+      assert.strictEqual(on.status, 200);
+      assert.ok(onBody.includes("completed"));
+      assert.ok(onBody.includes("ok"));
+      assert.strictEqual(count, 2);
+      enabled = false;
+      count = 0;
+      await (await request()).text();
+      assert.strictEqual(count, 1);
+    });
+  }
+});

--- a/src/test/utils/config.test.ts
+++ b/src/test/utils/config.test.ts
@@ -21,6 +21,7 @@ suite("Config Test Suite", () => {
       assert.strictEqual(DEFAULT_CONFIG.mcpServerPort, 23334);
       assert.strictEqual(DEFAULT_CONFIG.allowOutsideWorkspaceAccess, false);
       assert.strictEqual(DEFAULT_CONFIG.fallbackModelId, "");
+      assert.strictEqual(DEFAULT_CONFIG.responsesToolHistoryRecovery, false);
     });
   });
 
@@ -56,6 +57,7 @@ suite("Config Test Suite", () => {
   suite("readConfiguration", () => {
     test("should return configuration object with all required fields", () => {
       const config = readConfiguration();
+      assert.strictEqual(typeof config.responsesToolHistoryRecovery, "boolean");
 
       // Check that all fields exist
       assert.ok(

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -7,6 +7,7 @@ export interface AgentMaestroConfiguration {
   mcpServerPort: number;
   allowOutsideWorkspaceAccess: boolean;
   fallbackModelId: string;
+  responsesToolHistoryRecovery: boolean;
 }
 
 /**
@@ -19,6 +20,8 @@ export const CONFIG_KEYS = {
   MCP_SERVER_PORT: "agent-maestro.mcpServerPort",
   ALLOW_OUTSIDE_WORKSPACE_ACCESS: "agent-maestro.allowOutsideWorkspaceAccess",
   FALLBACK_MODEL_ID: "agent-maestro.fallbackModelId",
+  RESPONSES_TOOL_HISTORY_RECOVERY:
+    "agent-maestro.experimental.responsesToolHistoryRecovery",
 } as const;
 
 /**
@@ -31,6 +34,7 @@ export const DEFAULT_CONFIG: AgentMaestroConfiguration = {
   mcpServerPort: 23334,
   allowOutsideWorkspaceAccess: false,
   fallbackModelId: "",
+  responsesToolHistoryRecovery: false,
 };
 
 /**
@@ -63,6 +67,10 @@ export const readConfiguration = (): AgentMaestroConfiguration => {
     fallbackModelId: config.get<string>(
       CONFIG_KEYS.FALLBACK_MODEL_ID,
       DEFAULT_CONFIG.fallbackModelId,
+    ),
+    responsesToolHistoryRecovery: config.get<boolean>(
+      CONFIG_KEYS.RESPONSES_TOOL_HISTORY_RECOVERY,
+      DEFAULT_CONFIG.responsesToolHistoryRecovery,
     ),
   };
 };


### PR DESCRIPTION
## Summary

Proposes a **disabled-by-default, explicitly opt-in** compatibility mode, following the architectural discussion in #245 and the rejection of automatic rewriting in #246. This is not a claim that the upstream pruning defect has been fixed, nor a request to silently enable the previous fallback.

- Application setting: **agent-maestro.experimental.responsesToolHistoryRecovery**, default false, read per new request.
- Ordinary Copilot-backed Responses only; hosted search and other APIs are unchanged.
- One retry only for the specific downstream missing-call error when converted history has complete, unique, correctly ordered pairs and no model stream part has been received.
- Retry represents completed calls/results as labelled text/data context; input is not mutated and current tool definitions/new tool calls are preserved.
- Warns about the semantic change. No cross-request recovery cache or persisted rewritten history. Unsupported result parts, other errors, cancellation, and partial output are not retried.

### Trade-offs / maintainer decision

Enabling the mode deliberately changes historical tool semantics. It can alter model behavior, increase latency/usage, and still undergo downstream pruning. Normal compaction/new-session workarounds remain preferable. Default forwarding behavior is preserved. This option is presented for consideration, recognizing that maintainers may prefer diagnostics-only changes.

### Evidence

Additional sanitized investigation: https://github.com/Joouis/agent-maestro/issues/245#issuecomment-5594995963

A prior local workaround using the same recovery representation recovered a real long-history pressure request after Copilot rejected an otherwise paired transcript. Direct inspection of the new failing request showed output present/call absent with truncation disabled. The affected user confirmed recovery. That local patch is **not identical to this PR** (it additionally cached recovery mode and wrapped the model resolver); the PR deliberately omits those behaviors. Private transcripts, internal model identifiers, debugger scripts, and machine paths are not included.

## Test plan

- [x] TypeScript check
- [x] ESLint
- [x] Full VS Code test-host suite: 616 passing
- [x] Regression coverage for enabled/disabled and non-Copilot behavior, direct/streamed failure, partial text/tool/metadata, unrelated errors, failed retry, invalid/parallel histories, preserved content/new calls, cancellation, original timeout, HTTP streaming/non-streaming toggles, hosted-search exclusion
- [x] git diff --check

Settings UI interaction and live provider generation were not rerun against the exact PR bundle; settings are covered by configuration tests and injected route toggles. Full tests use mock models, not account credentials.

Changeset: .changeset/deep-houses-fail.md (minor, explicit experimental option).
